### PR TITLE
feat(sui): support multiple trusted addresses

### DIFF
--- a/sui/its.js
+++ b/sui/its.js
@@ -3,7 +3,18 @@ const { TxBuilder } = require('@axelar-network/axelar-cgp-sui');
 const { loadConfig, saveConfig, getChainConfig } = require('../common/utils');
 const { addBaseOptions, addOptionsToCommands, getWallet, printWalletInfo, broadcastFromTxBuilder } = require('./utils');
 
-async function setupTrustedAddress(keypair, client, contracts, args, options) {
+function parseTrustedChains(config, trustedChain) {
+    if (trustedChain === 'all-evm') {
+        const evmChains = Object.keys(config.chains).filter(
+            (chain) => config.chains[chain].chainType === 'evm' && config.chains[chain].contracts.InterchainTokenService,
+        );
+        return evmChains;
+    }
+
+    return trustedChain.split(',');
+}
+
+async function setupTrustedAddress(keypair, client, config, contracts, args, options) {
     const [trustedChain, trustedAddress] = args;
 
     const { ITS: itsConfig } = contracts;
@@ -12,21 +23,22 @@ async function setupTrustedAddress(keypair, client, contracts, args, options) {
 
     const txBuilder = new TxBuilder(client);
 
-    const trustedChains = trustedChain.split(',');
+    const trustedChains = parseTrustedChains(config, trustedChain);
 
+    const trustedAddressesObject = await txBuilder.moveCall({
+        target: `${itsConfig.address}::trusted_addresses::new`,
+        arguments: [trustedChains, trustedChains.map(() => trustedAddress)],
+    });
+
+    await txBuilder.moveCall({
+        target: `${itsConfig.address}::its::set_trusted_addresses`,
+        arguments: [ITS, OwnerCap, trustedAddressesObject],
+    });
+
+    await broadcastFromTxBuilder(txBuilder, keypair, 'Setup Trusted Addresses');
+
+    // Update ITS config
     for (const trustedChain of trustedChains) {
-        const trustedAddressesObject = await txBuilder.moveCall({
-            target: `${itsConfig.address}::trusted_addresses::new`,
-            arguments: [[trustedChain], [trustedAddress]],
-        });
-
-        await txBuilder.moveCall({
-            target: `${itsConfig.address}::its::set_trusted_addresses`,
-            arguments: [ITS, OwnerCap, trustedAddressesObject],
-        });
-
-        await broadcastFromTxBuilder(txBuilder, keypair, 'Setup Trusted Address');
-
         // Add trusted address to ITS config
         if (!contracts.ITS.trustedAddresses) contracts.ITS.trustedAddresses = {};
         if (!contracts.ITS.trustedAddresses[trustedChain]) contracts.ITS.trustedAddresses[trustedChain] = [];
@@ -35,18 +47,18 @@ async function setupTrustedAddress(keypair, client, contracts, args, options) {
     }
 }
 
-async function processCommand(command, chain, args, options) {
+async function processCommand(command, config, chain, args, options) {
     const [keypair, client] = getWallet(chain, options);
 
     await printWalletInfo(keypair, client, chain, options);
 
-    await command(keypair, client, chain.contracts, args, options);
+    await command(keypair, client, config, chain.contracts, args, options);
 }
 
 async function mainProcessor(command, options, args, processor) {
     const config = loadConfig(options.env);
     const chain = getChainConfig(config, options.chainName);
-    await processor(command, chain, args, options);
+    await processor(command, config, chain, args, options);
     saveConfig(config, options.env);
 }
 
@@ -59,10 +71,8 @@ if (require.main === module) {
     const setupTrustedAddressProgram = new Command()
         .name('setup-trusted-address')
         .command('setup-trusted-address <trusted-chain> <trusted-address>')
-        .description('Setup trusted address. The <trusted-chain> can be a list of chains separated by commas.')
-        .option(
-            '--chain-tag <tag>',
-            'A convenient tag to setup a set of trusted addresses e.g. `all-evm` to target all ITS-deployed EVM chains',
+        .description(
+            'Setup trusted address. The <trusted-chain> can be a list of chains separated by commas. It can also be a special tag to indicate a specific set of chains e.g. `all-evm` to target all ITS-deployed EVM chains',
         )
         .action((trustedChain, trustedAddress, options) => {
             mainProcessor(setupTrustedAddress, options, [trustedChain, trustedAddress], processCommand);

--- a/sui/its.js
+++ b/sui/its.js
@@ -45,9 +45,8 @@ async function setupTrustedAddress(keypair, client, config, contracts, args, opt
     for (const trustedChain of trustedChains) {
         // Add trusted address to ITS config
         if (!contracts.ITS.trustedAddresses) contracts.ITS.trustedAddresses = {};
-        if (!contracts.ITS.trustedAddresses[trustedChain]) contracts.ITS.trustedAddresses[trustedChain] = [];
 
-        contracts.ITS.trustedAddresses[trustedChain].push(trustedAddress);
+        contracts.ITS.trustedAddresses[trustedChain] = trustedAddress;
     }
 }
 

--- a/sui/its.js
+++ b/sui/its.js
@@ -3,8 +3,12 @@ const { TxBuilder } = require('@axelar-network/axelar-cgp-sui');
 const { loadConfig, saveConfig, getChainConfig } = require('../common/utils');
 const { addBaseOptions, addOptionsToCommands, getWallet, printWalletInfo, broadcastFromTxBuilder } = require('./utils');
 
+const SPECIAL_CHAINS_TAGS = {
+    ALL_EVM: 'all-evm', // All EVM chains that have ITS deployed
+};
+
 function parseTrustedChains(config, trustedChain) {
-    if (trustedChain === 'all-evm') {
+    if (trustedChain === SPECIAL_CHAINS_TAGS.ALL_EVM) {
         const evmChains = Object.keys(config.chains).filter(
             (chain) => config.chains[chain].chainType === 'evm' && config.chains[chain].contracts.InterchainTokenService,
         );
@@ -72,7 +76,7 @@ if (require.main === module) {
         .name('setup-trusted-address')
         .command('setup-trusted-address <trusted-chain> <trusted-address>')
         .description(
-            'Setup trusted address. The <trusted-chain> can be a list of chains separated by commas. It can also be a special tag to indicate a specific set of chains e.g. `all-evm` to target all ITS-deployed EVM chains',
+            `Setup trusted address. The <trusted-chain> can be a list of chains separated by commas. It can also be a special tag to indicate a specific set of chains e.g. '${SPECIAL_CHAINS_TAGS.ALL_EVM}' to target all ITS-deployed EVM chains`,
         )
         .action((trustedChain, trustedAddress, options) => {
             mainProcessor(setupTrustedAddress, options, [trustedChain, trustedAddress], processCommand);


### PR DESCRIPTION
# Description

https://axelarnetwork.atlassian.net/browse/AXE-6784

This PR allows multiple target chains for `setup-trusted-address` command with the comma-separated chains. It also supports a special tag e.g. `all-evm` to target all evm chains that has `InterchainTokenService` deployed.