### PR TITLE
fix(stellar): update sorting for rotate signers with amplifier verifiers

### DIFF
--- a/stellar/utils.js
+++ b/stellar/utils.js
@@ -240,12 +240,15 @@ const getAmplifierVerifiers = async (config, chainAxelarId) => {
     );
     const signers = Object.values(verifierSet.signers);
 
+    // Include pubKey for sorting, sort based on pubKey, then remove pubKey after sorting.
     const weightedSigners = signers
         .map((signer) => ({
             signer: Address.account(Buffer.from(arrayify(`0x${signer.pub_key.ed25519}`))).toString(),
             weight: Number(signer.weight),
+            pubKey: signer.pub_key.ed25519,
         }))
-        .sort((a, b) => a.signer.localeCompare(b.signer));
+        .sort((a, b) => a.pubKey.localeCompare(b.pubKey))
+        .map(({ signer, weight }) => ({ signer, weight }));
 
     return {
         signers: weightedSigners,


### PR DESCRIPTION
[AXE-7061](https://axelarnetwork.atlassian.net/browse/AXE-7061)

## Issue:
- rotate signers with amplifier verifiers were failing with [ContractError::InvalidSigners](https://github.com/axelarnetwork/axelar-cgp-soroban/blob/778ee8eea30b9feb73aacf922fc3c5fe32cd068d/contracts/axelar-gateway/src/auth.rs#L223) and this is because of the incorrect order of signers.

```
Error: HostError: Error(Contract, #4)

Event log (newest first):
   0: [Diagnostic Event] contract:CBECMRORSIPG4XG4CNZILCH233OXYMLCY4GL3GIO4SURSHTKHDAPEOVM, topics:[error, Error(Contract, #4)], data:"escalating Ok(ScErrorType::Contract) frame-exit to Err"
   1: [Diagnostic Event] topics:[fn_call, CBECMRORSIPG4XG4CNZILCH233OXYMLCY4GL3GIO4SURSHTKHDAPEOVM, rotate_signers], data:[{nonce: Bytes(00000000000000000000000000000000000000000000000000000000004c2a4d), signers: [{signer: Bytes(6bf111dc9b4136a3c0ce770131f3b0c054eb4dd7dd9de08eb38fff6f6c1f5807), weight: 1}, {signer: Bytes(bd90e0be8127f37682146dfac2f0b30aea59af95a69ab591cff71a3fd2b70734), weight: 1}, {signer: Bytes(835f6a7704392b05b782835298e0e752aa04b355e9428157b412f2a65d04aaec), weight: 1}, {signer: Bytes(908ef636f7bc66af0954139a8e6393fa478184ae2affe82a2dfc09f3b5176b0a), weight: 1}, {signer: Bytes(f10e8cde18527732563e7e466840764149585754b4c88ce9a8d02e6cc3360eb1), weight: 1}], threshold: 3}, {nonce: Bytes(0000000000000000000000000000000000000000000000000000000000000000), signers: [{signature: [Signed, Bytes(5f1a18c46d81da2b5d24d8e396a3656f46ef12243e511c2986a0d56228fc695e1f1f015ad5cdfb96313aa591fe9b618d4243e934560a4af5a4bc192091cec107)], signer: {signer: Bytes(e8898cba5a371e9d9c5622b5b62b25958096b9ab881f1e4bf91d6d29da58fd5e), weight: 1}}], threshold: 1}, false]
```

- the expected sorted order of the pub_key is:
```
The sorted order of the pub_key strings is:
6bf111dc9b4136a3c0ce770131f3b0c054eb4dd7dd9de08eb38fff6f6c1f5807
835f6a7704392b05b782835298e0e752aa04b355e9428157b412f2a65d04aaec
908ef636f7bc66af0954139a8e6393fa478184ae2affe82a2dfc09f3b5176b0a
bd90e0be8127f37682146dfac2f0b30aea59af95a69ab591cff71a3fd2b70734
f10e8cde18527732563e7e466840764149585754b4c88ce9a8d02e6cc3360eb1
```

- After this fix, rotate_signers were successful with sorted order based on pub_key:
https://stellar.expert/explorer/testnet/tx/2224780174442496


[AXE-7061]: https://axelarnetwork.atlassian.net/browse/AXE-7061?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ