### PR TITLE
chore: read env variables

### DIFF
--- a/evm/sign-message.js
+++ b/evm/sign-message.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { ethers } = require('hardhat');
+require('dotenv').config();
 const {
     utils: { isHexString, arrayify },
 } = ethers;

--- a/evm/sign-message.js
+++ b/evm/sign-message.js
@@ -1,13 +1,13 @@
 'use strict';
 
 const { ethers } = require('hardhat');
-require('dotenv').config();
 const {
     utils: { isHexString, arrayify },
 } = ethers;
 const { Command, Option } = require('commander');
 const { getWallet } = require('./sign-utils');
 const { printInfo, validateParameters } = require('./utils');
+const { addBaseOptions } = require('./cli-utils');
 
 async function processCommand(options) {
     const { message, privateKey } = options;
@@ -39,8 +39,8 @@ if (require.main === module) {
 
     program.name('sign-message').description('sign a message from the user wallet');
 
+    addBaseOptions(program, { ignoreChainNames: true });
     program.addOption(new Option('-m, --message <message>', 'the message to be signed').makeOptionMandatory(true).env('MESSAGE'));
-    program.addOption(new Option('-p, --privateKey <privateKey>', 'private key').makeOptionMandatory(true).env('PRIVATE_KEY'));
 
     program.action((options) => {
         main(options);


### PR DESCRIPTION
Add `require('dotenv').config();` to be able to use env in script.