### PR TITLE
fix(config): update `ConstAddressDeployer` address and deployer

### DIFF
--- a/evm/deploy-const-address-deployer.js
+++ b/evm/deploy-const-address-deployer.js
@@ -31,6 +31,8 @@ async function deploy(options, chain) {
 
     if (!force && (await provider.getCode(expectedAddress)) !== '0x') {
         console.log(`ConstAddressDeployer already deployed at address ${expectedAddress}`);
+        contractConfig.address = expectedAddress;
+        contractConfig.deployer = wallet.address;
         return;
     }
 

--- a/evm/deploy-const-address-deployer.js
+++ b/evm/deploy-const-address-deployer.js
@@ -23,9 +23,11 @@ async function deploy(options, chain) {
         contracts[contractName] = {};
     }
 
+    const contractConfig = contracts[contractName];
+
     const rpc = chain.rpc;
     const provider = getDefaultProvider(rpc);
-    const expectedAddress = contracts[contractName].address
+    const expectedAddress = contractConfig.address
         ? contracts[contractName].address
         : await predictAddressCreate(wallet.address, 0);
 
@@ -50,7 +52,6 @@ async function deploy(options, chain) {
 
     console.log(`Deployer has ${balance / 1e18} ${chalk.green(chain.tokenSymbol)} and nonce ${nonce} on ${chain.name}.`);
 
-    const contractConfig = contracts[contractName];
     const gasOptions = contractConfig.gasOptions || chain.gasOptions || {};
     console.log(`Gas override for chain ${chain.name}: ${JSON.stringify(gasOptions)}`);
 

--- a/evm/deploy-const-address-deployer.js
+++ b/evm/deploy-const-address-deployer.js
@@ -27,7 +27,7 @@ async function deploy(options, chain) {
 
     const rpc = chain.rpc;
     const provider = getDefaultProvider(rpc);
-    const expectedAddress = contractConfig.address ? contracts[contractName].address : await predictAddressCreate(wallet.address, 0);
+    const expectedAddress = contractConfig.address ? contractConfig.address : await predictAddressCreate(wallet.address, 0);
 
     if (!force && (await provider.getCode(expectedAddress)) !== '0x') {
         console.log(`ConstAddressDeployer already deployed at address ${expectedAddress}`);

--- a/evm/deploy-const-address-deployer.js
+++ b/evm/deploy-const-address-deployer.js
@@ -27,9 +27,7 @@ async function deploy(options, chain) {
 
     const rpc = chain.rpc;
     const provider = getDefaultProvider(rpc);
-    const expectedAddress = contractConfig.address
-        ? contracts[contractName].address
-        : await predictAddressCreate(wallet.address, 0);
+    const expectedAddress = contractConfig.address ? contracts[contractName].address : await predictAddressCreate(wallet.address, 0);
 
     if (!force && (await provider.getCode(expectedAddress)) !== '0x') {
         console.log(`ConstAddressDeployer already deployed at address ${expectedAddress}`);


### PR DESCRIPTION
Update json configuration with `ConstAddressDeployer` address and deployer even when exiting earlier due to already being deployed