### PR TITLE
feat: added InterchainProposalSender constructor args

### DIFF
--- a/evm/deploy-contract.js
+++ b/evm/deploy-contract.js
@@ -69,6 +69,21 @@ async function getConstructorArgs(contractName, config, wallet) {
             return [gateway, governanceChain, governanceAddress, minimumTimeDelay, cosigners, threshold];
         }
 
+        case 'InterchainProposalSender': {
+            const gateway = config.AxelarGateway?.address;
+            const gasService = config.AxelarGasService?.address;
+
+            if (!isAddress(gateway)) {
+                throw new Error(`Missing AxelarGateway address in the chain info.`);
+            }
+
+            if (!isAddress(gasService)) {
+                throw new Error(`Missing AxelarGasService address in the chain info.`);
+            }
+
+            return [gateway, gasService];
+        }
+
         case 'InterchainGovernance': {
             const gateway = config.AxelarGateway?.address;
 


### PR DESCRIPTION
Tested from my local with the following steps:

## Clone and compile InterchainProposalSender contract
1. Clone `git clone git@github.com:axelarnetwork/interchain-governance-executor.git`
2. Install dep `yarn` 
3. Compile contracts `yarn compile`

## Deploy
1. Added my private key in `.env`
2. Execute a command and provide a path to the contract 
```
node evm/deploy-contract.js -n fantom -a ../../interchain-governance-executor/artifacts/contracts/ -c InterchainProposalSender -m create2
```

