### PR TITLE
feat(cosmwasm): add previous admin and creator by default to instantiation permissions

### DIFF
--- a/cosmwasm/cli-utils.js
+++ b/cosmwasm/cli-utils.js
@@ -121,7 +121,9 @@ const addStoreProposalOptions = (program) => {
         new Option('--builder <builder>', 'a valid docker image name with tag, such as "cosmwasm/workspace-optimizer:0.16.0'),
     );
     program.addOption(
-        new Option('-i, --instantiateAddresses <instantiateAddresses>', 'comma separated list of addresses allowed to instantiate'),
+        new Option('-i, --instantiateAddresses <instantiateAddresses>', 'comma separated list of addresses allowed to instantiate')
+            .default([])
+            .argParser((addresses) => addresses.split(',').map((address) => address.trim())),
     );
 };
 

--- a/cosmwasm/submit-proposal.js
+++ b/cosmwasm/submit-proposal.js
@@ -17,6 +17,7 @@ const {
     getAmplifierBaseContractConfig,
     getAmplifierContractConfig,
     updateCodeId,
+    addDefaultInstantiateAddresses,
     getChainTruncationParams,
     decodeProposalAttributes,
     encodeStoreCodeProposal,
@@ -80,6 +81,7 @@ const callSubmitProposal = async (client, wallet, config, options, proposal) => 
 const storeCode = async (client, wallet, config, options) => {
     const { contractName } = options;
     const contractBaseConfig = getAmplifierBaseContractConfig(config, contractName);
+    await addDefaultInstantiateAddresses(client, config, options);
 
     const proposal = encodeStoreCodeProposal(options);
 
@@ -96,6 +98,7 @@ const storeCode = async (client, wallet, config, options) => {
 const storeInstantiate = async (client, wallet, config, options) => {
     const { contractName, instantiate2 } = options;
     const { contractConfig, contractBaseConfig } = getAmplifierContractConfig(config, options);
+    await addDefaultInstantiateAddresses(client, config, options);
 
     if (instantiate2) {
         throw new Error('instantiate2 not supported for storeInstantiate');

--- a/cosmwasm/utils.js
+++ b/cosmwasm/utils.js
@@ -20,6 +20,7 @@ const { ParameterChangeProposal } = require('cosmjs-types/cosmos/params/v1beta1/
 const { AccessType } = require('cosmjs-types/cosmwasm/wasm/v1/types');
 const {
     printInfo,
+    printWarn,
     isString,
     isStringArray,
     isKeccak256Hash,
@@ -129,6 +130,7 @@ const uploadContract = async (client, wallet, config, options) => {
 
     const uploadFee = gasLimit === 'auto' ? 'auto' : calculateFee(gasLimit, GasPrice.fromString(gasPrice));
 
+    // uploading through stargate doesn't support defining instantiate permissions
     return await client.upload(account.address, wasm, uploadFee);
 };
 
@@ -540,6 +542,36 @@ const fetchCodeIdFromCodeHash = async (client, contractBaseConfig) => {
     return codeId;
 };
 
+const addDefaultInstantiateAddresses = async (client, config, options) => {
+    const { contractConfig } = getAmplifierContractConfig(config, options);
+
+    if (!contractConfig.address) {
+        return;
+    }
+
+    const contract = await client.getContract(contractConfig.address);
+
+    let { instantiateAddresses } = options;
+
+    if (!instantiateAddresses) {
+        instantiateAddresses = [];
+    }
+
+    if (contract.admin && !instantiateAddresses.includes(contract.admin)) {
+        instantiateAddresses.push(contract.admin);
+        printWarn(
+            `Contract ${contractConfig.address} admin address ${contract.admin} was not included in instantiateAddresses list. Adding it by default.`,
+        );
+    }
+
+    if (contract.creator && !instantiateAddresses.includes(contract.creator)) {
+        instantiateAddresses.push(contract.creator);
+        printWarn(
+            `Contract ${contractConfig.address} creator address ${contract.creator} was not included in instantiateAddresses list. Adding it by default.`,
+        );
+    }
+};
+
 const getChainTruncationParams = (config, chainConfig) => {
     const key = chainConfig.axelarId.toLowerCase();
     const chainTruncationParams = config.axelar.contracts.InterchainTokenService[key];
@@ -561,7 +593,7 @@ const getChainTruncationParams = (config, chainConfig) => {
 const getInstantiatePermission = (accessType, addresses) => {
     return {
         permission: accessType,
-        addresses: addresses.split(',').map((address) => address.trim()),
+        addresses,
     };
 };
 
@@ -587,9 +619,10 @@ const getStoreCodeParams = (options) => {
         codeHash = createHash('sha256').update(wasm).digest();
     }
 
-    const instantiatePermission = instantiateAddresses
-        ? getInstantiatePermission(AccessType.ACCESS_TYPE_ANY_OF_ADDRESSES, instantiateAddresses)
-        : getInstantiatePermission(AccessType.ACCESS_TYPE_NOBODY, '');
+    const instantiatePermission =
+        instantiateAddresses && instantiateAddresses.length > 0
+            ? getInstantiatePermission(AccessType.ACCESS_TYPE_ANY_OF_ADDRESSES, instantiateAddresses)
+            : getInstantiatePermission(AccessType.ACCESS_TYPE_NOBODY, []);
 
     return {
         ...getSubmitProposalParams(options),
@@ -837,6 +870,7 @@ module.exports = {
     uploadContract,
     instantiateContract,
     fetchCodeIdFromCodeHash,
+    addDefaultInstantiateAddresses,
     getChainTruncationParams,
     decodeProposalAttributes,
     encodeStoreCodeProposal,


### PR DESCRIPTION
When submitting a proposal to store code, it will check if the contract has been previously deployed, if yes then it will add the contract admin and creator by default to the list of addresses allowed to instantiate. This is done to prevent issues like blocking migration if the admin address has no instantiation rights

https://axelarnetwork.atlassian.net/browse/AXE-6727