### PR TITLE
fix: use chain id for unique chain naming

### DIFF
--- a/evm/deploy-its.js
+++ b/evm/deploy-its.js
@@ -207,7 +207,7 @@ async function deployImplementation(wallet, chain, deploymentKey, skipExisting =
                         contracts.AxelarGasService.address,
                         contractConfig.remoteAddressValidator,
                         Object.values(contractConfig.tokenManagerImplementations),
-                        chain.name,
+                        chain.id,  // use the unique Axelar registered chain id
                     ],
                     deploymentKey,
                     gasOptions,

--- a/evm/deploy-its.js
+++ b/evm/deploy-its.js
@@ -207,7 +207,7 @@ async function deployImplementation(wallet, chain, deploymentKey, skipExisting =
                         contracts.AxelarGasService.address,
                         contractConfig.remoteAddressValidator,
                         Object.values(contractConfig.tokenManagerImplementations),
-                        chain.id,  // use the unique Axelar registered chain id
+                        chain.id, // use the unique Axelar registered chain id
                     ],
                     deploymentKey,
                     gasOptions,


### PR DESCRIPTION
This avoids the scenario where two chains are added under the same (for e..g a new ethereum testnet since old is deprecated)