### PR TITLE
feat(sui)!: track more objects on deployment

### DIFF
--- a/sui/deploy-contract.js
+++ b/sui/deploy-contract.js
@@ -71,6 +71,7 @@ const PACKAGE_CONFIGS = {
         Squid: postDeploySquid,
         Utils: postDeployUtils,
         Abi: postDeployAbi,
+        VersionControl: postDeployVersionControl,
     },
 };
 
@@ -112,6 +113,7 @@ async function postDeployRelayerDiscovery(published, keypair, client, config, ch
         RelayerDiscovery: relayerDiscoveryObjectId,
         RelayerDiscoveryv0: relayerDiscoveryObjectIdv0,
         OwnerCap: ownerCap,
+        UpgradeCap: upgradeCap,
     };
 }
 
@@ -127,10 +129,28 @@ async function postDeployUtils(published, keypair, client, config, chain, option
     }
 }
 
+async function postDeployVersionControl(published, keypair, client, config, chain, options) {
+    const [upgradeCap] = getObjectIdsByObjectTypes(published.publishTxn, [`${suiPackageAddress}::package::UpgradeCap`]);
+
+    await broadcastRestrictedUpgradePolicy(client, keypair, upgradeCap, options);
+
+    if (options.policy !== 'immutable') {
+        chain.contracts.VersionControl.objects = {
+            UpgradeCap: upgradeCap,
+        };
+    }
+}
+
 async function postDeployAbi(published, keypair, client, config, chain, options) {
     const [upgradeCap] = getObjectIdsByObjectTypes(published.publishTxn, [`${suiPackageAddress}::package::UpgradeCap`]);
 
     await broadcastRestrictedUpgradePolicy(client, keypair, upgradeCap, options);
+
+    if (options.policy !== 'immutable') {
+        chain.contracts.Abi.objects = {
+            UpgradeCap: upgradeCap,
+        };
+    }
 }
 
 async function postDeployGasService(published, keypair, client, config, chain, options) {
@@ -205,6 +225,7 @@ async function postDeployOperators(published, keypair, client, config, chain, op
     chain.contracts.Operators.objects = {
         Operators: operatorsObjectId,
         OwnerCap: ownerCapObjectId,
+        UpgradeCap: upgradeCap,
     };
 }
 


### PR DESCRIPTION
[AXE-7512]

[AXE-7512]: https://axelarnetwork.atlassian.net/browse/AXE-7512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ