### PR TITLE
feat(stellar): upgrade to stellar-sdk v13.0 and support constructor initialization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@cosmjs/cosmwasm-stargate": "^0.32.1",
         "@ledgerhq/hw-app-eth": "6.32.2",
         "@mysten/sui": "^1.3.0",
-        "@stellar/stellar-sdk": "^12.1.0",
+        "@stellar/stellar-sdk": "^13.0",
         "axios": "^1.7.2",
         "csv-parser": "^3.0.0",
         "path": "^0.12.7",
@@ -2147,11 +2147,13 @@
     },
     "node_modules/@stellar/js-xdr": {
       "version": "3.1.2",
-      "license": "Apache-2.0"
+      "resolved": "https://registry.npmjs.org/@stellar/js-xdr/-/js-xdr-3.1.2.tgz",
+      "integrity": "sha512-VVolPL5goVEIsvuGqDc5uiKxV03lzfWdvYg1KikvwheDmTBO68CKDji3bAZ/kppZrx5iTA8z3Ld5yuytcvhvOQ=="
     },
     "node_modules/@stellar/stellar-base": {
-      "version": "12.1.0",
-      "license": "Apache-2.0",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-13.0.1.tgz",
+      "integrity": "sha512-Xbd12mc9Oj/130Tv0URmm3wXG77XMshZtZ2yNCjqX5ZbMD5IYpbBs3DVCteLU/4SLj/Fnmhh1dzhrQXnk4r+pQ==",
       "dependencies": {
         "@stellar/js-xdr": "^3.1.2",
         "base32.js": "^0.1.0",
@@ -2161,17 +2163,19 @@
         "tweetnacl": "^1.0.3"
       },
       "optionalDependencies": {
-        "sodium-native": "^4.1.1"
+        "sodium-native": "^4.3.0"
       }
     },
     "node_modules/@stellar/stellar-sdk": {
-      "version": "12.2.0",
-      "license": "Apache-2.0",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-sdk/-/stellar-sdk-13.0.0.tgz",
+      "integrity": "sha512-+wvmKi+XWwu27nLYTM17EgBdpbKohEkOfCIK4XKfsI4WpMXAqvnqSm98i9h5dAblNB+w8BJqzGs1JY0PtTGm4A==",
       "dependencies": {
-        "@stellar/stellar-base": "^12.1.0",
-        "axios": "^1.7.2",
+        "@stellar/stellar-base": "^13.0.1",
+        "axios": "^1.7.7",
         "bignumber.js": "^9.1.2",
         "eventsource": "^2.0.2",
+        "feaxios": "^0.0.20",
         "randombytes": "^2.1.0",
         "toml": "^3.0.0",
         "urijs": "^1.19.1"
@@ -2829,8 +2833,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.7.5",
-      "license": "MIT",
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -2848,7 +2853,8 @@
     },
     "node_modules/base32.js": {
       "version": "0.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/base32.js/-/base32.js-0.1.0.tgz",
+      "integrity": "sha512-n3TkB02ixgBOhTvANakDb4xaMXnYUVkNoRFJjQflcqMQhyEKxEHdj3E6N8t8sUQ0mjH/3/JxzlXuz3ul/J90pQ==",
       "engines": {
         "node": ">=0.12.0"
       }
@@ -5080,6 +5086,14 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/feaxios": {
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/feaxios/-/feaxios-0.0.20.tgz",
+      "integrity": "sha512-g3hm2YDNffNxA3Re3Hd8ahbpmDee9Fv1Pb1C/NoWsjY7mtD8nyNeJytUzn+DK0Hyl9o6HppeWOrtnqgmhOYfWA==",
+      "dependencies": {
+        "is-retry-allowed": "^3.0.0"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "dev": true,
@@ -6489,6 +6503,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-retry-allowed": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-3.0.0.tgz",
+      "integrity": "sha512-9xH0xvoggby+u0uGF7cZXdrutWiBiaFG8ZT4YFPXL8NzkyAwX3AKGLeFQLvzDpM430+nDFBZ1LHkie/8ocL06A==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-shared-array-buffer": {
@@ -8469,9 +8494,9 @@
       }
     },
     "node_modules/sodium-native": {
-      "version": "4.1.1",
-      "hasInstallScript": true,
-      "license": "MIT",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-4.3.1.tgz",
+      "integrity": "sha512-YdP64gAdpIKHfL4ttuX4aIfjeunh9f+hNeQJpE9C8UMndB3zkgZ7YmmGT4J2+v6Ibyp6Wem8D1TcSrtdW0bqtg==",
       "optional": true,
       "dependencies": {
         "node-gyp-build": "^4.8.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@cosmjs/cosmwasm-stargate": "^0.32.1",
         "@ledgerhq/hw-app-eth": "6.32.2",
         "@mysten/sui": "^1.3.0",
-        "@stellar/stellar-sdk": "^13.0",
+        "@stellar/stellar-sdk": "^13.0.0",
         "axios": "^1.7.2",
         "csv-parser": "^3.0.0",
         "path": "^0.12.7",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@cosmjs/cosmwasm-stargate": "^0.32.1",
     "@ledgerhq/hw-app-eth": "6.32.2",
     "@mysten/sui": "^1.3.0",
-    "@stellar/stellar-sdk": "^12.1.0",
+    "@stellar/stellar-sdk": "^13.0",
     "axios": "^1.7.2",
     "csv-parser": "^3.0.0",
     "path": "^0.12.7",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@cosmjs/cosmwasm-stargate": "^0.32.1",
     "@ledgerhq/hw-app-eth": "6.32.2",
     "@mysten/sui": "^1.3.0",
-    "@stellar/stellar-sdk": "^13.0",
+    "@stellar/stellar-sdk": "^13.0.0",
     "axios": "^1.7.2",
     "csv-parser": "^3.0.0",
     "path": "^0.12.7",

--- a/stellar/README.md
+++ b/stellar/README.md
@@ -88,7 +88,7 @@ node stellar/deploy-contract.js deploy axelar_gas_service --chain-name <CHAIN_NA
 ### Interchain Token Service
 
 ```bash
-node stellar/deploy-contract.js deploy interchain_token_service --wasm-path ../axelar-cgp-soroban/target/wasm32-unknown-unknown/release/interchain_token_service.optimized.wasm 
+node stellar/deploy-contract.js deploy interchain_token_service --wasm-path --chain-name <CHAIN_NAME> ../axelar-cgp-soroban/target/wasm32-unknown-unknown/release/interchain_token_service.optimized.wasm 
 ```
 
 ## Generate bindings

--- a/stellar/README.md
+++ b/stellar/README.md
@@ -68,7 +68,7 @@ stellar contract build
 Deploy the gateway contract
 
 ```bash
-node stellar/deploy-contract.js deploy axelar_gateway --chain-name <CHAIN_NAME> --wasm-path ../axelar-cgp-soroban/target/wasm32-unknown-unknown/release/axelar_gateway.optimized.wasm --initialize
+node stellar/deploy-contract.js deploy axelar_gateway --chain-name <CHAIN_NAME> --wasm-path ../axelar-cgp-soroban/target/wasm32-unknown-unknown/release/axelar_gateway.optimized.wasm
 ```
 
 Provide `--estimate-cost` to show the gas costs for the initialize transaction instead of executing it.
@@ -76,19 +76,19 @@ Provide `--estimate-cost` to show the gas costs for the initialize transaction i
 ### Operators
 
 ```bash
-node stellar/deploy-contract.js deploy axelar_operators --chain-name <CHAIN_NAME> --wasm-path ../axelar-cgp-soroban/target/wasm32-unknown-unknown/release/axelar_operators.optimized.wasm --initialize
+node stellar/deploy-contract.js deploy axelar_operators --chain-name <CHAIN_NAME> --wasm-path ../axelar-cgp-soroban/target/wasm32-unknown-unknown/release/axelar_operators.optimized.wasm 
 ```
 
 ### Gas Service
 
 ```bash
-node stellar/deploy-contract.js deploy axelar_gas_service --chain-name <CHAIN_NAME> --wasm-path ../axelar-cgp-soroban/target/wasm32-unknown-unknown/release/axelar_gas_service.optimized.wasm --initialize
+node stellar/deploy-contract.js deploy axelar_gas_service --chain-name <CHAIN_NAME> --wasm-path ../axelar-cgp-soroban/target/wasm32-unknown-unknown/release/axelar_gas_service.optimized.wasm 
 ```
 
 ### Interchain Token Service
 
 ```bash
-node stellar/deploy-contract.js deploy interchain_token_service --wasm-path ../axelar-cgp-soroban/target/wasm32-unknown-unknown/release/interchain_token_service.optimized.wasm --initialize
+node stellar/deploy-contract.js deploy interchain_token_service --wasm-path ../axelar-cgp-soroban/target/wasm32-unknown-unknown/release/interchain_token_service.optimized.wasm 
 ```
 
 ## Generate bindings

--- a/stellar/deploy-contract.js
+++ b/stellar/deploy-contract.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { Contract, Address, nativeToScVal, scValToNative } = require('@stellar/stellar-sdk');
+const { Address, nativeToScVal, scValToNative, Operation, StrKey } = require('@stellar/stellar-sdk');
 const { Command, Option } = require('commander');
 const { execSync } = require('child_process');
 const { loadConfig, printInfo, saveConfig } = require('../evm/utils');
@@ -9,6 +9,7 @@ const { getDomainSeparator, getChainConfig } = require('../common');
 const { prompt, validateParameters } = require('../common/utils');
 const { weightedSignersToScVal } = require('./type-utils');
 const { ethers } = require('hardhat');
+const { readFileSync } = require('fs');
 const {
     utils: { arrayify, id },
 } = ethers;
@@ -65,41 +66,11 @@ async function getInitializeArgs(config, chain, contractName, wallet, options) {
     }
 }
 
-const initializeFuncNames = {
-    axelar_gateway: 'initialize',
-    axelar_operators: 'initialize',
-    axelar_gas_service: 'initialize_gas_service',
-    interchain_token_service: 'initialize_its',
-};
-
 async function deploy(options, config, chain, contractName) {
-    const { privateKey, wasmPath, yes } = options;
-    const { rpc, networkType } = chain;
-    const networkPassphrase = getNetworkPassphrase(networkType);
+    const { wasmPath, yes } = options;
     const wallet = await getWallet(chain, options);
 
     if (prompt(`Proceed with deployment on ${chain.name}?`, yes)) {
-        return;
-    }
-
-    const params = `--source ${privateKey} --rpc-url ${rpc} --network-passphrase "${networkPassphrase}"`;
-    const cmd = `${stellarCmd} contract deploy --wasm ${wasmPath} ${params}`;
-
-    let contractAddress = options.address;
-
-    if (!contractAddress) {
-        contractAddress = execSync(cmd, { encoding: 'utf-8', stdio: 'pipe' }).trimEnd();
-        printInfo('Contract deployed successfully!', contractAddress);
-    } else {
-        printInfo('Using existing contract', contractAddress);
-    }
-
-    chain.contracts[contractName] = {
-        address: contractAddress,
-        deployer: wallet.publicKey(),
-    };
-
-    if (!options.initialize) {
         return;
     }
 
@@ -107,14 +78,32 @@ async function deploy(options, config, chain, contractName) {
     const serializedArgs = Object.fromEntries(
         Object.entries(initializeArgs).map(([key, value]) => [key, serializeValue(scValToNative(value))]),
     );
-    chain.contracts[contractName].initializeArgs = serializedArgs;
+    const wasmHash = await uploadWasm(wasmPath, wallet, chain);
 
-    const contract = new Contract(contractAddress);
-    const operation = contract.call(initializeFuncNames[contractName], ...Object.values(initializeArgs));
-
+    const operation = Operation.createCustomContract({
+        wasmHash: wasmHash,
+        address: Address.fromString(wallet.publicKey()),
+        // requires that initializeArgs returns the parameters in the appropriate order
+        constructorArgs: Object.values(initializeArgs),
+    });
     printInfo('Initializing contract with args', JSON.stringify(serializedArgs, null, 2));
 
-    await broadcast(operation, wallet, chain, 'Initialized contract', options);
+    const responseDeploy = await broadcast(operation, wallet, chain, 'Initialized contract', options);
+    const contractAddress = StrKey.encodeContract(Address.fromScAddress(responseDeploy.address()).toBuffer());
+
+    printInfo('Contract initialized at address', contractAddress);
+
+    chain.contracts[contractName] = {
+        address: contractAddress,
+        deployer: wallet.publicKey(),
+    };
+}
+
+async function uploadWasm(filePath, wallet, chain) {
+    const bytecode = readFileSync(filePath);
+    const operation = Operation.uploadContractWasm({ wasm: bytecode });
+    const wasmResponse = await broadcast(operation, wallet, chain, 'Uploaded wasm');
+    return wasmResponse.value();
 }
 
 async function upgrade(options, _, chain, contractName) {
@@ -168,7 +157,6 @@ function main() {
         .argument('<contract-name>', 'contract name to deploy')
         .addOption(new Option('--wasm-path <wasmPath>', 'path to the WASM file').makeOptionMandatory(true))
         .addOption(new Option('--nonce <nonce>', 'optional nonce for the signer set'))
-        .addOption(new Option('--initialize', 'initialize the contract'))
         .addOption(new Option('--domain-separator <domainSeparator>', 'domain separator (keccak256 hash or "offline")').default('offline'))
         .addOption(
             new Option('--previous-signers-retention <previousSignersRetention>', 'previous signer retention')

--- a/stellar/deploy-contract.js
+++ b/stellar/deploy-contract.js
@@ -81,7 +81,7 @@ async function deploy(options, config, chain, contractName) {
     const wasmHash = await uploadWasm(wasmPath, wallet, chain);
 
     const operation = Operation.createCustomContract({
-        wasmHash: wasmHash,
+        wasmHash,
         address: Address.fromString(wallet.publicKey()),
         // requires that initializeArgs returns the parameters in the appropriate order
         constructorArgs: Object.values(initializeArgs),

--- a/stellar/deploy-contract.js
+++ b/stellar/deploy-contract.js
@@ -2,9 +2,8 @@
 
 const { Address, nativeToScVal, scValToNative, Operation, StrKey } = require('@stellar/stellar-sdk');
 const { Command, Option } = require('commander');
-const { execSync } = require('child_process');
 const { loadConfig, printInfo, saveConfig } = require('../evm/utils');
-const { stellarCmd, getNetworkPassphrase, getWallet, broadcast, serializeValue, addBaseOptions } = require('./utils');
+const { getWallet, broadcast, serializeValue, addBaseOptions } = require('./utils');
 const { getDomainSeparator, getChainConfig } = require('../common');
 const { prompt, validateParameters } = require('../common/utils');
 const { weightedSignersToScVal } = require('./type-utils');

--- a/stellar/operators.js
+++ b/stellar/operators.js
@@ -98,8 +98,8 @@ async function processCommand(options, _, chain) {
 
     const returnValue = await broadcast(operation, wallet, chain, `${options.action} performed`, options);
 
-    if (returnValue) {
-        printInfo('Return value', returnValue);
+    if (returnValue.value()) {
+        printInfo('Return value', returnValue.value());
     }
 }
 

--- a/stellar/utils.js
+++ b/stellar/utils.js
@@ -139,8 +139,7 @@ async function sendTransaction(tx, server, action, options = {}) {
         if (options.verbose) {
             printInfo('Transaction result', returnValue.value());
         }
-
-        return returnValue.value();
+        return returnValue;
     } catch (err) {
         console.log('Sending transaction failed');
         throw err;

--- a/stellar/utils.js
+++ b/stellar/utils.js
@@ -2,7 +2,7 @@
 
 const {
     Keypair,
-    SorobanRpc,
+    rpc,
     Horizon,
     TransactionBuilder,
     Networks,
@@ -148,7 +148,7 @@ async function sendTransaction(tx, server, action, options = {}) {
 }
 
 async function broadcast(operation, wallet, chain, action, options = {}) {
-    const server = new SorobanRpc.Server(chain.rpc);
+    const server = new rpc.Server(chain.rpc);
 
     if (options.estimateCost) {
         const tx = await buildTransaction(operation, server, wallet, chain.networkType, options);
@@ -168,7 +168,7 @@ function getAssetCode(balance, chain) {
 async function getWallet(chain, options) {
     const keypair = Keypair.fromSecret(options.privateKey);
     const address = keypair.publicKey();
-    const provider = new SorobanRpc.Server(chain.rpc);
+    const provider = new rpc.Server(chain.rpc);
     const horizonServer = new Horizon.Server(chain.horizonRpc);
     const balances = await getBalances(horizonServer, address);
 

--- a/stellar/utils.js
+++ b/stellar/utils.js
@@ -139,6 +139,7 @@ async function sendTransaction(tx, server, action, options = {}) {
         if (options.verbose) {
             printInfo('Transaction result', returnValue.value());
         }
+
         return returnValue;
     } catch (err) {
         console.log('Sending transaction failed');


### PR DESCRIPTION
closes https://axelarnetwork.atlassian.net/browse/AXE-6664 

supersedes #439 

## Summary

Stop using the `stellar` command to deploy contracts and instead rely on the JS sdk. To do so, needed to upgrade the stellar sdk version to `13.0` to support protocol v22 (where constructors are introduced).

- Mostly based on the [stellar doc](https://developers.stellar.org/docs/build/guides/transactions/install-deploy-contract-with-code) which describes the process.

- Also reworks the `upgrade` command to use the SDK.

- `SorobanRpc` was removed in 13.0, renamed to `rpc`

- `--initialize` has been dropped since all contracts are initialized when constructed now.

- `broadcast` now returns the full response instead of just `the .value()`, since the full response is needed to extract the contract address. 
    - This doesn't affect most of the uses of `broadcast` since all but one of them (in `operators.js`) expect no response

## Testing
Assuming the axelar-cgp-soroban repo is placed within the root of the repo, and the contracts have been compiled + optimized with `optimize.sh`,  the following command should work as expected.

```bash
WASM_DIR=axelar-cgp-soroban/target/wasm32-unknown-unknown/release
for contract in axelar_gateway axelar_gas_service axelar_operators interchain_token_service; do
  node stellar/deploy-contract deploy $contract --wasm-path $WASM_DIR/$contract.optimized.wasm
done

CONTRACT=axelar_gateway
node stellar/deploy-contract.js upgrade $CONTRACT --wasm-path $WASM_DIR/$CONTRACT.optimized.wasm
```

