### PR TITLE
chore: iterate through all owner objects to find target 

### DIFF
--- a/sui/utils.js
+++ b/sui/utils.js
@@ -146,14 +146,23 @@ const getSigners = async (keypair, config, chain, options) => {
 };
 
 const findOwnedObjectId = async (client, ownerAddress, objectType) => {
-    const ownedObjects = await client.getOwnedObjects({
-        owner: ownerAddress,
-        options: {
-            showContent: true,
-        },
-    });
+    var hasNextPage = true;
+    var nextCursor = null;
+    var targetObject = null;
 
-    const targetObject = ownedObjects.data.find(({ data }) => data.content.type === objectType);
+    while (hasNextPage && targetObject == null) {
+        var ownedObjects = await client.getOwnedObjects({
+            owner: ownerAddress,
+            options: {
+                showContent: true,
+            },
+            cursor: nextCursor,
+        });
+
+        targetObject = ownedObjects.data.find(({ data }) => data.content.type === objectType);
+        hasNextPage = ownedObjects.hasNextPage;
+        nextCursor = ownedObjects.nextCursor;
+    }
 
     if (!targetObject) {
         throw new Error(`No object found for type: ${objectType}`);


### PR DESCRIPTION
`getOwnedObjects` returns a limited number of objects per page (50 by default), and our target might not be found in the first one. That's why we should iterate through all pages of the result until no next page is found, or we track our target object.