### PR TITLE
chore: partially deploy deposit service in stagenet

### DIFF
--- a/axelar-chains-config/info/stagenet.json
+++ b/axelar-chains-config/info/stagenet.json
@@ -29,7 +29,12 @@
           "deployer": "0xBeF25f4733b9d451072416360609e5A4c115293E"
         },
         "AxelarDepositService": {
-          "wrappedSymbol": "WAVAX"
+          "wrappedSymbol": "WAVAX",
+          "refundIssuer": "0x2517bA7a3E2cef54c1CD8618e7B0B661A7623817",
+          "salt": "AxelarDepositService",
+          "address": "0x405407133E2783aEb56F2cA9d8e6025465De0B9f",
+          "implementation": "0x523ee715a997bd471BfbE1B66acCF0d47D1fD812",
+          "deployer": "0xBeF25f4733b9d451072416360609e5A4c115293E"
         },
         "ConstAddressDeployer": {
           "address": "0x98B2920D53612483F91F12Ed7754E51b4A77919e"
@@ -132,7 +137,12 @@
           "deployer": "0xBeF25f4733b9d451072416360609e5A4c115293E"
         },
         "AxelarDepositService": {
-          "wrappedSymbol": "WFTM"
+          "wrappedSymbol": "WFTM",
+          "refundIssuer": "0x2517bA7a3E2cef54c1CD8618e7B0B661A7623817",
+          "salt": "AxelarDepositService",
+          "address": "0x405407133E2783aEb56F2cA9d8e6025465De0B9f",
+          "implementation": "0x523ee715a997bd471BfbE1B66acCF0d47D1fD812",
+          "deployer": "0xBeF25f4733b9d451072416360609e5A4c115293E"
         },
         "ConstAddressDeployer": {
           "address": "0x98B2920D53612483F91F12Ed7754E51b4A77919e"
@@ -235,7 +245,12 @@
           "deployer": "0xBeF25f4733b9d451072416360609e5A4c115293E"
         },
         "AxelarDepositService": {
-          "wrappedSymbol": "WDEV"
+          "wrappedSymbol": "WDEV",
+          "refundIssuer": "0x2517bA7a3E2cef54c1CD8618e7B0B661A7623817",
+          "salt": "AxelarDepositService",
+          "address": "0x405407133E2783aEb56F2cA9d8e6025465De0B9f",
+          "implementation": "0x20fee12E3d138b783aa9238467BDFDDECA407EF9",
+          "deployer": "0xBeF25f4733b9d451072416360609e5A4c115293E"
         },
         "ConstAddressDeployer": {
           "address": "0x98B2920D53612483F91F12Ed7754E51b4A77919e"


### PR DESCRIPTION
Notes:

* This is needed to test deposit service in stagenet - doesn't look like this has been deployed since the refresh
* Needed this asap so deployed myself - hopefully I didn't do it wrong
* I checked which wrapped assets are registered for the active EVM chains first - `wavax-wei`, `wdev-wei`, and `wftm-wei` are registered and confirmed everywhere, no other wrapped tokens are, hence only having those three deployed in this PR
* For lack of any better ideas, I took `refundIssuer` from old stagenet [here](https://github.com/axelarnetwork/axelar-contract-deployments/blob/fedbfeed03ac4618b1de769191612cc91abef0a1/axelar-chains-config/info/stagenet.json#L34)

Deployed using the stagenet deployer wallet like so:

```
node evm/deploy-upgradable.js -e stagenet -n avalanche -c AxelarDepositService
node evm/deploy-upgradable.js -e stagenet -n fantom -c AxelarDepositService
node evm/deploy-upgradable.js -e stagenet -n moonbeam -c AxelarDepositService
```