### PR TITLE
fix(stellar): u128 signature weight

### DIFF
--- a/stellar/deploy-contract.js
+++ b/stellar/deploy-contract.js
@@ -29,10 +29,10 @@ function getInitializeArgs(chain, contractName, wallet, options) {
                 signers: [
                     {
                         signer: Address.fromString(wallet.publicKey()).toBuffer(),
-                        weight: new ScInt(1, { type: 'u256' }),
+                        weight: new ScInt(1, { type: 'u128' }),
                     },
                 ],
-                threshold: new ScInt(1, { type: 'u256' }),
+                threshold: new ScInt(1, { type: 'u128' }),
                 nonce: Buffer.alloc(32),
             });
 


### PR DESCRIPTION
[AXE-4342]
* [x] Stellar: deploy script using u128 for signature weight and threshold

[AXE-4342]: https://axelarnetwork.atlassian.net/browse/AXE-4342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ