### PR TITLE
chore: move addExtendedOptions to evm/cli-utils

### DIFF
--- a/common/cli-utils.js
+++ b/common/cli-utils.js
@@ -3,7 +3,7 @@
 require('dotenv').config();
 
 const fs = require('fs');
-const { Option, Command } = require('commander');
+const { Option } = require('commander');
 
 // A path to the chain configuration files
 const CHAIN_CONFIG_PATH = `${__dirname}/../axelar-chains-config/info`;
@@ -44,53 +44,8 @@ const addBaseOptions = (program, options = {}) => {
     return program;
 };
 
-const addExtendedOptions = (program, options = {}) => {
-    addBaseOptions(program, options);
-
-    program.addOption(new Option('-v, --verify', 'verify the deployed contract on the explorer').env('VERIFY'));
-
-    if (options.artifactPath) {
-        program.addOption(new Option('--artifactPath <artifactPath>', 'artifact path'));
-    }
-
-    if (options.contractName) {
-        program.addOption(new Option('-c, --contractName <contractName>', 'contract name').makeOptionMandatory(true));
-    }
-
-    if (options.deployMethod) {
-        program.addOption(
-            new Option('-m, --deployMethod <deployMethod>', 'deployment method')
-                .choices(['create', 'create2', 'create3'])
-                .default(options.deployMethod),
-        );
-    }
-
-    if (options.salt) {
-        program.addOption(new Option('-s, --salt <salt>', 'salt to use for create2 deployment').env('SALT'));
-    }
-
-    if (options.skipExisting) {
-        program.addOption(new Option('-x, --skipExisting', 'skip existing if contract was already deployed on chain').env('SKIP_EXISTING'));
-    }
-
-    if (options.upgrade) {
-        program.addOption(new Option('-u, --upgrade', 'upgrade a deployed contract').env('UPGRADE'));
-    }
-
-    if (options.predictOnly) {
-        program.addOption(new Option('--predictOnly', 'output the predicted changes only').env('PREDICT_ONLY'));
-    }
-
-    return program;
-};
-
-if (require.main === module) {
-    addBaseOptions(new Command());
-}
-
 module.exports = {
     CHAIN_CONFIG_PATH,
     CHAIN_ENVIRONMENTS,
     addBaseOptions,
-    addExtendedOptions,
 };

--- a/evm/cli-utils.js
+++ b/evm/cli-utils.js
@@ -1,7 +1,7 @@
 const { Option } = require('commander');
 const { addBaseOptions, ...exportedCliUtils } = require('../common/cli-utils');
 
-const addExtendedOptions = (program, options = {}) => {
+const addEvmOptions = (program, options = {}) => {
     addBaseOptions(program, options);
 
     program.addOption(new Option('-v, --verify', 'verify the deployed contract on the explorer').env('VERIFY'));
@@ -44,5 +44,5 @@ const addExtendedOptions = (program, options = {}) => {
 module.exports = {
     ...exportedCliUtils,
     addBaseOptions,
-    addExtendedOptions,
+    addEvmOptions,
 };

--- a/evm/cli-utils.js
+++ b/evm/cli-utils.js
@@ -1,3 +1,5 @@
+const { addBaseOptions, ...exportedCliUtils } = require('../common/cli-utils');
+
 const addExtendedOptions = (program, options = {}) => {
     addBaseOptions(program, options);
 
@@ -39,6 +41,7 @@ const addExtendedOptions = (program, options = {}) => {
 };
 
 module.exports = {
-    ...require('../common/cli-utils'),
+    ...exportedCliUtils,
+    addBaseOptions,
     addExtendedOptions,
 };

--- a/evm/cli-utils.js
+++ b/evm/cli-utils.js
@@ -1,3 +1,4 @@
+const { Option } = require('commander');
 const { addBaseOptions, ...exportedCliUtils } = require('../common/cli-utils');
 
 const addExtendedOptions = (program, options = {}) => {

--- a/evm/cli-utils.js
+++ b/evm/cli-utils.js
@@ -1,3 +1,44 @@
+const addExtendedOptions = (program, options = {}) => {
+    addBaseOptions(program, options);
+
+    program.addOption(new Option('-v, --verify', 'verify the deployed contract on the explorer').env('VERIFY'));
+
+    if (options.artifactPath) {
+        program.addOption(new Option('--artifactPath <artifactPath>', 'artifact path'));
+    }
+
+    if (options.contractName) {
+        program.addOption(new Option('-c, --contractName <contractName>', 'contract name').makeOptionMandatory(true));
+    }
+
+    if (options.deployMethod) {
+        program.addOption(
+            new Option('-m, --deployMethod <deployMethod>', 'deployment method')
+                .choices(['create', 'create2', 'create3'])
+                .default(options.deployMethod),
+        );
+    }
+
+    if (options.salt) {
+        program.addOption(new Option('-s, --salt <salt>', 'salt to use for create2 deployment').env('SALT'));
+    }
+
+    if (options.skipExisting) {
+        program.addOption(new Option('-x, --skipExisting', 'skip existing if contract was already deployed on chain').env('SKIP_EXISTING'));
+    }
+
+    if (options.upgrade) {
+        program.addOption(new Option('-u, --upgrade', 'upgrade a deployed contract').env('UPGRADE'));
+    }
+
+    if (options.predictOnly) {
+        program.addOption(new Option('--predictOnly', 'output the predicted changes only').env('PREDICT_ONLY'));
+    }
+
+    return program;
+};
+
 module.exports = {
     ...require('../common/cli-utils'),
+    addExtendedOptions,
 };

--- a/evm/deploy-amplifier-gateway.js
+++ b/evm/deploy-amplifier-gateway.js
@@ -28,7 +28,7 @@ const {
     getDeployOptions,
     getDomainSeparator,
 } = require('./utils');
-const { addExtendedOptions } = require('./cli-utils');
+const { addEvmOptions } = require('./cli-utils');
 const { storeSignedTx, signTransaction, getWallet } = require('./sign-utils.js');
 
 const { WEIGHTED_SIGNERS_TYPE, encodeWeightedSigners } = require('@axelar-network/axelar-gmp-sdk-solidity/scripts/utils');
@@ -399,7 +399,7 @@ async function programHandler() {
     program.name('deploy-amplifier-gateway').description('Deploy Amplifier Gateway');
 
     // use create3 as default deploy method
-    addExtendedOptions(program, { salt: true, deployMethod: 'create3', skipExisting: true, upgrade: true, predictOnly: true });
+    addEvmOptions(program, { salt: true, deployMethod: 'create3', skipExisting: true, upgrade: true, predictOnly: true });
 
     program.addOption(new Option('-r, --rpc <rpc>', 'chain rpc url').env('URL'));
     program.addOption(new Option('--previousSignersRetention <previousSignersRetention>', 'previous signer retention').default(15));

--- a/evm/deploy-contract.js
+++ b/evm/deploy-contract.js
@@ -27,7 +27,7 @@ const {
     getContractJSON,
     getDeployOptions,
 } = require('./utils');
-const { addExtendedOptions } = require('./cli-utils');
+const { addEvmOptions } = require('./cli-utils');
 
 async function getConstructorArgs(contractName, config, wallet, options) {
     const args = options.args ? JSON.parse(options.args) : {};
@@ -335,7 +335,7 @@ if (require.main === module) {
 
     program.name('deploy-contract').description('Deploy contracts using create, create2, or create3');
 
-    addExtendedOptions(program, {
+    addEvmOptions(program, {
         artifactPath: true,
         contractName: true,
         salt: true,

--- a/evm/deploy-gateway-v6.2.x.js
+++ b/evm/deploy-gateway-v6.2.x.js
@@ -29,7 +29,7 @@ const {
     getGasOptions,
     getDeployOptions,
 } = require('./utils');
-const { addExtendedOptions } = require('./cli-utils');
+const { addEvmOptions } = require('./cli-utils');
 const { storeSignedTx, signTransaction, getWallet } = require('./sign-utils.js');
 
 const AxelarGatewayProxy = require('@axelar-network/axelar-cgp-solidity/artifacts/contracts/AxelarGatewayProxy.sol/AxelarGatewayProxy.json');
@@ -523,7 +523,7 @@ async function programHandler() {
 
     program.name('deploy-gateway-v6.2.x').description('Deploy gateway v6.2.x');
 
-    addExtendedOptions(program, { salt: true, deployMethod: 'create', skipExisting: true, upgrade: true, predictOnly: true });
+    addEvmOptions(program, { salt: true, deployMethod: 'create', skipExisting: true, upgrade: true, predictOnly: true });
 
     program.addOption(new Option('-r, --rpc <rpc>', 'chain rpc url').env('URL'));
     program.addOption(new Option('--reuseProxy', 'reuse proxy contract modules for new implementation deployment'));

--- a/evm/deploy-its.js
+++ b/evm/deploy-its.js
@@ -25,7 +25,7 @@ const {
     getDeployedAddress,
     wasEventEmitted,
 } = require('./utils');
-const { addExtendedOptions } = require('./cli-utils');
+const { addEvmOptions } = require('./cli-utils');
 const { Command, Option } = require('commander');
 
 /**
@@ -478,7 +478,7 @@ if (require.main === module) {
             .default('create3'),
     );
 
-    addExtendedOptions(program, { artifactPath: true, skipExisting: true, upgrade: true, predictOnly: true });
+    addEvmOptions(program, { artifactPath: true, skipExisting: true, upgrade: true, predictOnly: true });
 
     program.addOption(new Option('--reuseProxy', 'reuse existing proxy (useful for upgrade deployments'));
     program.addOption(new Option('--contractName <contractName>', 'contract name').default('InterchainTokenService')); // added for consistency

--- a/evm/deploy-upgradable.js
+++ b/evm/deploy-upgradable.js
@@ -22,7 +22,7 @@ const {
     getDeployOptions,
     mainProcessor,
 } = require('./utils');
-const { addExtendedOptions } = require('./cli-utils');
+const { addEvmOptions } = require('./cli-utils');
 
 function getProxy(wallet, proxyAddress) {
     return new Contract(proxyAddress, IUpgradable.abi, wallet);
@@ -297,7 +297,7 @@ if (require.main === module) {
 
     program.name('deploy-upgradable').description('Deploy upgradable contracts');
 
-    addExtendedOptions(program, { artifactPath: true, contractName: true, salt: true, skipChains: true, upgrade: true, predictOnly: true });
+    addEvmOptions(program, { artifactPath: true, contractName: true, salt: true, skipChains: true, upgrade: true, predictOnly: true });
 
     program.addOption(
         new Option('-m, --deployMethod <deployMethod>', 'deployment method').choices(['create', 'create2', 'create3']).default('create2'),

--- a/evm/interchainTokenFactory.js
+++ b/evm/interchainTokenFactory.js
@@ -8,7 +8,7 @@ const {
 } = ethers;
 const { Command, Option } = require('commander');
 const { printInfo, prompt, mainProcessor, validateParameters, getContractJSON, getGasOptions, printWalletInfo } = require('./utils');
-const { addExtendedOptions } = require('./cli-utils');
+const { addEvmOptions } = require('./cli-utils');
 const { getDeploymentSalt, handleTx, isValidDestinationChain } = require('./its');
 const { getWallet } = require('./sign-utils');
 const IInterchainTokenFactory = getContractJSON('IInterchainTokenFactory');
@@ -222,7 +222,7 @@ if (require.main === module) {
 
     program.name('InterchainTokenFactory').description('Script to perform interchain token factory commands');
 
-    addExtendedOptions(program, { address: true, salt: true });
+    addEvmOptions(program, { address: true, salt: true });
 
     program.addOption(
         new Option('--action <action>', 'interchain token factory action')

--- a/evm/its.js
+++ b/evm/its.js
@@ -30,7 +30,7 @@ const InterchainTokenService = getContractJSON('InterchainTokenService');
 const InterchainTokenFactory = getContractJSON('InterchainTokenFactory');
 const IInterchainTokenDeployer = getContractJSON('IInterchainTokenDeployer');
 const IOwnable = getContractJSON('IOwnable');
-const { addExtendedOptions } = require('./cli-utils');
+const { addEvmOptions } = require('./cli-utils');
 const { getSaltFromKey } = require('@axelar-network/axelar-gmp-sdk-solidity/scripts/utils');
 const tokenManagerImplementations = {
     INTERCHAIN_TOKEN: 0,
@@ -656,7 +656,7 @@ if (require.main === module) {
 
     program.name('ITS').description('Script to perform ITS commands');
 
-    addExtendedOptions(program, { address: true, salt: true });
+    addEvmOptions(program, { address: true, salt: true });
 
     program.addOption(new Option('-c, --contractName <contractName>', 'contract name').default('InterchainTokenService'));
     program.addOption(


### PR DESCRIPTION
# Description

This PR moves `addExtendedOptions` function to `evm/cli-utils.js` since it's more closelyrelated to the evm scripts.