### PR TITLE
feat: update amp worker set query to not use keyID

### DIFF
--- a/evm/deploy-gateway-v5.0.x.js
+++ b/evm/deploy-gateway-v5.0.x.js
@@ -394,6 +394,7 @@ async function programHandler() {
     program.addOption(new Option('-g, --governance <governance>', 'governance address').env('GOVERNANCE'));
     program.addOption(new Option('-m, --mintLimiter <mintLimiter>', 'mint limiter address').env('MINT_LIMITER'));
     program.addOption(new Option('-y, --yes', 'skip deployment prompt confirmation').env('YES'));
+    program.addOption(new Option('-k, --keyID <keyID>', 'key ID').env('KEY_ID'));
     program.addOption(new Option('-a, --amplifier', 'deploy amplifier gateway').env('AMPLIFIER'));
     program.addOption(new Option('--prevKeyIDs <prevKeyIDs>', 'previous key IDs to be used for auth contract'));
     program.addOption(new Option('-u, --upgrade', 'upgrade gateway').env('UPGRADE'));

--- a/evm/deploy-gateway-v5.0.x.js
+++ b/evm/deploy-gateway-v5.0.x.js
@@ -394,7 +394,6 @@ async function programHandler() {
     program.addOption(new Option('-g, --governance <governance>', 'governance address').env('GOVERNANCE'));
     program.addOption(new Option('-m, --mintLimiter <mintLimiter>', 'mint limiter address').env('MINT_LIMITER'));
     program.addOption(new Option('-y, --yes', 'skip deployment prompt confirmation').env('YES'));
-    program.addOption(new Option('-k, --keyID <keyID>', 'key ID').env('KEY_ID'));
     program.addOption(new Option('-a, --amplifier', 'deploy amplifier gateway').env('AMPLIFIER'));
     program.addOption(new Option('--prevKeyIDs <prevKeyIDs>', 'previous key IDs to be used for auth contract'));
     program.addOption(new Option('-u, --upgrade', 'upgrade gateway').env('UPGRADE'));

--- a/evm/utils.js
+++ b/evm/utils.js
@@ -543,7 +543,7 @@ const getAmplifierKeyAddresses = async (config, chain) => {
     });
 
     const weightedAddresses = workerSet.signers.map((signer) => ({
-        address: computeAddress(`0x${signer.pub_key.e_c_d_s_a}`),
+        address: computeAddress(`0x${signer.pub_key.ecdsa}`),
         weight: signer.weight,
     }));
 

--- a/evm/utils.js
+++ b/evm/utils.js
@@ -421,9 +421,7 @@ const getEVMAddresses = async (config, chain, options = {}) => {
 
 const getAmplifierKeyAddresses = async (config, chain) => {
     const client = await CosmWasmClient.connect(config.axelar.rpc);
-    const workerSet = await client.queryContractSmart(config.axelar.contracts.MultisigProver[chain].address, {
-        get_worker_set: {},
-    });
+    const workerSet = await client.queryContractSmart(config.axelar.contracts.MultisigProver[chain].address, 'get_worker_set');
 
     const weightedAddresses = workerSet.signers.map((signer) => ({
         address: computeAddress(`0x${signer.pub_key.ecdsa}`),

--- a/evm/utils.js
+++ b/evm/utils.js
@@ -524,7 +524,7 @@ const getEVMAddresses = async (config, chain, options = {}) => {
     const keyID = options.keyID || '';
 
     const evmAddresses = options.amplifier
-        ? await getAmplifierKeyAddresses(config, chain, keyID)
+        ? await getAmplifierKeyAddresses(config, chain)
         : await httpGet(`${config.axelar.lcd}/axelar/evm/v1beta1/key_address/${chain}?key_id=${keyID}`);
 
     const sortedAddresses = evmAddresses.addresses.sort((a, b) => a.address.toLowerCase().localeCompare(b.address.toLowerCase()));
@@ -536,19 +536,18 @@ const getEVMAddresses = async (config, chain, options = {}) => {
     return { addresses, weights, threshold };
 };
 
-const getAmplifierKeyAddresses = async (config, chain, keyID = '') => {
+const getAmplifierKeyAddresses = async (config, chain) => {
     const client = await CosmWasmClient.connect(config.axelar.rpc);
-    const key = await client.queryContractSmart(config.axelar.contracts.Multisig.address, {
-        get_key: { key_id: { owner: config.axelar.contracts.MultisigProver[chain].address, subkey: keyID } },
+    const workerSet = await client.queryContractSmart(config.axelar.contracts.MultisigProver[chain].address, {
+        get_worker_set: {},
     });
-    const pubkeys = new Map(Object.entries(key.pub_keys));
 
-    const weightedAddresses = Object.values(key.snapshot.participants).map((participant) => ({
-        address: computeAddress(`0x${pubkeys.get(participant.address)}`),
-        weight: participant.weight,
+    const weightedAddresses = workerSet.signers.map((signer) => ({
+        address: computeAddress(`0x${signer.pub_key.e_c_d_s_a}`),
+        weight: signer.weight,
     }));
 
-    return { addresses: weightedAddresses, threshold: key.snapshot.quorum };
+    return { addresses: weightedAddresses, threshold: workerSet.threshold };
 };
 
 function sleep(ms) {


### PR DESCRIPTION
Adjust amplifier contract query to new key rotation logic. Key ID is not longer needed to get current worker set

https://axelarnetwork.atlassian.net/browse/AXE-1683