### PR TITLE
refactor(sui): update upgrade policy handling and add immutable policy

### DIFF
--- a/sui/README.md
+++ b/sui/README.md
@@ -65,6 +65,19 @@ node sui/faucet.js
 
 The following packages need to be deployed in order because they are referenced by other packages.
 
+Command syntax:
+
+```bash
+node sui/deploy-contract.js deploy <package name> [--policy <policy>]
+```
+
+Where the policy can be one of the following:
+
+- `any_upgrade` (default): Allow any upgrade.
+- `code_upgrade`: Upgrade policy to just add code.
+- `dep_upgrade`: Upgrade policy to just change dependencies.
+- `immutable`: Make the package immutable.
+
 #### Utils
 
 ```bash

--- a/sui/README.md
+++ b/sui/README.md
@@ -2,12 +2,12 @@
 
 ## Table of Contents
 
--   [Prerequisites](#prerequisites)
--   [Deployment](#deployment)
--   [Contract Upgrades](#contract-upgrades)
--   [Contract Interactions](#contract-interactions)
--   [Examples](#examples)
--   [Troubleshooting](#troubleshooting)
+- [Prerequisites](#prerequisites)
+- [Deployment](#deployment)
+- [Contract Upgrades](#contract-upgrades)
+- [Contract Interactions](#contract-interactions)
+- [Examples](#examples)
+- [Troubleshooting](#troubleshooting)
 
 ## Prerequisites
 
@@ -79,7 +79,7 @@ node sui/deploy-contract.js deploy VersionControl
 
 ### AxelarGateway
 
--   By querying the signer set from the Amplifier contract (this only works if Amplifier contracts have been setup):
+- By querying the signer set from the Amplifier contract (this only works if Amplifier contracts have been setup):
 
 ```bash
 node sui/deploy-contract.js deploy AxelarGateway
@@ -89,13 +89,13 @@ Note: the `minimumRotationDelay` is in `seconds` unit. The default value is `24 
 
 Use `--help` flag to see other setup params that can be overridden.
 
--   For testing convenience, you can use the secp256k1 wallet as the signer set for the gateway.
+- For testing convenience, you can use the secp256k1 wallet as the signer set for the gateway.
 
 ```bash
 node sui/deploy-contract.js deploy AxelarGateway --signers wallet --nonce test
 ```
 
--   You can also provide a JSON object with a full signer set:
+- You can also provide a JSON object with a full signer set:
 
 ```bash
 node sui/deploy-contract.js deploy AxelarGateway -e testnet --signers '{"signers": [{"pub_key": "0x020194ead85b350d90472117e6122cf1764d93bf17d6de4b51b03d19afc4d6302b", "weight": 1}], "threshold": 1, "nonce": "0x0000000000000000000000000000000000000000000000000000000000000000"}'
@@ -179,9 +179,10 @@ node sui/deploy-contract.js upgrade AxelarGateway <policy>
 
 policy should be one of the following:
 
--   `any_upgrade`: Allow any upgrade.
--   `code_upgrade`: Upgrade policy to just add code. https://docs.sui.io/references/framework/sui-framework/package#function-only_additive_upgrades
--   `dep_upgrade`: Upgrade policy to just change dependencies. https://docs.sui.io/references/framework/sui-framework/package#function-only_dep_upgrades
+- `immutable`: Upgrade policy to make the package immutable by discarding the UpgradeCap. https://docs.sui.io/references/framework/sui/package#sui_package_make_immutable
+- `any_upgrade`: Allow any upgrade.
+- `code_upgrade`: Upgrade policy to just add code. https://docs.sui.io/references/framework/sui-framework/package#function-only_additive_upgrades
+- `dep_upgrade`: Upgrade policy to just change dependencies. https://docs.sui.io/references/framework/sui-framework/package#function-only_dep_upgrades
 
 Provide `--txFilePath` with `--offline` to generate tx data file for offline signing.
 
@@ -277,7 +278,7 @@ example for adding multisig info to chains config:
 }
 ```
 
-*Note: To sign via ledger replace private-key with 'ledger' keyword in env and update key scheme to ed25519, as it is the only signatureScheme supported by Ledger currently for Sui. 
+\*Note: To sign via ledger replace private-key with 'ledger' keyword in env and update key scheme to ed25519, as it is the only signatureScheme supported by Ledger currently for Sui.
 
 ## Contract Interactions
 
@@ -365,8 +366,8 @@ node sui/tokens.js split --amount <amount> --coin-type <coin type to split> --tr
 
 Note:
 
--   If coin type is not provided, it will split all the coins.
--   If transfer address is not provided, it will split the coins in the same wallet. Otherwise, it will transfer the splitted coins to the provided address.
+- If coin type is not provided, it will split all the coins.
+- If transfer address is not provided, it will split the coins in the same wallet. Otherwise, it will transfer the splitted coins to the provided address.
 
 ## Setup Trusted Addresses
 
@@ -390,8 +391,8 @@ node sui/its.js remove-trusted-address <sourceChain>,<sourceChain2>,...
 
 ## Examples
 
--   [GMP Example Guide](docs/gmp.md)
--   [ITS Example Guide](docs/its.md)
+- [GMP Example Guide](docs/gmp.md)
+- [ITS Example Guide](docs/its.md)
 
 ## Troubleshooting
 

--- a/sui/README.md
+++ b/sui/README.md
@@ -2,12 +2,12 @@
 
 ## Table of Contents
 
-- [Prerequisites](#prerequisites)
-- [Deployment](#deployment)
-- [Contract Upgrades](#contract-upgrades)
-- [Contract Interactions](#contract-interactions)
-- [Examples](#examples)
-- [Troubleshooting](#troubleshooting)
+-   [Prerequisites](#prerequisites)
+-   [Deployment](#deployment)
+-   [Contract Upgrades](#contract-upgrades)
+-   [Contract Interactions](#contract-interactions)
+-   [Examples](#examples)
+-   [Troubleshooting](#troubleshooting)
 
 ## Prerequisites
 
@@ -79,7 +79,7 @@ node sui/deploy-contract.js deploy VersionControl
 
 ### AxelarGateway
 
-- By querying the signer set from the Amplifier contract (this only works if Amplifier contracts have been setup):
+-   By querying the signer set from the Amplifier contract (this only works if Amplifier contracts have been setup):
 
 ```bash
 node sui/deploy-contract.js deploy AxelarGateway
@@ -89,13 +89,13 @@ Note: the `minimumRotationDelay` is in `seconds` unit. The default value is `24 
 
 Use `--help` flag to see other setup params that can be overridden.
 
-- For testing convenience, you can use the secp256k1 wallet as the signer set for the gateway.
+-   For testing convenience, you can use the secp256k1 wallet as the signer set for the gateway.
 
 ```bash
 node sui/deploy-contract.js deploy AxelarGateway --signers wallet --nonce test
 ```
 
-- You can also provide a JSON object with a full signer set:
+-   You can also provide a JSON object with a full signer set:
 
 ```bash
 node sui/deploy-contract.js deploy AxelarGateway -e testnet --signers '{"signers": [{"pub_key": "0x020194ead85b350d90472117e6122cf1764d93bf17d6de4b51b03d19afc4d6302b", "weight": 1}], "threshold": 1, "nonce": "0x0000000000000000000000000000000000000000000000000000000000000000"}'
@@ -179,9 +179,9 @@ node sui/deploy-contract.js upgrade AxelarGateway <policy>
 
 policy should be one of the following:
 
-- `any_upgrade`: Allow any upgrade.
-- `code_upgrade`: Upgrade policy to just add code. https://docs.sui.io/references/framework/sui-framework/package#function-only_additive_upgrades
-- `dep_upgrade`: Upgrade policy to just change dependencies. https://docs.sui.io/references/framework/sui-framework/package#function-only_dep_upgrades
+-   `any_upgrade`: Allow any upgrade.
+-   `code_upgrade`: Upgrade policy to just add code. https://docs.sui.io/references/framework/sui-framework/package#function-only_additive_upgrades
+-   `dep_upgrade`: Upgrade policy to just change dependencies. https://docs.sui.io/references/framework/sui-framework/package#function-only_dep_upgrades
 
 Provide `--txFilePath` with `--offline` to generate tx data file for offline signing.
 
@@ -277,7 +277,7 @@ example for adding multisig info to chains config:
 }
 ```
 
-\*Note: To sign via ledger replace private-key with 'ledger' keyword in env and update key scheme to ed25519, as it is the only signatureScheme supported by Ledger currently for Sui.
+*Note: To sign via ledger replace private-key with 'ledger' keyword in env and update key scheme to ed25519, as it is the only signatureScheme supported by Ledger currently for Sui. 
 
 ## Contract Interactions
 
@@ -365,8 +365,8 @@ node sui/tokens.js split --amount <amount> --coin-type <coin type to split> --tr
 
 Note:
 
-- If coin type is not provided, it will split all the coins.
-- If transfer address is not provided, it will split the coins in the same wallet. Otherwise, it will transfer the splitted coins to the provided address.
+-   If coin type is not provided, it will split all the coins.
+-   If transfer address is not provided, it will split the coins in the same wallet. Otherwise, it will transfer the splitted coins to the provided address.
 
 ## Setup Trusted Addresses
 
@@ -390,8 +390,8 @@ node sui/its.js remove-trusted-address <sourceChain>,<sourceChain2>,...
 
 ## Examples
 
-- [GMP Example Guide](docs/gmp.md)
-- [ITS Example Guide](docs/its.md)
+-   [GMP Example Guide](docs/gmp.md)
+-   [ITS Example Guide](docs/its.md)
 
 ## Troubleshooting
 

--- a/sui/README.md
+++ b/sui/README.md
@@ -179,7 +179,6 @@ node sui/deploy-contract.js upgrade AxelarGateway <policy>
 
 policy should be one of the following:
 
-- `immutable`: Upgrade policy to make the package immutable by discarding the UpgradeCap. https://docs.sui.io/references/framework/sui/package#sui_package_make_immutable
 - `any_upgrade`: Allow any upgrade.
 - `code_upgrade`: Upgrade policy to just add code. https://docs.sui.io/references/framework/sui-framework/package#function-only_additive_upgrades
 - `dep_upgrade`: Upgrade policy to just change dependencies. https://docs.sui.io/references/framework/sui-framework/package#function-only_dep_upgrades

--- a/sui/deploy-contract.js
+++ b/sui/deploy-contract.js
@@ -143,6 +143,9 @@ async function postDeployGasService(published, keypair, client, config, chain, o
             `${suiPackageAddress}::package::UpgradeCap`,
         ],
     );
+
+    await broadcastRestrictedUpgradePolicy(client, keypair, upgradeCap, options);
+
     chain.contracts.GasService.objects = {
         GasCollectorCap: gasCollectorCapObjectId,
         GasService: gasServiceObjectId,
@@ -153,6 +156,7 @@ async function postDeployGasService(published, keypair, client, config, chain, o
 
 async function postDeployExample(published, keypair, client, config, chain, options) {
     const relayerDiscovery = chain.contracts.RelayerDiscovery?.objects?.RelayerDiscovery;
+    const { policy } = options;
 
     // GMP Example Params
     const [gmpSingletonObjectId] = getObjectIdsByObjectTypes(published.publishTxn, [`${published.packageId}::gmp::Singleton`]);
@@ -172,6 +176,9 @@ async function postDeployExample(published, keypair, client, config, chain, opti
         target: `${published.packageId}::its::register_transaction`,
         arguments: [tx.object(relayerDiscovery), tx.object(itsSingletonObjectId), tx.object(itsObjectId), tx.object(suiClockAddress)],
     });
+
+    const [upgradeCap] = getObjectIdsByObjectTypes(published.publishTxn, [`${suiPackageAddress}::package::UpgradeCap`]);
+    restrictUpgradePolicy(tx, policy, upgradeCap);
 
     await broadcast(client, keypair, tx, 'Registered Transaction', options);
 

--- a/sui/deploy-contract.js
+++ b/sui/deploy-contract.js
@@ -407,7 +407,7 @@ async function mainProcessor(args, options, processor) {
 // Common deploy command options for all packages
 const DEPLOY_CMD_OPTIONS = [
     new Option('--policy <policy>', 'upgrade policy for upgrade cap: For example, use "any_upgrade" to allow all types of upgrades')
-        .choices(['any_upgrade', 'code_upgrade', 'dep_upgrade'])
+        .choices(['immutable', 'any_upgrade', 'code_upgrade', 'dep_upgrade'])
         .default('any_upgrade'),
 ];
 

--- a/sui/deploy-contract.js
+++ b/sui/deploy-contract.js
@@ -213,8 +213,9 @@ async function postDeployAxelarGateway(published, keypair, client, config, chain
         ],
     });
 
-    if (policy !== 'any_upgrade') {
-        const upgradeType = UPGRADE_POLICIES[policy];
+    const upgradeType = UPGRADE_POLICIES[policy];
+
+    if (upgradeType) {
         tx.moveCall({
             target: `${suiPackageAddress}::package::${upgradeType}`,
             arguments: [tx.object(upgradeCap)],

--- a/sui/utils/sign-utils.js
+++ b/sui/utils/sign-utils.js
@@ -135,11 +135,12 @@ function getRawPrivateKey(keypair) {
 }
 
 // Prompt the user for confirmation before executing a transaction
-async function askForConfirmation(commandOptions = {}) {
+async function askForConfirmation(actionName, commandOptions = {}) {
     const { yes } = commandOptions;
 
     if (!yes) {
-        const aborted = prompt('Confirm Tx?');
+        const promptTitle = actionName ? `Confirm ${actionName} Tx?` : 'Confirm Tx?';
+        const aborted = prompt(promptTitle);
 
         if (aborted) {
             printInfo('Aborted');
@@ -149,7 +150,7 @@ async function askForConfirmation(commandOptions = {}) {
 }
 
 async function broadcast(client, keypair, tx, actionName, commandOptions = {}) {
-    await askForConfirmation(commandOptions);
+    await askForConfirmation(actionName, commandOptions);
 
     const receipt = await client.signAndExecuteTransaction({
         transaction: tx,
@@ -166,7 +167,7 @@ async function broadcast(client, keypair, tx, actionName, commandOptions = {}) {
 }
 
 async function broadcastFromTxBuilder(txBuilder, keypair, actionName, commandOptions = {}, suiResponseOptions) {
-    await askForConfirmation(commandOptions);
+    await askForConfirmation(actionName, commandOptions);
 
     const receipt = await txBuilder.signAndExecute(keypair, suiResponseOptions);
 
@@ -184,7 +185,7 @@ const broadcastExecuteApprovedMessage = async (
     actionName,
     commandOptions = {},
 ) => {
-    await askForConfirmation(commandOptions);
+    await askForConfirmation(actionName, commandOptions);
     const receipt = await execute(client, keypair, discoveryInfo, gatewayInfo, messageInfo);
 
     printInfo(actionName || 'Tx', receipt.digest);
@@ -193,7 +194,7 @@ const broadcastExecuteApprovedMessage = async (
 };
 
 async function broadcastSignature(client, txBytes, signature, actionName, commandOptions = {}) {
-    await askForConfirmation(commandOptions);
+    await askForConfirmation(actionName, commandOptions);
 
     const receipt = await client.executeTransactionBlock({
         transactionBlock: txBytes,

--- a/sui/utils/upgrade-utils.js
+++ b/sui/utils/upgrade-utils.js
@@ -45,6 +45,10 @@ function broadcastRestrictedUpgradePolicy(client, keypair, upgradeCap, options) 
         return;
     }
 
+    if (!upgradeCap) {
+        throw new Error(`Cannot find upgrade cap to restrict upgrade policy`);
+    }
+
     return broadcast(
         client,
         keypair,


### PR DESCRIPTION
# Description

https://axelarnetwork.atlassian.net/browse/AXE-7481

This PR introduces the `immutable` deployment policy option, which allows packages to be permanently locked from future upgrades. When this policy is provided, the `UpgradeCap` is automatically discarded after the package is published, making the package immutable and preventing any subsequent upgrades.

## Changes

- Allow passing `immutable` policy for the `node sui/deploy-contract.js deploy` command
- Apply upgrade policy after all packages deployment, instead of just `Gateway` contract. This only applies when the policy option is specified and it is not `any_upgrade` policy.
- Update `sui/README.md` for this changes.
- Bonus: Removed duplicated package deployment log.
- Bonus: Add action name to the tx confirmation prompt

## Implementation Details

1. Add `broadcastRestrictedUpgradePolicy` function where it broadcasts the transaction to apply the upgrade policy. 
2. Add `restrictUpgradePolicy` function where it only adds upgrade policy `moveCall` to the existing tx.
3. Apply two functions above to post deployment functions in `sui/deploy-contract.js` file.

## Usage

To deploy the package and prevent future upgrade:
```
node sui/deploy-contract.js deploy <package_name> --policy immutable
```

To deploy the package and allow future upgrade:
```
node sui/deploy-contract.js deploy <package_name>
```

or 

```
node sui/deploy-contract.js deploy <package_name> --policy <code_upgrade|dep_upgrade>
```