### PR TITLE
fix: remove caret from xrpl dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "csv-parser": "^3.0.0",
         "path": "^0.12.7",
         "toml": "^3.0.0",
-        "xrpl": "^4.2.5"
+        "xrpl": "4.2.5"
       },
       "devDependencies": {
         "@ledgerhq/hw-transport-node-hid": "^6.27.21",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "csv-parser": "^3.0.0",
     "path": "^0.12.7",
     "toml": "^3.0.0",
-    "xrpl": "^4.2.5"
+    "xrpl": "4.2.5"
   },
   "devDependencies": {
     "@ledgerhq/hw-transport-node-hid": "^6.27.21",


### PR DESCRIPTION
This PR remove caret from xrpl dependency.

JIRA: https://axelarnetwork.atlassian.net/browse/AXE-9142