### PR TITLE
fix: get gas options

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,7 +36,15 @@ jobs:
                 "chainId": 31337,
                 "rpc": "http://127.0.0.1:8545",
                 "tokenSymbol": "TEST",
+                "gasOptions": {
+                  "gasLimit": 5000000
+                },
                 "contracts": {
+                  "AxelarGateway": {
+                    "gasOptions": {
+                      "gasLimit": 8000000
+                    }  
+                  },
                   "AxelarGasService": {
                     "collector": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
                   },

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,15 +36,7 @@ jobs:
                 "chainId": 31337,
                 "rpc": "http://127.0.0.1:8545",
                 "tokenSymbol": "TEST",
-                "gasOptions": {
-                  "gasLimit": 8000000
-                },
                 "contracts": {
-                  "AxelarGateway": {
-                    "gasOptions": {
-                      "gasLimit": 8000000
-                    }  
-                  },
                   "AxelarGasService": {
                     "collector": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
                   },

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,7 +37,7 @@ jobs:
                 "rpc": "http://127.0.0.1:8545",
                 "tokenSymbol": "TEST",
                 "gasOptions": {
-                  "gasLimit": 5000000
+                  "gasLimit": 8000000
                 },
                 "contracts": {
                   "AxelarGateway": {

--- a/evm/utils.js
+++ b/evm/utils.js
@@ -947,10 +947,10 @@ async function getGasOptions(chain, options, contractName, defaultGasOptions) {
     const contractConfig = contractName ? chain?.contracts[contractName] : null;
 
     if (offline) {
-        return copyObject(contractConfig?.staticGasOptions || chain?.staticGasOptions || (defaultGasOptions ? defaultGasOptions : {}));
+        return copyObject(contractConfig?.staticGasOptions || chain?.staticGasOptions || defaultGasOptions || {});
     }
 
-    const gasOptions = copyObject(contractConfig?.gasOptions || chain?.gasOptions || (defaultGasOptions ? defaultGasOptions : {}));
+    const gasOptions = copyObject(contractConfig?.gasOptions || chain?.gasOptions || defaultGasOptions || {});
     const gasPriceAdjustment = gasOptions.gasPriceAdjustment;
 
     if (gasPriceAdjustment && !gasOptions.gasPrice) {

--- a/evm/utils.js
+++ b/evm/utils.js
@@ -947,10 +947,10 @@ async function getGasOptions(chain, options, contractName, defaultGasOptions) {
     const contractConfig = contractName ? chain?.contracts[contractName] : null;
 
     if (offline) {
-        return copyObject(contractConfig?.staticGasOptions || chain?.staticGasOptions || defaultGasOptions ? defaultGasOptions : {});
+        return copyObject(contractConfig?.staticGasOptions || chain?.staticGasOptions || (defaultGasOptions ? defaultGasOptions : {}));
     }
 
-    const gasOptions = copyObject(contractConfig?.gasOptions || chain?.gasOptions || defaultGasOptions ? defaultGasOptions : {});
+    const gasOptions = copyObject(contractConfig?.gasOptions || chain?.gasOptions || (defaultGasOptions ? defaultGasOptions : {}));
     const gasPriceAdjustment = gasOptions.gasPriceAdjustment;
 
     if (gasPriceAdjustment && !gasOptions.gasPrice) {

--- a/evm/utils.js
+++ b/evm/utils.js
@@ -941,16 +941,16 @@ function getContractJSON(contractName, artifactPath) {
  * - If 'gasPriceAdjustment' is set in gas options and 'gasPrice' is not pre-defined, the gas price
  *   is fetched from the provider and adjusted according to 'gasPriceAdjustment'.
  */
-async function getGasOptions(chain, options, contractName, defaultGasOptions) {
+async function getGasOptions(chain, options, contractName, defaultGasOptions = {}) {
     const { offline } = options;
 
     const contractConfig = contractName ? chain?.contracts[contractName] : null;
 
     if (offline) {
-        return copyObject(contractConfig?.staticGasOptions || chain?.staticGasOptions || defaultGasOptions || {});
+        return copyObject(contractConfig?.staticGasOptions || chain?.staticGasOptions || defaultGasOptions);
     }
 
-    const gasOptions = copyObject(contractConfig?.gasOptions || chain?.gasOptions || defaultGasOptions || {});
+    const gasOptions = copyObject(contractConfig?.gasOptions || chain?.gasOptions || defaultGasOptions);
     const gasPriceAdjustment = gasOptions.gasPriceAdjustment;
 
     if (gasPriceAdjustment && !gasOptions.gasPrice) {


### PR DESCRIPTION
Small fix for `getGasOptions`, the recent addition of the `defaultGasOptions` optional parameter and lack of correct parentheses surrounding two ternary expressions was causing `gasOptions` to be returned as `undefined` as opposed to `{}` which was causing the `copyObject` method to throw an error. I added `gasOptions` in both the chain config and contract config for the GitHub action test to detect similar errors earlier.