### PR TITLE
feat(stellar): support contract deployment with constrcutors

### DIFF
--- a/stellar/README.md
+++ b/stellar/README.md
@@ -68,7 +68,7 @@ stellar contract build
 Deploy the gateway contract
 
 ```bash
-node stellar/deploy-contract.js deploy axelar_gateway --chain-name <CHAIN_NAME> --wasm-path ../axelar-cgp-soroban/target/wasm32-unknown-unknown/release/axelar_gateway.optimized.wasm --initialize
+node stellar/deploy-contract.js deploy axelar_gateway --chain-name <CHAIN_NAME> --wasm-path ../axelar-cgp-soroban/target/wasm32-unknown-unknown/release/axelar_gateway.optimized.wasm
 ```
 
 Provide `--estimate-cost` to show the gas costs for the initialize transaction instead of executing it.
@@ -76,19 +76,19 @@ Provide `--estimate-cost` to show the gas costs for the initialize transaction i
 ### Operators
 
 ```bash
-node stellar/deploy-contract.js deploy axelar_operators --chain-name <CHAIN_NAME> --wasm-path ../axelar-cgp-soroban/target/wasm32-unknown-unknown/release/axelar_operators.optimized.wasm --initialize
+node stellar/deploy-contract.js deploy axelar_operators --chain-name <CHAIN_NAME> --wasm-path ../axelar-cgp-soroban/target/wasm32-unknown-unknown/release/axelar_operators.optimized.wasm
 ```
 
 ### Gas Service
 
 ```bash
-node stellar/deploy-contract.js deploy axelar_gas_service --chain-name <CHAIN_NAME> --wasm-path ../axelar-cgp-soroban/target/wasm32-unknown-unknown/release/axelar_gas_service.optimized.wasm --initialize
+node stellar/deploy-contract.js deploy axelar_gas_service --chain-name <CHAIN_NAME> --wasm-path ../axelar-cgp-soroban/target/wasm32-unknown-unknown/release/axelar_gas_service.optimized.wasm 
 ```
 
 ### Interchain Token Service
 
 ```bash
-node stellar/deploy-contract.js deploy interchain_token_service --wasm-path ../axelar-cgp-soroban/target/wasm32-unknown-unknown/release/interchain_token_service.optimized.wasm --initialize
+node stellar/deploy-contract.js deploy interchain_token_service --wasm-path ../axelar-cgp-soroban/target/wasm32-unknown-unknown/release/interchain_token_service.optimized.wasm 
 ```
 
 ## Generate bindings

--- a/stellar/deploy-contract.js
+++ b/stellar/deploy-contract.js
@@ -106,7 +106,7 @@ async function deploy(options, config, chain, contractName) {
             `${rpc}`,
             '--network-passphrase',
             `${networkPassphrase}`,
-            '--',
+            '--', // constructor arguments are passed here
         ].concat(
             Object.entries(serializedArgs)
                 .map(([key, value]) => churn(key, value))

--- a/stellar/deploy-contract.js
+++ b/stellar/deploy-contract.js
@@ -86,7 +86,7 @@ async function deploy(options, config, chain, contractName) {
     printInfo('Initializing contract with args', JSON.stringify(serializedArgs, null, 2));
 
     // construct arguments in this way to avoid encoding issues when passing arguments to the stellar CLI
-    function churn(key, value) {
+    function setupCLIParams(key, value) {
         if (typeof value === 'object') {
             return [`--${key}`, JSON.stringify(value)];
         } else {
@@ -109,7 +109,7 @@ async function deploy(options, config, chain, contractName) {
             '--', // constructor arguments are passed here
         ].concat(
             Object.entries(serializedArgs)
-                .map(([key, value]) => churn(key, value))
+                .map(([key, value]) => setupCLIParams(key, value))
                 .flat(1),
         ),
     );


### PR DESCRIPTION
closes https://axelarnetwork.atlassian.net/browse/AXE-6664

## Summary

- removed `-initialize` option because contracts are initialized when they are constructed now
- use `spawnSync` over `execSync` when setting up the stellar command to avoid spawning up a subshell just to call a program, and to avoid encoding issues (using `execSync` would cause some issues with passing JSON values)

## future

Move away from setting up stellar CLI commands. looked into this slightly but the docs seem lacking (especially with the v22 migration business). So, just pushing this through now.