### PR TITLE
chore(xrpl): upgrade xrpl dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "csv-parser": "^3.0.0",
         "path": "^0.12.7",
         "toml": "^3.0.0",
-        "xrpl": "^4.2.0"
+        "xrpl": "^4.2.5"
       },
       "devDependencies": {
         "@ledgerhq/hw-transport-node-hid": "^6.27.21",
@@ -11592,9 +11592,9 @@
       }
     },
     "node_modules/xrpl": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/xrpl/-/xrpl-4.2.0.tgz",
-      "integrity": "sha512-RR6lJhRyQHPoI/rZGuKBzUc45KSC3thpYVzn3ATu78GXDZ6vsyn8SXmNveMhAJ2AVRvpRiyyztbU2TmGRUp2Xg==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/xrpl/-/xrpl-4.2.5.tgz",
+      "integrity": "sha512-QIpsqvhaRiVvlq7px7lC+lhrxESDMN1vd8mW0SfTgY5WgzP9RLiDoVywOOvSZqDDjPs0EGfhxzYjREW1gGu0Ng==",
       "license": "ISC",
       "dependencies": {
         "@scure/bip32": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "csv-parser": "^3.0.0",
     "path": "^0.12.7",
     "toml": "^3.0.0",
-    "xrpl": "^4.2.0"
+    "xrpl": "^4.2.5"
   },
   "devDependencies": {
     "@ledgerhq/hw-transport-node-hid": "^6.27.21",


### PR DESCRIPTION
- A backdoor was implanted into [xrpl.js](https://www.npmjs.com/package/xrpl) versions v4.2.1-4.2.4: https://github.com/XRPLF/xrpl.js/security/advisories/GHSA-33qr-m49q-rxfx.
- Even though `package.json` uses `^4.2.0`, this repo should've been unaffected since the `package-lock.json` file fixes v4.2.0.
- This PR bumps the `xrpl` dependency to v2.5.0, which contains the patch.