### PR TITLE
feat: add gas adjustment option

### DIFF
--- a/axelar-chains-config/info/mainnet.json
+++ b/axelar-chains-config/info/mainnet.json
@@ -271,7 +271,7 @@
       },
       "gasOptions": {
         "gasLimit": 5000000,
-        "gasPriceAdjustment": 1.6
+        "gasPriceAdjustment": 1.4
       },
       "staticGasOptions": {
         "gasLimit": 3000000,
@@ -550,7 +550,7 @@
       },
       "gasOptions": {
         "gasLimit": 8000000,
-        "gasPriceAdjustment": 1.6
+        "gasPriceAdjustment": 1.4
       },
       "staticGasOptions": {
         "gasLimit": 3000000,

--- a/axelar-chains-config/info/mainnet.json
+++ b/axelar-chains-config/info/mainnet.json
@@ -270,7 +270,8 @@
         "api": "https://api.ftmscan.com/api"
       },
       "gasOptions": {
-        "gasLimit": 5000000
+        "gasLimit": 5000000,
+        "gasPriceAdjustment": 1.6
       },
       "staticGasOptions": {
         "gasLimit": 3000000,
@@ -363,7 +364,8 @@
         "api": "https://api.polygonscan.com/api"
       },
       "gasOptions": {
-        "gasLimit": 6000000
+        "gasLimit": 6000000,
+        "gasPriceAdjustment": 1.6
       },
       "staticGasOptions": {
         "gasLimit": 3000000,
@@ -547,7 +549,8 @@
         "api": "https://api.bscscan.com/api"
       },
       "gasOptions": {
-        "gasLimit": 8000000
+        "gasLimit": 8000000,
+        "gasPriceAdjustment": 1.6
       },
       "staticGasOptions": {
         "gasLimit": 3000000,

--- a/evm/deploy-const-address-deployer.js
+++ b/evm/deploy-const-address-deployer.js
@@ -8,7 +8,7 @@ const readlineSync = require('readline-sync');
 const { Command, Option } = require('commander');
 const chalk = require('chalk');
 
-const { printInfo, writeJSON, predictAddressCreate, deployCreate } = require('./utils');
+const { printInfo, writeJSON, predictAddressCreate, deployCreate, getGasOptions } = require('./utils');
 const { addExtendedOptions } = require('./cli-utils');
 const contractJson = require('@axelar-network/axelar-gmp-sdk-solidity/artifacts/contracts/deploy/ConstAddressDeployer.sol/ConstAddressDeployer.json');
 const contractName = 'ConstAddressDeployer';
@@ -48,7 +48,7 @@ async function deployConstAddressDeployer(wallet, chain, options = {}, verifyOpt
 
     console.log(`Deployer has ${balance / 1e18} ${chalk.green(chain.tokenSymbol)} and nonce ${nonce} on ${chain.name}.`);
 
-    const gasOptions = contractConfig.gasOptions || chain.gasOptions || {};
+    const gasOptions = getGasOptions(contractConfig, chain, options, provider);
     console.log(`Gas override for chain ${chain.name}: ${JSON.stringify(gasOptions)}`);
 
     const constAddressDeployerAddress = await predictAddressCreate(wallet.address, nonce);

--- a/evm/deploy-const-address-deployer.js
+++ b/evm/deploy-const-address-deployer.js
@@ -48,8 +48,7 @@ async function deployConstAddressDeployer(wallet, chain, options = {}, verifyOpt
 
     console.log(`Deployer has ${balance / 1e18} ${chalk.green(chain.tokenSymbol)} and nonce ${nonce} on ${chain.name}.`);
 
-    const gasOptions = getGasOptions(contractConfig, chain, options, provider);
-    console.log(`Gas override for chain ${chain.name}: ${JSON.stringify(gasOptions)}`);
+    const gasOptions = await getGasOptions(chain, options, contractName);
 
     const constAddressDeployerAddress = await predictAddressCreate(wallet.address, nonce);
     printInfo('ConstAddressDeployer will be deployed to', constAddressDeployerAddress);

--- a/evm/deploy-contract.js
+++ b/evm/deploy-contract.js
@@ -255,15 +255,9 @@ async function processCommand(config, chain, options) {
     printInfo('Pre-deploy Contract bytecode hash', predeployCodehash);
 
     const constructorArgs = await getConstructorArgs(contractName, chain, wallet, options);
-    const gasOptions = getGasOptions(contractConfig, chain, options, provider);
-
-    // Some chains require a gas adjustment
-    if (env === 'mainnet' && !gasOptions.gasPrice && (chain.name === 'Fantom' || chain.name === 'Binance' || chain.name === 'Polygon')) {
-        gasOptions.gasPrice = Math.floor((await provider.getGasPrice()) * 1.6);
-    }
+    const gasOptions = await getGasOptions(chain, options, contractName);
 
     printInfo(`Constructor args for chain ${chain.name}`, constructorArgs);
-    printInfo(`Gas override for chain ${chain.name}`, JSON.stringify(gasOptions, null, 2));
 
     const salt = options.salt || contractName;
     let deployerContract = deployMethod === 'create3' ? contracts.Create3Deployer?.address : contracts.ConstAddressDeployer?.address;

--- a/evm/deploy-contract.js
+++ b/evm/deploy-contract.js
@@ -14,7 +14,7 @@ const {
     printInfo,
     printWarn,
     printError,
-    copyObject,
+    getGasOptions,
     isNonEmptyString,
     isNumber,
     isAddressArray,
@@ -255,7 +255,7 @@ async function processCommand(config, chain, options) {
     printInfo('Pre-deploy Contract bytecode hash', predeployCodehash);
 
     const constructorArgs = await getConstructorArgs(contractName, chain, wallet, options);
-    const gasOptions = copyObject(contractConfig.gasOptions || chain.gasOptions || {});
+    const gasOptions = getGasOptions(contractConfig, chain, options, provider);
 
     // Some chains require a gas adjustment
     if (env === 'mainnet' && !gasOptions.gasPrice && (chain.name === 'Fantom' || chain.name === 'Binance' || chain.name === 'Polygon')) {

--- a/evm/deploy-create3-deployer.js
+++ b/evm/deploy-create3-deployer.js
@@ -31,8 +31,7 @@ async function deployCreate3Deployer(wallet, chain, provider, options = {}, veri
     }
 
     const contractConfig = contracts[contractName];
-    const gasOptions = getGasOptions(contractConfig, chain, options, provider);
-    console.log(`Gas override for chain ${chain.name}: ${JSON.stringify(gasOptions)}`);
+    const gasOptions = await getGasOptions(chain, options, contractName);
 
     const salt = options.salt || contractName;
     printInfo('Create3 deployer deployment salt', salt);

--- a/evm/deploy-gateway-v4.3.x.js
+++ b/evm/deploy-gateway-v4.3.x.js
@@ -16,6 +16,7 @@ const {
     isAddressArray,
     isNumber,
     prompt,
+    getGasOptions,
 } = require('./utils');
 const { addExtendedOptions } = require('./cli-utils');
 const { ethers } = require('hardhat');
@@ -65,7 +66,7 @@ async function deploy(config, options) {
     });
     printInfo('Predicted proxy address', proxyAddress);
 
-    const gasOptions = contractConfig.gasOptions || chain.gasOptions || { gasLimit: 6e6 };
+    const gasOptions = getGasOptions(contractConfig, chain, options, provider, 6e6);
     printInfo('Gas override', JSON.stringify(gasOptions, null, 2));
     printInfo('Is verification enabled?', verify ? 'y' : 'n');
     printInfo('Skip existing contracts?', skipExisting ? 'y' : 'n');
@@ -272,7 +273,7 @@ async function upgrade(config, options) {
     printInfo('Upgrading to implementation', contractConfig.implementation);
     printInfo('Implementation codehash', implementationCodehash);
 
-    const gasOptions = contractConfig.gasOptions || chain.gasOptions || {};
+    const gasOptions = getGasOptions(contractConfig, chain, options, provider);
     printInfo('Gas options', JSON.stringify(gasOptions, null, 2));
 
     if (prompt(`Proceed with upgrade on ${chain.name}?`, yes)) {

--- a/evm/deploy-gateway-v4.3.x.js
+++ b/evm/deploy-gateway-v4.3.x.js
@@ -66,8 +66,8 @@ async function deploy(config, options) {
     });
     printInfo('Predicted proxy address', proxyAddress);
 
-    const gasOptions = getGasOptions(contractConfig, chain, options, provider, 6e6);
-    printInfo('Gas override', JSON.stringify(gasOptions, null, 2));
+    const gasOptions = await getGasOptions(chain, options, contractName);
+
     printInfo('Is verification enabled?', verify ? 'y' : 'n');
     printInfo('Skip existing contracts?', skipExisting ? 'y' : 'n');
 
@@ -273,8 +273,7 @@ async function upgrade(config, options) {
     printInfo('Upgrading to implementation', contractConfig.implementation);
     printInfo('Implementation codehash', implementationCodehash);
 
-    const gasOptions = getGasOptions(contractConfig, chain, options, provider);
-    printInfo('Gas options', JSON.stringify(gasOptions, null, 2));
+    const gasOptions = await getGasOptions(chain, options, contractName);
 
     if (prompt(`Proceed with upgrade on ${chain.name}?`, yes)) {
         return;

--- a/evm/deploy-gateway-v6.2.x.js
+++ b/evm/deploy-gateway-v6.2.x.js
@@ -132,9 +132,8 @@ async function deploy(config, chain, options) {
         printInfo('MintLimiter address', mintLimiter);
     }
 
-    const gasOptions = getGasOptions(contractConfig, chain, options, provider);
+    const gasOptions = await getGasOptions(chain, options, contractName);
 
-    printInfo('Gas override', JSON.stringify(gasOptions, null, 2));
     const gatewayFactory = new ContractFactory(AxelarGateway.abi, AxelarGateway.bytecode, wallet);
     const authFactory = new ContractFactory(AxelarAuthWeighted.abi, AxelarAuthWeighted.bytecode, wallet);
     const tokenDeployerFactory = new ContractFactory(TokenDeployer.abi, TokenDeployer.bytecode, wallet);
@@ -477,14 +476,13 @@ async function upgrade(_, chain, options) {
     printInfo('Mint limiter', mintLimiter);
     printInfo('Setup params', setupParams);
 
-    const gasOptions = getGasOptions(contractConfig, chain, options, provider);
-    printInfo('Gas options', JSON.stringify(gasOptions, null, 2));
+    const gasOptions = await getGasOptions(chain, options, contractName);
 
     if (prompt(`Proceed with an upgrade on ${chain.name}?`, yes)) {
         return;
     }
 
-    const tx = await gateway.populateTransaction.upgrade(contractConfig.implementation, implementationCodehash, setupParams);
+    const tx = await gateway.populateTransaction.upgrade(contractConfig.implementation, implementationCodehash, setupParams, gasOptions);
 
     const { baseTx, signedTx } = await signTransaction(wallet, chain, tx, options);
 

--- a/evm/deploy-its.js
+++ b/evm/deploy-its.js
@@ -32,9 +32,6 @@ async function deployImplementation(config, wallet, chain, options) {
     const contracts = chain.contracts;
     const contractConfig = contracts[contractName] || {};
 
-    const rpc = chain.rpc;
-    const provider = getDefaultProvider(rpc);
-
     contractConfig.salt = salt;
     contractConfig.deployer = wallet.address;
 
@@ -57,7 +54,7 @@ async function deployImplementation(config, wallet, chain, options) {
         return;
     }
 
-    const gasOptions = getGasOptions(contractConfig, chain, options, provider);
+    const gasOptions = await getGasOptions(chain, options, contractName);
 
     const deployOptions =
         deployMethod === 'create'
@@ -328,7 +325,7 @@ async function upgrade(config, chain, options) {
 
     printInfo(`Upgrading Interchain Token Service.`);
 
-    const gasOptions = getGasOptions(contractConfig, chain, options, provider);
+    const gasOptions = await getGasOptions(chain, options, contractName);
     const contract = new Contract(contractConfig.address, InterchainTokenService.abi, wallet);
 
     const codehash = await getBytecodeHash(contractConfig.implementation, chain.id, provider);

--- a/evm/deploy-upgradable.js
+++ b/evm/deploy-upgradable.js
@@ -130,9 +130,8 @@ async function deploy(options, chain) {
 
     const contractConfig = contracts[contractName];
     const implArgs = await getImplementationArgs(contractName, contracts, options);
-    const gasOptions = getGasOptions(contractConfig, chain, options, provider);
+    const gasOptions = await getGasOptions(chain, options, contractName);
     printInfo(`Implementation args for chain ${chain.name}`, implArgs);
-    console.log(`Gas override for chain ${chain.name}: ${JSON.stringify(gasOptions, null, 2)}`);
     const salt = options.salt || contractName;
     let deployerContract = deployMethod === 'create3' ? contracts.Create3Deployer?.address : contracts.ConstAddressDeployer?.address;
 

--- a/evm/deploy-upgradable.js
+++ b/evm/deploy-upgradable.js
@@ -14,7 +14,7 @@ const IUpgradable = require('@axelar-network/axelar-gmp-sdk-solidity/interfaces/
 const { Command, Option } = require('commander');
 
 const { deployUpgradable, deployCreate2Upgradable, deployCreate3Upgradable, upgradeUpgradable } = require('./upgradable');
-const { printInfo, printError, saveConfig, loadConfig, printWalletInfo, getDeployedAddress, prompt } = require('./utils');
+const { printInfo, printError, saveConfig, loadConfig, printWalletInfo, getDeployedAddress, prompt, getGasOptions } = require('./utils');
 const { addExtendedOptions } = require('./cli-utils');
 
 function getProxy(wallet, proxyAddress) {
@@ -130,7 +130,7 @@ async function deploy(options, chain) {
 
     const contractConfig = contracts[contractName];
     const implArgs = await getImplementationArgs(contractName, contracts, options);
-    const gasOptions = contractConfig.gasOptions || chain.gasOptions || {};
+    const gasOptions = getGasOptions(contractConfig, chain, options, provider);
     printInfo(`Implementation args for chain ${chain.name}`, implArgs);
     console.log(`Gas override for chain ${chain.name}: ${JSON.stringify(gasOptions, null, 2)}`);
     const salt = options.salt || contractName;

--- a/evm/gateway.js
+++ b/evm/gateway.js
@@ -21,6 +21,7 @@ const {
     wasEventEmitted,
     mainProcessor,
     printError,
+    getGasOptions,
 } = require('./utils');
 const { addBaseOptions } = require('./cli-utils');
 const { getWallet } = require('./sign-utils');
@@ -82,7 +83,7 @@ async function processCommand(config, chain, options) {
 
     const gateway = new Contract(gatewayAddress, IGateway.abi, wallet);
 
-    const gasOptions = contractConfig?.gasOptions || chain?.gasOptions || {};
+    const gasOptions = getGasOptions(contractConfig, chain, options, provider);
     printInfo('Gas options', JSON.stringify(gasOptions, null, 2));
 
     printInfo('Action', action);

--- a/evm/gateway.js
+++ b/evm/gateway.js
@@ -62,7 +62,6 @@ async function processCommand(config, chain, options) {
 
     const contracts = chain.contracts;
     const contractName = 'AxelarGateway';
-    const contractConfig = contracts.AxelarGateway;
 
     const gatewayAddress = address || contracts.AxelarGateway?.address;
 
@@ -83,8 +82,7 @@ async function processCommand(config, chain, options) {
 
     const gateway = new Contract(gatewayAddress, IGateway.abi, wallet);
 
-    const gasOptions = getGasOptions(contractConfig, chain, options, provider);
-    printInfo('Gas options', JSON.stringify(gasOptions, null, 2));
+    const gasOptions = await getGasOptions(chain, options, contractName);
 
     printInfo('Action', action);
 

--- a/evm/governance.js
+++ b/evm/governance.js
@@ -106,9 +106,7 @@ async function processCommand(_, chain, options) {
 
     const governance = new Contract(governanceAddress, IGovernance.abi, wallet);
 
-    const gasOptions = getGasOptions(contractConfig, chain, options, provider, 5e6);
-
-    printInfo('Gas options', JSON.stringify(gasOptions, null, 2));
+    const gasOptions = await getGasOptions(chain, options, contractName);
 
     printInfo('Proposal Action', action);
 

--- a/evm/governance.js
+++ b/evm/governance.js
@@ -13,7 +13,7 @@ const {
 const { Command, Option } = require('commander');
 const {
     printInfo,
-    copyObject,
+    getGasOptions,
     printWalletInfo,
     isValidTimeFormat,
     dateToEta,
@@ -65,7 +65,7 @@ async function getGatewaySetupParams(governance, gateway, contracts, options) {
 }
 
 async function processCommand(_, chain, options) {
-    const { env, contractName, address, action, date, privateKey, yes } = options;
+    const { contractName, address, action, date, privateKey, yes } = options;
 
     const contracts = chain.contracts;
     const contractConfig = contracts[contractName];
@@ -106,12 +106,7 @@ async function processCommand(_, chain, options) {
 
     const governance = new Contract(governanceAddress, IGovernance.abi, wallet);
 
-    const gasOptions = copyObject(contractConfig?.gasOptions || chain?.gasOptions || { gasLimit: 5e6 });
-
-    // Some chains require a gas adjustment
-    if (env === 'mainnet' && !gasOptions.gasPrice && (chain.name === 'Fantom' || chain.name === 'Binance' || chain.name === 'Polygon')) {
-        gasOptions.gasPrice = Math.floor((await provider.getGasPrice()) * 1.4);
-    }
+    const gasOptions = getGasOptions(contractConfig, chain, options, provider, 5e6);
 
     printInfo('Gas options', JSON.stringify(gasOptions, null, 2));
 

--- a/evm/its.js
+++ b/evm/its.js
@@ -19,6 +19,7 @@ const {
     validateParameters,
     getContractJSON,
     isValidTokenId,
+    getGasOptions,
 } = require('./utils');
 const { getWallet } = require('./sign-utils');
 const IInterchainTokenService = getContractJSON('IInterchainTokenService');
@@ -62,7 +63,6 @@ async function processCommand(config, chain, options) {
 
     const contracts = chain.contracts;
     const contractName = 'InterchainTokenService';
-    const contractConfig = contracts.InterchainTokenService;
 
     const interchainTokenServiceAddress = address || contracts.InterchainTokenService?.address;
 
@@ -81,8 +81,7 @@ async function processCommand(config, chain, options) {
 
     const interchainTokenService = new Contract(interchainTokenServiceAddress, IInterchainTokenService.abi, wallet);
 
-    const gasOptions = contractConfig?.gasOptions || chain?.gasOptions || {};
-    printInfo('Gas options', JSON.stringify(gasOptions, null, 2));
+    const gasOptions = await getGasOptions(chain, options, contractName);
 
     printInfo('Action', action);
 
@@ -201,6 +200,7 @@ async function processCommand(config, chain, options) {
                 tokenManagerImplementations[type],
                 params,
                 gasValue,
+                gasOptions,
             );
 
             await handleTx(tx, chain, interchainTokenService, options.action, 'TokenManagerDeployed', 'TokenManagerDeploymentStarted');
@@ -228,6 +228,7 @@ async function processCommand(config, chain, options) {
                 decimals,
                 distributor,
                 gasValue,
+                gasOptions,
             );
 
             await handleTx(tx, chain, interchainTokenService, options.action, 'TokenManagerDeployed', 'InterchainTokenDeploymentStarted');
@@ -263,7 +264,7 @@ async function processCommand(config, chain, options) {
                 isValidCalldata: { payload },
             });
 
-            const tx = await interchainTokenService.expressExecute(commandID, sourceChain, sourceAddress, payload);
+            const tx = await interchainTokenService.expressExecute(commandID, sourceChain, sourceAddress, payload, gasOptions);
 
             await handleTx(tx, chain, interchainTokenService, options.action, 'ExpressExecuted');
 
@@ -288,6 +289,7 @@ async function processCommand(config, chain, options) {
                 destinationAddress,
                 amount,
                 metadata,
+                gasOptions,
             );
 
             await handleTx(tx, chain, interchainTokenService, options.action, 'InterchainTransfer', 'InterchainTransferWithData');
@@ -313,6 +315,7 @@ async function processCommand(config, chain, options) {
                 destinationAddress,
                 amount,
                 data,
+                gasOptions,
             );
 
             await handleTx(tx, chain, interchainTokenService, options.action, 'InterchainTransfer', 'InterchainTransferWithData');
@@ -335,7 +338,7 @@ async function processCommand(config, chain, options) {
 
             validateParameters({ isNumberArray: { flowLimits } });
 
-            const tx = await interchainTokenService.setFlowLimits(tokenIdsBytes32, flowLimits);
+            const tx = await interchainTokenService.setFlowLimits(tokenIdsBytes32, flowLimits, gasOptions);
 
             await handleTx(tx, chain, interchainTokenService, options.action, 'FlowLimitSet');
 
@@ -353,7 +356,7 @@ async function processCommand(config, chain, options) {
 
             validateParameters({ isNonEmptyString: { trustedChain, trustedAddress } });
 
-            const tx = await interchainTokenService.setTrustedAddress(trustedChain, trustedAddress);
+            const tx = await interchainTokenService.setTrustedAddress(trustedChain, trustedAddress, gasOptions);
 
             await handleTx(tx, chain, interchainTokenService, options.action, 'TrustedAddressSet');
 
@@ -371,7 +374,7 @@ async function processCommand(config, chain, options) {
 
             validateParameters({ isNonEmptyString: { trustedChain } });
 
-            const tx = await interchainTokenService.removeTrustedAddress(trustedChain);
+            const tx = await interchainTokenService.removeTrustedAddress(trustedChain, gasOptions);
 
             await handleTx(tx, chain, interchainTokenService, options.action, 'TrustedAddressRemoved');
 
@@ -387,7 +390,7 @@ async function processCommand(config, chain, options) {
 
             const pauseStatus = options.pauseStatus;
 
-            const tx = await interchainTokenService.setPauseStatus(pauseStatus);
+            const tx = await interchainTokenService.setPauseStatus(pauseStatus, gasOptions);
 
             await handleTx(tx, chain, interchainTokenService, options.action, 'Paused', 'Unpaused');
 
@@ -407,7 +410,7 @@ async function processCommand(config, chain, options) {
 
             validateParameters({ isValidCalldata: { payload } });
 
-            const tx = await interchainTokenService.execute(commandID, sourceChain, sourceAddress, payload);
+            const tx = await interchainTokenService.execute(commandID, sourceChain, sourceAddress, payload, gasOptions);
 
             await handleTx(tx, chain, interchainTokenService, options.action);
 

--- a/evm/multisig.js
+++ b/evm/multisig.js
@@ -22,6 +22,7 @@ const {
     mainProcessor,
     isValidDecimal,
     prompt,
+    getGasOptions,
 } = require('./utils');
 const { addBaseOptions } = require('./cli-utils');
 const IMultisig = require('@axelar-network/axelar-gmp-sdk-solidity/interfaces/IMultisig.json');
@@ -123,7 +124,7 @@ async function processCommand(_, chain, options) {
 
     const multisigContract = new Contract(multisigAddress, IMultisig.abi, wallet);
 
-    const gasOptions = contractConfig?.gasOptions || chain?.gasOptions || {};
+    const gasOptions = getGasOptions(contractConfig, chain, options, provider);
     printInfo('Gas options', JSON.stringify(gasOptions, null, 2));
 
     printInfo('Multisig Action', action);

--- a/evm/multisig.js
+++ b/evm/multisig.js
@@ -124,8 +124,7 @@ async function processCommand(_, chain, options) {
 
     const multisigContract = new Contract(multisigAddress, IMultisig.abi, wallet);
 
-    const gasOptions = getGasOptions(contractConfig, chain, options, provider);
-    printInfo('Gas options', JSON.stringify(gasOptions, null, 2));
+    const gasOptions = await getGasOptions(chain, options, contractName);
 
     printInfo('Multisig Action', action);
 

--- a/evm/operators.js
+++ b/evm/operators.js
@@ -21,6 +21,7 @@ const {
     isKeccak256Hash,
     parseArgs,
     prompt,
+    getGasOptions,
 } = require('./utils');
 const { addBaseOptions } = require('./cli-utils');
 const IAxelarGasService = require('@axelar-network/axelar-gmp-sdk-solidity/interfaces/IAxelarGasService.json');
@@ -58,7 +59,7 @@ async function processCommand(options, chain) {
 
     const operatorsContract = new Contract(operatorsAddress, IOperators.abi, wallet);
 
-    const gasOptions = contractConfig.gasOptions || chain.gasOptions || {};
+    const gasOptions = getGasOptions(contractConfig, chain, options, provider);
     console.log(`Gas override for chain ${chain.name}: ${JSON.stringify(gasOptions)}`);
 
     printInfo('Operator Action', action);

--- a/evm/operators.js
+++ b/evm/operators.js
@@ -59,8 +59,7 @@ async function processCommand(options, chain) {
 
     const operatorsContract = new Contract(operatorsAddress, IOperators.abi, wallet);
 
-    const gasOptions = getGasOptions(contractConfig, chain, options, provider);
-    console.log(`Gas override for chain ${chain.name}: ${JSON.stringify(gasOptions)}`);
+    const gasOptions = await getGasOptions(chain, options, contractName);
 
     printInfo('Operator Action', action);
 

--- a/evm/ownership.js
+++ b/evm/ownership.js
@@ -45,8 +45,7 @@ async function processCommand(options, chain) {
 
     const ownershipContract = new Contract(ownershipAddress, IOwnable.abi, wallet);
 
-    const gasOptions = getGasOptions(contractConfig, chain, options, provider);
-    printInfo(`Gas override for ${chain.name}`, JSON.stringify(gasOptions, null, 2));
+    const gasOptions = await getGasOptions(chain, options, contractName);
 
     printInfo('Ownership Action', action);
 

--- a/evm/ownership.js
+++ b/evm/ownership.js
@@ -11,7 +11,7 @@ const {
     Contract,
 } = ethers;
 const { Command, Option } = require('commander');
-const { printInfo, printWalletInfo, loadConfig, saveConfig, prompt } = require('./utils');
+const { printInfo, printWalletInfo, loadConfig, saveConfig, prompt, getGasOptions } = require('./utils');
 const { addBaseOptions } = require('./cli-utils');
 
 const IOwnable = require('@axelar-network/axelar-gmp-sdk-solidity/artifacts/contracts/interfaces/IOwnable.sol/IOwnable.json');
@@ -45,7 +45,7 @@ async function processCommand(options, chain) {
 
     const ownershipContract = new Contract(ownershipAddress, IOwnable.abi, wallet);
 
-    const gasOptions = contractConfig.gasOptions || chain.gasOptions || {};
+    const gasOptions = getGasOptions(contractConfig, chain, options, provider);
     printInfo(`Gas override for ${chain.name}`, JSON.stringify(gasOptions, null, 2));
 
     printInfo('Ownership Action', action);

--- a/evm/send-tokens.js
+++ b/evm/send-tokens.js
@@ -51,7 +51,7 @@ async function processCommand(_, chain, options) {
 
     printInfo('Chain', chain.name);
 
-    const gasOptions = getGasOptions(null, chain, options, provider);
+    const gasOptions = await getGasOptions(chain, options);
 
     if (
         prompt(

--- a/evm/send-tokens.js
+++ b/evm/send-tokens.js
@@ -9,7 +9,7 @@ const {
     getDefaultProvider,
     utils: { parseEther, parseUnits },
 } = ethers;
-const { printInfo, printError, printWalletInfo, isAddressArray, mainProcessor, isValidDecimal, prompt, copyObject } = require('./utils');
+const { printInfo, printError, printWalletInfo, isAddressArray, mainProcessor, isValidDecimal, prompt, getGasOptions } = require('./utils');
 const { addBaseOptions } = require('./cli-utils');
 const { storeSignedTx, getWallet, signTransaction } = require('./sign-utils.js');
 
@@ -51,7 +51,7 @@ async function processCommand(_, chain, options) {
 
     printInfo('Chain', chain.name);
 
-    const gasOptions = copyObject(chain.gasOptions || {});
+    const gasOptions = getGasOptions(null, chain, options, provider);
 
     if (
         prompt(


### PR DESCRIPTION
Added gas adjustment option and `getGasOptions` method as per [AXE-2572](https://axelarnetwork.atlassian.net/browse/AXE-2572)

Note: There was a discrepancy in `gasPriceAdjustment` for mainnet Fantom, Binance, and Polygon between `1.6` and `1.4` in the gateway deployment vs governance scripts. I stuck with the higher value in the chain configs.

[AXE-2572]: https://axelarnetwork.atlassian.net/browse/AXE-2572?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ