### PR TITLE
feat(amplifier)!: remove support for looping through multiple chains

### DIFF
--- a/common/utils.js
+++ b/common/utils.js
@@ -410,7 +410,7 @@ async function getDomainSeparator(config, chain, options) {
 }
 
 const getChainConfig = (config, chainName) => {
-    if (chainName === 'none') {
+    if (!chainName) {
         return undefined;
     }
 

--- a/cosmwasm/cli-utils.js
+++ b/cosmwasm/cli-utils.js
@@ -68,7 +68,7 @@ const addAmplifierOptions = (program, options) => {
 
 const addContractOptions = (program) => {
     program.addOption(new Option('-c, --contractName <contractName>', 'contract name').makeOptionMandatory(true));
-    program.addOption(new Option('-n, --chainNames <chainNames>', 'chain names').default('none').env('CHAINS'));
+    program.addOption(new Option('-n, --chainName <chainName>', 'chain name').default('none').env('CHAIN'));
 };
 
 const addStoreOptions = (program) => {

--- a/cosmwasm/cli-utils.js
+++ b/cosmwasm/cli-utils.js
@@ -68,7 +68,7 @@ const addAmplifierOptions = (program, options) => {
 
 const addContractOptions = (program) => {
     program.addOption(new Option('-c, --contractName <contractName>', 'contract name').makeOptionMandatory(true));
-    program.addOption(new Option('-n, --chainName <chainName>', 'chain name').default('none').env('CHAIN'));
+    program.addOption(new Option('-n, --chainName <chainName>', 'chain name').env('CHAIN'));
 };
 
 const addStoreOptions = (program) => {

--- a/cosmwasm/deploy-contract.js
+++ b/cosmwasm/deploy-contract.js
@@ -76,7 +76,7 @@ const main = async (options) => {
     const wallet = await prepareWallet(options);
     const client = await prepareClient(config, wallet);
 
-    await upload(client, wallet, chains[0], config, options);
+    await upload(client, wallet, config, options);
 
     if (!(uploadOnly || prompt(`Proceed with deployment on axelar?`, yes))) {
         await instantiate(client, wallet, config, options);

--- a/cosmwasm/deploy-contract.js
+++ b/cosmwasm/deploy-contract.js
@@ -11,7 +11,7 @@ const {
     prepareClient,
     fromHex,
     getSalt,
-    getChains,
+    getAmplifierContractConfig,
     updateContractConfig,
     fetchCodeIdFromCodeHash,
     uploadContract,
@@ -22,14 +22,11 @@ const {
 const { Command, Option } = require('commander');
 const { addAmplifierOptions } = require('./cli-utils');
 
-const upload = async (client, wallet, chainName, config, options) => {
-    const { reuseCodeId, contractName, fetchCodeId, instantiate2, salt, chainNames } = options;
-    const {
-        axelar: {
-            contracts: { [contractName]: contractConfig },
-        },
-    } = config;
-    const chainConfig = chainName === 'none' ? undefined : getChainConfig(config, chainName);
+const upload = async (client, wallet, config, options) => {
+    const { reuseCodeId, contractName, fetchCodeId, instantiate2, salt, chainName } = options;
+
+    const contractConfig = getAmplifierContractConfig(config, contractName);
+    const chainConfig = getChainConfig(config, chainName);
 
     if (!fetchCodeId && (!reuseCodeId || isNil(contractConfig.codeId))) {
         printInfo('Uploading contract binary');
@@ -41,7 +38,7 @@ const upload = async (client, wallet, chainName, config, options) => {
 
         if (instantiate2) {
             const [account] = await wallet.getAccounts();
-            const address = instantiate2Address(fromHex(checksum), account.address, getSalt(salt, contractName, chainNames), 'axelar');
+            const address = instantiate2Address(fromHex(checksum), account.address, getSalt(salt, contractName, chainName), 'axelar');
 
             updateContractConfig(contractConfig, chainConfig, 'address', address);
 
@@ -52,14 +49,11 @@ const upload = async (client, wallet, chainName, config, options) => {
     }
 };
 
-const instantiate = async (client, wallet, chainName, config, options) => {
-    const { contractName, fetchCodeId } = options;
-    const {
-        axelar: {
-            contracts: { [contractName]: contractConfig },
-        },
-        chains: { [chainName]: chainConfig },
-    } = config;
+const instantiate = async (client, wallet, config, options) => {
+    const { contractName, fetchCodeId, chainName } = options;
+
+    const contractConfig = getAmplifierContractConfig(config, contractName);
+    const chainConfig = getChainConfig(config, chainName);
 
     if (fetchCodeId) {
         contractConfig.codeId = await fetchCodeIdFromCodeHash(client, contractConfig);
@@ -79,17 +73,13 @@ const main = async (options) => {
     const { env, uploadOnly, yes } = options;
     const config = loadConfig(env);
 
-    const chains = getChains(config, options);
-
     const wallet = await prepareWallet(options);
     const client = await prepareClient(config, wallet);
 
     await upload(client, wallet, chains[0], config, options);
 
     if (!(uploadOnly || prompt(`Proceed with deployment on axelar?`, yes))) {
-        for (const chain of chains) {
-            await instantiate(client, wallet, chain.toLowerCase(), config, options);
-        }
+        await instantiate(client, wallet, config, options);
     }
 
     saveConfig(config, env);

--- a/cosmwasm/deploy-contract.js
+++ b/cosmwasm/deploy-contract.js
@@ -66,7 +66,7 @@ const instantiate = async (client, wallet, config, options) => {
 
     updateContractConfig(contractConfig, chainConfig, 'address', contractAddress);
 
-    printInfo(`Instantiated ${chainName === 'none' ? '' : chainName.concat(' ')}${contractName}. Address`, contractAddress);
+    printInfo(`Instantiated ${chainName ? chainName.concat(' ') : ''}${contractName}. Address`, contractAddress);
 };
 
 const main = async (options) => {

--- a/cosmwasm/submit-proposal.js
+++ b/cosmwasm/submit-proposal.js
@@ -12,7 +12,6 @@ const {
     fromHex,
     getSalt,
     readWasmFile,
-    getChains,
     getAmplifierContractConfig,
     updateContractConfig,
     fetchCodeIdFromCodeHash,
@@ -41,18 +40,15 @@ const { ParameterChangeProposal } = require('cosmjs-types/cosmos/params/v1beta1/
 const { Command } = require('commander');
 const { addAmplifierOptions } = require('./cli-utils');
 
-const predictAndUpdateAddress = async (client, contractConfig, chainConfig, chainName, options) => {
-    const { contractName, salt, chainNames, runAs } = options;
+const predictAndUpdateAddress = async (client, contractConfig, chainConfig, options) => {
+    const { contractName, salt, chainName, runAs } = options;
 
     const { checksum } = await client.getCodeDetails(contractConfig.codeId);
-    const contractAddress = instantiate2Address(fromHex(checksum), runAs, getSalt(salt, contractName, chainNames), 'axelar');
+    const contractAddress = instantiate2Address(fromHex(checksum), runAs, getSalt(salt, contractName, chainName), 'axelar');
 
     updateContractConfig(contractConfig, chainConfig, 'address', contractAddress);
 
-    printInfo(
-        `Predicted address for ${chainName.toLowerCase() === 'none' ? '' : chainName.toLowerCase().concat(' ')}${contractName}. Address`,
-        contractAddress,
-    );
+    printInfo(`Predicted address for ${chainName === 'none' ? '' : chainName.concat(' ')}${contractName}. Address`, contractAddress);
 };
 
 const printProposal = (proposal, proposalType) => {
@@ -96,100 +92,82 @@ const storeCode = async (client, wallet, config, options) => {
 };
 
 const storeInstantiate = async (client, wallet, config, options) => {
-    const chains = getChains(config, options);
+    const { contractName, instantiate2, chainName } = options;
+    const contractConfig = getAmplifierContractConfig(config, contractName);
+    const chainConfig = getChainConfig(config, chainName);
 
-    for (const chain of chains) {
-        const chainName = chain.toLowerCase();
-
-        const { contractName, instantiate2 } = options;
-        const contractConfig = getAmplifierContractConfig(config, contractName);
-        const chainConfig = getChainConfig(config, chainName);
-
-        if (instantiate2) {
-            throw new Error('instantiate2 not supported for storeInstantiate');
-        }
-
-        const initMsg = makeInstantiateMsg(contractName, chainName, config);
-        const proposal = encodeStoreInstantiateProposal(config, options, initMsg);
-
-        if (!confirmProposalSubmission(options, proposal, StoreAndInstantiateContractProposal)) {
-            return;
-        }
-
-        const proposalId = await callSubmitProposal(client, wallet, config, options, proposal);
-
-        updateContractConfig(contractConfig, chainConfig, 'storeInstantiateProposalId', proposalId);
-        contractConfig.storeCodeProposalCodeHash = createHash('sha256').update(readWasmFile(options)).digest().toString('hex');
+    if (instantiate2) {
+        throw new Error('instantiate2 not supported for storeInstantiate');
     }
+
+    const initMsg = makeInstantiateMsg(contractName, chainName, config);
+    const proposal = encodeStoreInstantiateProposal(config, options, initMsg);
+
+    if (!confirmProposalSubmission(options, proposal, StoreAndInstantiateContractProposal)) {
+        return;
+    }
+
+    const proposalId = await callSubmitProposal(client, wallet, config, options, proposal);
+
+    updateContractConfig(contractConfig, chainConfig, 'storeInstantiateProposalId', proposalId);
+    contractConfig.storeCodeProposalCodeHash = createHash('sha256').update(readWasmFile(options)).digest().toString('hex');
 };
 
 const instantiate = async (client, wallet, config, options) => {
-    const chains = getChains(config, options);
+    const { contractName, instantiate2, predictOnly, fetchCodeId, chainName } = options;
+    const contractConfig = getAmplifierContractConfig(config, contractName);
+    const chainConfig = getChainConfig(config, chainName);
 
-    for (const chain of chains) {
-        const chainName = chain.toLowerCase();
+    if (fetchCodeId) {
+        contractConfig.codeId = await fetchCodeIdFromCodeHash(client, contractConfig);
+    } else if (!isNumber(contractConfig.codeId)) {
+        throw new Error('Code Id is not defined');
+    }
 
-        const { contractName, instantiate2, predictOnly, fetchCodeId } = options;
-        const contractConfig = getAmplifierContractConfig(config, contractName);
-        const chainConfig = getChainConfig(config, chainName);
+    if (predictOnly) {
+        return predictAndUpdateAddress(client, contractConfig, chainConfig, options);
+    }
 
-        if (fetchCodeId) {
-            contractConfig.codeId = await fetchCodeIdFromCodeHash(client, contractConfig);
-        } else if (!isNumber(contractConfig.codeId)) {
-            throw new Error('Code Id is not defined');
-        }
+    const initMsg = makeInstantiateMsg(contractName, chainName, config);
 
-        if (predictOnly) {
-            return predictAndUpdateAddress(client, contractConfig, chainConfig, chainName, options);
-        }
+    let proposal;
+    let proposalType;
 
-        const initMsg = makeInstantiateMsg(contractName, chainName, config);
+    if (instantiate2) {
+        proposal = encodeInstantiate2Proposal(config, options, initMsg);
+        proposalType = InstantiateContract2Proposal;
+    } else {
+        proposal = encodeInstantiateProposal(config, options, initMsg);
+        proposalType = InstantiateContractProposal;
+    }
 
-        let proposal;
-        let proposalType;
+    if (!confirmProposalSubmission(options, proposal, proposalType)) {
+        return;
+    }
 
-        if (instantiate2) {
-            proposal = encodeInstantiate2Proposal(config, options, initMsg);
-            proposalType = InstantiateContract2Proposal;
-        } else {
-            proposal = encodeInstantiateProposal(config, options, initMsg);
-            proposalType = InstantiateContractProposal;
-        }
+    const proposalId = await callSubmitProposal(client, wallet, config, options, proposal);
 
-        if (!confirmProposalSubmission(options, proposal, proposalType)) {
-            return;
-        }
+    updateContractConfig(contractConfig, chainConfig, 'instantiateProposalId', proposalId);
 
-        const proposalId = await callSubmitProposal(client, wallet, config, options, proposal);
-
-        updateContractConfig(contractConfig, chainConfig, 'instantiateProposalId', proposalId);
-
-        if (instantiate2) {
-            return predictAndUpdateAddress(client, contractConfig, chainConfig, chainName, options);
-        }
+    if (instantiate2) {
+        return predictAndUpdateAddress(client, contractConfig, chainConfig, options);
     }
 };
 
 const execute = async (client, wallet, config, options) => {
-    const chains = getChains(config, options);
+    const { contractName, chainName } = options;
+    const contractConfig = getAmplifierContractConfig(config, contractName);
+    const chainConfig = getChainConfig(config, chainName);
 
-    for (const chain of chains) {
-        const chainName = chain.toLowerCase();
+    const proposal = encodeExecuteContractProposal(config, options, chainName);
 
-        const { contractName } = options;
-        const contractConfig = getAmplifierContractConfig(config, contractName);
-        const chainConfig = getChainConfig(config, chainName);
-
-        const proposal = encodeExecuteContractProposal(config, options, chainName);
-
-        if (!confirmProposalSubmission(options, proposal, ExecuteContractProposal)) {
-            return;
-        }
-
-        const proposalId = await callSubmitProposal(client, wallet, config, options, proposal);
-
-        updateContractConfig(contractConfig, chainConfig, 'executeProposalId', proposalId);
+    if (!confirmProposalSubmission(options, proposal, ExecuteContractProposal)) {
+        return;
     }
+
+    const proposalId = await callSubmitProposal(client, wallet, config, options, proposal);
+
+    updateContractConfig(contractConfig, chainConfig, 'executeProposalId', proposalId);
 };
 
 const paramChange = async (client, wallet, config, options) => {
@@ -203,28 +181,22 @@ const paramChange = async (client, wallet, config, options) => {
 };
 
 const migrate = async (client, wallet, config, options) => {
-    const chains = getChains(config, options);
+    const { contractName, fetchCodeId, chainName } = options;
+    const contractConfig = getAmplifierContractConfig(config, contractName);
 
-    for (const chain of chains) {
-        const chainName = chain.toLowerCase();
-
-        const { contractName, fetchCodeId } = options;
-        const contractConfig = getAmplifierContractConfig(config, contractName);
-
-        if (fetchCodeId) {
-            contractConfig.codeId = await fetchCodeIdFromCodeHash(client, contractConfig);
-        } else if (!isNumber(contractConfig.codeId)) {
-            throw new Error('Code Id is not defined');
-        }
-
-        const proposal = encodeMigrateContractProposal(config, options, chainName);
-
-        if (!confirmProposalSubmission(options, proposal, MigrateContractProposal)) {
-            return;
-        }
-
-        await callSubmitProposal(client, wallet, config, options, proposal);
+    if (fetchCodeId) {
+        contractConfig.codeId = await fetchCodeIdFromCodeHash(client, contractConfig);
+    } else if (!isNumber(contractConfig.codeId)) {
+        throw new Error('Code Id is not defined');
     }
+
+    const proposal = encodeMigrateContractProposal(config, options, chainName);
+
+    if (!confirmProposalSubmission(options, proposal, MigrateContractProposal)) {
+        return;
+    }
+
+    await callSubmitProposal(client, wallet, config, options, proposal);
 };
 
 const mainProcessor = async (processor, options) => {

--- a/cosmwasm/submit-proposal.js
+++ b/cosmwasm/submit-proposal.js
@@ -48,7 +48,7 @@ const predictAndUpdateAddress = async (client, contractConfig, chainConfig, opti
 
     updateContractConfig(contractConfig, chainConfig, 'address', contractAddress);
 
-    printInfo(`Predicted address for ${chainName === 'none' ? '' : chainName.concat(' ')}${contractName}. Address`, contractAddress);
+    printInfo(`Predicted address for ${chainName ? chainName.concat(' ') : ''}${contractName}. Address`, contractAddress);
 };
 
 const printProposal = (proposal, proposalType) => {

--- a/cosmwasm/utils.js
+++ b/cosmwasm/utils.js
@@ -52,27 +52,11 @@ const isValidCosmosAddress = (str) => {
 
 const fromHex = (str) => new Uint8Array(Buffer.from(str.replace('0x', ''), 'hex'));
 
-const getSalt = (salt, contractName, chainNames) => fromHex(getSaltFromKey(salt || contractName.concat(chainNames)));
+const getSalt = (salt, contractName, chainName) => fromHex(getSaltFromKey(salt || contractName.concat(chainName)));
 
 const getLabel = ({ contractName, label }) => label || contractName;
 
 const readWasmFile = ({ artifactPath, contractName }) => readFileSync(`${artifactPath}/${pascalToSnake(contractName)}.wasm`);
-
-const getChains = (config, { chainNames, instantiate2 }) => {
-    let chains = chainNames.split(',').map((str) => str.trim());
-
-    if (chainNames === 'all') {
-        chains = Object.keys(config.chains);
-    }
-
-    if (chains.length !== 1 && instantiate2) {
-        throw new Error('Cannot pass --instantiate2 with more than one chain');
-    }
-
-    chains.every((chain) => chain === 'none' || getChainConfig(config, chain));
-
-    return chains;
-};
 
 const getAmplifierContractConfig = (config, contractName) => {
     const contractConfig = config.axelar.contracts[contractName];
@@ -109,7 +93,7 @@ const uploadContract = async (client, wallet, config, options) => {
 };
 
 const instantiateContract = async (client, wallet, initMsg, config, options) => {
-    const { contractName, salt, instantiate2, chainNames, admin } = options;
+    const { contractName, salt, instantiate2, chainName, admin } = options;
 
     const [account] = await wallet.getAccounts();
 
@@ -126,7 +110,7 @@ const instantiateContract = async (client, wallet, initMsg, config, options) => 
         ? await client.instantiate2(
               account.address,
               contractConfig.codeId,
-              getSalt(salt, contractName, chainNames),
+              getSalt(salt, contractName, chainName),
               initMsg,
               contractLabel,
               initFee,
@@ -479,7 +463,7 @@ const makeInstantiateMsg = (contractName, chainName, config) => {
     switch (contractName) {
         case 'Coordinator': {
             if (chainConfig) {
-                throw new Error('Coordinator does not support chainNames option');
+                throw new Error('Coordinator does not support chainName option');
             }
 
             return makeCoordinatorInstantiateMsg(contractConfig);
@@ -487,7 +471,7 @@ const makeInstantiateMsg = (contractName, chainName, config) => {
 
         case 'ServiceRegistry': {
             if (chainConfig) {
-                throw new Error('ServiceRegistry does not support chainNames option');
+                throw new Error('ServiceRegistry does not support chainName option');
             }
 
             return makeServiceRegistryInstantiateMsg(contractConfig);
@@ -495,7 +479,7 @@ const makeInstantiateMsg = (contractName, chainName, config) => {
 
         case 'Multisig': {
             if (chainConfig) {
-                throw new Error('Multisig does not support chainNames option');
+                throw new Error('Multisig does not support chainName option');
             }
 
             return makeMultisigInstantiateMsg(contractConfig, contracts);
@@ -503,7 +487,7 @@ const makeInstantiateMsg = (contractName, chainName, config) => {
 
         case 'Rewards': {
             if (chainConfig) {
-                throw new Error('Rewards does not support chainNames option');
+                throw new Error('Rewards does not support chainName option');
             }
 
             return makeRewardsInstantiateMsg(contractConfig);
@@ -511,7 +495,7 @@ const makeInstantiateMsg = (contractName, chainName, config) => {
 
         case 'Router': {
             if (chainConfig) {
-                throw new Error('Router does not support chainNames option');
+                throw new Error('Router does not support chainName option');
             }
 
             return makeRouterInstantiateMsg(contractConfig, contracts);
@@ -519,7 +503,7 @@ const makeInstantiateMsg = (contractName, chainName, config) => {
 
         case 'NexusGateway': {
             if (chainConfig) {
-                throw new Error('NexusGateway does not support chainNames option');
+                throw new Error('NexusGateway does not support chainName option');
             }
 
             return makeNexusGatewayInstantiateMsg(contractConfig, contracts);
@@ -527,7 +511,7 @@ const makeInstantiateMsg = (contractName, chainName, config) => {
 
         case 'VotingVerifier': {
             if (!chainConfig) {
-                throw new Error('VotingVerifier requires chainNames option');
+                throw new Error('VotingVerifier requires chainName option');
             }
 
             return makeVotingVerifierInstantiateMsg(contractConfig, contracts, chainConfig);
@@ -535,7 +519,7 @@ const makeInstantiateMsg = (contractName, chainName, config) => {
 
         case 'Gateway': {
             if (!chainConfig) {
-                throw new Error('Gateway requires chainNames option');
+                throw new Error('Gateway requires chainName option');
             }
 
             return makeGatewayInstantiateMsg(contracts, chainConfig);
@@ -543,7 +527,7 @@ const makeInstantiateMsg = (contractName, chainName, config) => {
 
         case 'MultisigProver': {
             if (!chainConfig) {
-                throw new Error('MultisigProver requires chainNames option');
+                throw new Error('MultisigProver requires chainName option');
             }
 
             return makeMultisigProverInstantiateMsg(config, chainName);
@@ -551,7 +535,7 @@ const makeInstantiateMsg = (contractName, chainName, config) => {
 
         case 'AxelarnetGateway': {
             if (!chainConfig) {
-                throw new Error('AxelarnetGateway requires chainNames option');
+                throw new Error('AxelarnetGateway requires chainName option');
             }
 
             return makeAxelarnetGatewayInstantiateMsg(config, chainName);
@@ -653,11 +637,11 @@ const getInstantiateContractParams = (config, options, msg) => {
 };
 
 const getInstantiateContract2Params = (config, options, msg) => {
-    const { contractName, salt, chainNames } = options;
+    const { contractName, salt, chainName } = options;
 
     return {
         ...getInstantiateContractParams(config, options, msg),
-        salt: getSalt(salt, contractName, chainNames),
+        salt: getSalt(salt, contractName, chainName),
     };
 };
 
@@ -810,7 +794,6 @@ module.exports = {
     getSalt,
     calculateDomainSeparator,
     readWasmFile,
-    getChains,
     getAmplifierContractConfig,
     updateContractConfig,
     uploadContract,


### PR DESCRIPTION
Amplifier scripts breaking changes:
- comma separated chains in `chainNames` (e.g. `-n chain1,chain2`) no longer supported, now the caller must execute the script once per chain
- `none` is no longer supported as a valid value for `chainNames` to denote no chain is required

https://axelarnetwork.atlassian.net/browse/AXE-5188