### PR TITLE
chore(sui): avoid printing private key

### DIFF
--- a/sui/utils/sign-utils.js
+++ b/sui/utils/sign-utils.js
@@ -50,7 +50,7 @@ function getWallet(chain, options) {
 
     switch (options.privateKeyType) {
         case 'bech32': {
-            const decodedKey = decodeSuiPrivateKey(options.privateKey);
+            const decodedKey = decodePrivateKey(options.privateKey);
             const secretKey = decodedKey.secretKey;
             keypair = scheme.fromSecretKey(secretKey);
             break;
@@ -116,8 +116,17 @@ async function generateKeypair(options) {
     }
 }
 
+// Redacted private key from the error message
+function decodePrivateKey(privateKey) {
+    try {
+        return decodeSuiPrivateKey(privateKey);
+    } catch (e) {
+        throw new Error(`Invalid Sui private key`);
+    }
+}
+
 function getRawPrivateKey(keypair) {
-    return decodeSuiPrivateKey(keypair.getSecretKey()).secretKey;
+    return decodePrivateKey(keypair.getSecretKey()).secretKey;
 }
 
 async function broadcast(client, keypair, tx, actionName) {

--- a/sui/utils/sign-utils.js
+++ b/sui/utils/sign-utils.js
@@ -116,12 +116,16 @@ async function generateKeypair(options) {
     }
 }
 
-// Redacted private key from the error message
+// Decodes a Sui private key without exposing the secret key when failing
 function decodePrivateKey(privateKey) {
+    if (typeof privateKey !== 'string' || !privateKey) {
+        throw new Error('Private key must be a non-empty string');
+    }
+
     try {
         return decodeSuiPrivateKey(privateKey);
     } catch (e) {
-        throw new Error(`Invalid Sui private key`);
+        throw new Error('Invalid Sui private key - please verify the format');
     }
 }
 


### PR DESCRIPTION
# Description

https://axelarnetwork.atlassian.net/browse/AXE-7288

Add try-catch block around `decodeSuiPrivateKey` to avoid exposing sensitive data
