### PR TITLE
fix(scripts): miscellaneous corrections

### DIFF
--- a/evm/deploy-const-address-deployer.js
+++ b/evm/deploy-const-address-deployer.js
@@ -7,9 +7,8 @@ const readlineSync = require('readline-sync');
 const { Command, Option } = require('commander');
 const chalk = require('chalk');
 
-const { deployCreate } = require('./upgradable');
-const { printInfo, writeJSON, predictAddressCreate } = require('./utils');
-const contractJson = require('../artifacts/contracts/deploy/ConstAddressDeployer.sol/ConstAddressDeployer.json');
+const { printInfo, writeJSON, predictAddressCreate, deployContract } = require('./utils');
+const contractJson = require('@axelar-network/axelar-gmp-sdk-solidity/dist/ConstAddressDeployer.json');
 const contractName = 'ConstAddressDeployer';
 
 async function deploy(options, chain) {
@@ -50,7 +49,7 @@ async function deploy(options, chain) {
     const anwser = readlineSync.question(`Proceed with deployment on ${chain.name}? ${chalk.green('(y/n)')} `);
     if (anwser !== 'y') return;
 
-    const contract = await deployCreate(wallet.connect(provider), contractJson, [], gasOptions, env, chain.name, verify);
+    const contract = await deployContract(wallet.connect(provider), contractJson, [], gasOptions, verify);
 
     contractConfig.address = contract.address;
     contractConfig.deployer = wallet.address;

--- a/evm/deploy-const-address-deployer.js
+++ b/evm/deploy-const-address-deployer.js
@@ -12,7 +12,7 @@ const contractJson = require('@axelar-network/axelar-gmp-sdk-solidity/dist/Const
 const contractName = 'ConstAddressDeployer';
 
 async function deploy(options, chain) {
-    const { env, privateKey, ignore, verify } = options;
+    const { privateKey, ignore, verify } = options;
     const wallet = new Wallet(privateKey);
 
     printInfo('Deployer address', wallet.address);

--- a/evm/deploy-contract.js
+++ b/evm/deploy-contract.js
@@ -33,7 +33,7 @@ async function getConstructorArgs(contractName, config) {
 
             const governanceAddress = contractConfig.governanceAddress;
 
-            if (!isAddress(governanceAddress)) {
+            if (!isString(governanceAddress)) {
                 throw new Error(`Missing InterchainGovernance.governanceAddress in the chain info.`);
             }
 

--- a/evm/deploy-create3-deployer.js
+++ b/evm/deploy-create3-deployer.js
@@ -9,7 +9,7 @@ const { Command, Option } = require('commander');
 const chalk = require('chalk');
 
 const { printInfo, writeJSON, deployCreate2 } = require('./utils');
-const implementationJson = require('../artifacts/contracts/deploy/Create3Deployer.sol/Create3Deployer.json');
+const implementationJson = require('@axelar-network/axelar-gmp-sdk-solidity/dist/Create3Deployer.json');
 const contractName = 'Create3Deployer';
 
 async function deploy(options, chain) {

--- a/evm/index.js
+++ b/evm/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { printObj, readJSON, writeJSON, importNetworks, verifyContract, getBytecodeHash } = require('./utils');
-const { deployGatewayv4_3 } = require('./deploy-gateway-v4.3.x');
+const { deployGatewayv43 } = require('./deploy-gateway-v4.3.x');
 const { deployGatewayv5 } = require('./deploy-gateway-v5.x');
 
 module.exports = {
@@ -11,6 +11,6 @@ module.exports = {
     importNetworks,
     verifyContract,
     getBytecodeHash,
-    deployGatewayv4_3,
+    deployGatewayv43,
     deployGatewayv5,
 };

--- a/evm/utils.js
+++ b/evm/utils.js
@@ -278,7 +278,7 @@ const predictAddressCreate = async (from, nonce) => {
 const getProxy = async (config, chain) => {
     const address = (await httpGet(`${config.axelar.lcd}/axelar/evm/v1beta1/gateway_address/${chain}`)).address;
     return address;
-}
+};
 
 const getEVMAddresses = async (config, chain) => {
     const evmAddresses = await httpGet(`${config.axelar.lcd}/axelar/evm/v1beta1/key_address/${chain}`);
@@ -289,7 +289,7 @@ const getEVMAddresses = async (config, chain) => {
     const threshold = Number(evmAddresses.threshold);
 
     return { addresses, weights, threshold };
-}
+};
 
 module.exports = {
     deployContract,

--- a/evm/utils.js
+++ b/evm/utils.js
@@ -5,6 +5,7 @@ const {
     utils: { isAddress, getContractAddress, keccak256 },
 } = require('ethers');
 const https = require('https');
+const http = require('http');
 const { outputJsonSync, readJsonSync } = require('fs-extra');
 const { exec } = require('child_process');
 const { writeFile } = require('fs');
@@ -86,7 +87,7 @@ const writeJSON = (data, name) => {
 
 const httpGet = (url) => {
     return new Promise((resolve, reject) => {
-        https.get(url, (res) => {
+        (url.startsWith('https://') ? https : http).get(url, (res) => {
             const { statusCode } = res;
             const contentType = res.headers['content-type'];
             let error;


### PR DESCRIPTION
- Allow regular `http` get request
- import `ConstAddressDeployer` and `ConstCreate3Deployer` from `axelar-network/axelar-gmp-sdk-solidity` repo
- use correct function name for deploying contract at `evm/deploy-const-address-deployer.js`
- check that governance chain address is a string, but not an EVM address
- ran linter and prettier