### PR TITLE
fix: add checks for contracts incompatible with create3

### DIFF
--- a/evm/deploy-upgradable.js
+++ b/evm/deploy-upgradable.js
@@ -97,6 +97,11 @@ async function deploy(options, chain) {
     const { artifactPath, contractName, deployMethod, privateKey, upgrade, verifyEnv, yes } = options;
     const verifyOptions = verifyEnv ? { env: verifyEnv, chain: chain.name } : null;
 
+    if (deployMethod === 'create3' && (contractName === 'AxelarGasService' || contractName === 'AxelarDepositService')) {
+        printError(`${deployMethod} not supported for ${contractName}`);
+        return;
+    }
+
     const rpc = chain.rpc;
     const provider = getDefaultProvider(rpc);
     const wallet = new Wallet(privateKey, provider);
@@ -257,10 +262,9 @@ async function deploy(options, chain) {
         printInfo(`${chain.name} | Proxy for ${contractName}`, contractConfig.address);
 
         const owner = await contract.owner();
+
         if (owner !== wallet.address) {
-            printError(
-                `${chain.name} | Signer ${wallet.address} does not match contract owner ${owner} for chain ${chain.name} in info.`,
-            );
+            printError(`${chain.name} | Signer ${wallet.address} does not match contract owner ${owner} for chain ${chain.name} in info.`);
         }
     }
 }

--- a/evm/upgradable.js
+++ b/evm/upgradable.js
@@ -1,10 +1,6 @@
 'use strict';
 
-const {
-    Contract,
-    ContractFactory,
-    utils: { keccak256 },
-} = require('ethers');
+const { Contract, ContractFactory } = require('ethers');
 const { deployAndInitContractConstant, create3DeployAndInitContract } = require('@axelar-network/axelar-gmp-sdk-solidity');
 const IUpgradable = require('@axelar-network/axelar-gmp-sdk-solidity/interfaces/IUpgradable.json');
 

--- a/evm/utils.js
+++ b/evm/utils.js
@@ -3,7 +3,7 @@
 const {
     ContractFactory,
     Contract,
-    utils: { getContractAddress, keccak256, isAddress, getCreate2Address, Interface, defaultAbiCoder },
+    utils: { getContractAddress, keccak256, isAddress, getCreate2Address, defaultAbiCoder },
 } = require('ethers');
 const https = require('https');
 const http = require('http');
@@ -404,11 +404,7 @@ const getDeployedAddress = async (deployer, deployMethod, options = {}) => {
             const initCode = factory.getDeployTransaction(...constructorArgs).data;
 
             if (!options.offline) {
-                const deployerInterface = new Contract(
-                    deployerContract,
-                    IDeployer.abi,
-                    options.provider,
-                );
+                const deployerInterface = new Contract(deployerContract, IDeployer.abi, options.provider);
 
                 return await deployerInterface.deployedAddress(initCode, deployer, salt);
             }
@@ -428,11 +424,7 @@ const getDeployedAddress = async (deployer, deployMethod, options = {}) => {
             if (!options.offline) {
                 const salt = getSaltFromKey(options.salt);
 
-                const deployerInterface = new Contract(
-                    deployerContract,
-                    IDeployer.abi,
-                    options.provider,
-                );
+                const deployerInterface = new Contract(deployerContract, IDeployer.abi, options.provider);
 
                 return await deployerInterface.deployedAddress('0x', deployer, salt);
             }


### PR DESCRIPTION
PR for deployment script to log an error if gas service or deposit service is deployed using create3.