### PR TITLE
chore: update its example and axelar-cgp-sui

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@axelar-network/axelar-cgp-solidity": "6.4.0",
-        "@axelar-network/axelar-cgp-sui": "1.1.2",
+        "@axelar-network/axelar-cgp-sui": "^1.1.3",
         "@axelar-network/axelar-gmp-sdk-solidity": "6.0.4",
         "@axelar-network/interchain-token-service": "2.1.0",
         "@cosmjs/cosmwasm-stargate": "^0.32.1",
@@ -145,9 +145,9 @@
       }
     },
     "node_modules/@axelar-network/axelar-cgp-sui": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@axelar-network/axelar-cgp-sui/-/axelar-cgp-sui-1.1.2.tgz",
-      "integrity": "sha512-hTSW8kjshB0jV0oS5D6UIm5rW3uRsQpN+gJu4rKJ6aWLtvtZSJnfIJbt6aOzG9ktYJ/IYa3L4B6uH8YSdsP+EA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@axelar-network/axelar-cgp-sui/-/axelar-cgp-sui-1.1.3.tgz",
+      "integrity": "sha512-hdl9za6OleruHK9Ye9sogPPeGE8yCcmEyzEGLzlLKrv4uXojOlW2hAz+ADfCMqT2izYYfvjIeZ77nonqMx76fg==",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.2",
         "@mysten/sui": "^1.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@axelar-network/axelar-cgp-solidity": "6.4.0",
-        "@axelar-network/axelar-cgp-sui": "^1.1.3",
+        "@axelar-network/axelar-cgp-sui": "1.1.3",
         "@axelar-network/axelar-gmp-sdk-solidity": "6.0.4",
         "@axelar-network/interchain-token-service": "2.1.0",
         "@cosmjs/cosmwasm-stargate": "^0.32.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/axelarnetwork/axelar-contract-deployments#readme",
   "dependencies": {
     "@axelar-network/axelar-cgp-solidity": "6.4.0",
-    "@axelar-network/axelar-cgp-sui": "1.1.2",
+    "@axelar-network/axelar-cgp-sui": "^1.1.3",
     "@axelar-network/axelar-gmp-sdk-solidity": "6.0.4",
     "@axelar-network/interchain-token-service": "2.1.0",
     "@cosmjs/cosmwasm-stargate": "^0.32.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/axelarnetwork/axelar-contract-deployments#readme",
   "dependencies": {
     "@axelar-network/axelar-cgp-solidity": "6.4.0",
-    "@axelar-network/axelar-cgp-sui": "^1.1.3",
+    "@axelar-network/axelar-cgp-sui": "1.1.3",
     "@axelar-network/axelar-gmp-sdk-solidity": "6.0.4",
     "@axelar-network/interchain-token-service": "2.1.0",
     "@cosmjs/cosmwasm-stargate": "^0.32.1",

--- a/sui/its-example.js
+++ b/sui/its-example.js
@@ -190,11 +190,20 @@ async function deployToken(keypair, client, contracts, args, options) {
     const postDeployTxBuilder = new TxBuilder(client);
 
     if (options.origin) {
-        await postDeployTxBuilder.moveCall({
-            target: `${Example.address}::its::register_coin`,
-            arguments: [InterchainTokenService.objects.InterchainTokenService, Metadata],
-            typeArguments: [tokenType],
-        });
+        if (options.tokenManagerMode === 'lock_unlock') {
+            await postDeployTxBuilder.moveCall({
+                target: `${Example.address}::its::register_coin`,
+                arguments: [InterchainTokenService.objects.InterchainTokenService, Metadata],
+                typeArguments: [tokenType],
+            });
+        } else {
+            await postDeployTxBuilder.moveCall({
+                target: `${Example.address}::its::register_coin_with_cap`,
+                arguments: [InterchainTokenService.objects.InterchainTokenService, Metadata, TreasuryCap],
+                typeArguments: [tokenType],
+            });
+        }
+
         const result = await broadcastFromTxBuilder(
             postDeployTxBuilder,
             keypair,
@@ -355,6 +364,11 @@ if (require.main === module) {
         .name('deploy-token')
         .description('Deploy token on Sui.')
         .command('deploy-token <symbol> <name> <decimals>')
+        .addOption(
+            new Option('--tokenManagerMode <tokenManagerMode>', 'Token Manager Mode')
+                .default('lock_unlock')
+                .choices(['lock_unlock', 'mint_burn']),
+        )
         .addOption(new Option('--origin', 'Deploy as a origin token or receive deployment from another chain', false))
         .action((symbol, name, decimals, options) => {
             mainProcessor(deployToken, options, [symbol, name, decimals], processCommand);

--- a/sui/its-example.js
+++ b/sui/its-example.js
@@ -362,7 +362,7 @@ if (require.main === module) {
 
     const deployTokenProgram = new Command()
         .name('deploy-token')
-        .description('Deploy token on Sui.')
+        .description('Deploy token on Sui. The supported token manager modes are lock_unlock (default) and mint_burn.')
         .command('deploy-token <symbol> <name> <decimals>')
         .addOption(
             new Option('--tokenManagerMode <tokenManagerMode>', 'Token Manager Mode')


### PR DESCRIPTION
# Description

https://axelarnetwork.atlassian.net/browse/AXE-7769

Update `axelar-cgp-sui` to `1.1.3` and include sui token deployment with `mint_and_burn` mode in the example

## Note
- Our current Example contract on `devnet-amplifier` haven't support `mint_and_burn` mode yet because we need to deploy a new contract first. cc: @blockchainguyy 