### PR TITLE
feat: add script to top up multiple EVM accounts from a single wallet

### DIFF
--- a/evm/README.md
+++ b/evm/README.md
@@ -158,6 +158,28 @@ To decode function calldata:
     Function: Unrecognized function call
     ```
 
+### Top Up Accounts
+
+To top up multiple accounts from a single wallet with native cryptocurrency or ERC20 tokens, you can use the following command:
+
+```bash
+node evm/top-up.js [native|token] -n <chain> --target <target-balance> --threshold <threshold> --addresses-to-derive [number-of-accounts]
+```
+
+Example usage:
+
+```bash
+# For native crypto
+node evm/top-up.js native -n xrpl-evm -t 50 --threshold 0 --addresses-to-derive 3
+
+# For ERC20 tokens
+node evm/top-up.js token -n xrpl-evm -t 10000 --threshold 0 --addresses-to-derive 3 --contract 0x02D0f033d365d0D1b6a4377bfc6cB9D87bE16Ab7 --decimals 0
+```
+
+You can use `--addresses-to-derive` to derive multiple accounts from a mnemonic set in the MNEMONIC environment variable, or use `--addresses` to specify a list of addresses to top up.
+
+For ERC20 token top ups, you must specify the contract address using `--contract` option.
+
 ## InterchainGovernance
 
 To update the min deposit on Axelar with a param change proposal, you can generate the proposal via

--- a/evm/cli-utils.js
+++ b/evm/cli-utils.js
@@ -41,8 +41,29 @@ const addEvmOptions = (program, options = {}) => {
     return program;
 };
 
+const addTopUpOptions = (program) => {
+    program.addOption(new Option('-t, --target <target>', 'target balance for each account').makeOptionMandatory(true));
+    program.addOption(
+        new Option('--threshold <threshold>', 'top up accounts only if the balance is below this threshold').makeOptionMandatory(true),
+    );
+    program.addOption(new Option('-u, --units', 'amounts are set in smallest unit'));
+    program.addOption(
+        new Option(
+            '--addresses-to-derive <addresses-to-derive>',
+            'number of addresses to derive from mnemonic. Derived addresses will be added to the list of addresses to fund set by using --addresses option',
+        ).env('DERIVE_ACCOUNTS'),
+    );
+    program.addOption(
+        new Option('--addresses <addresses>', 'comma separated list of addresses to top up')
+            .default([])
+            .argParser((addresses) => addresses.split(',').map((address) => address.trim())),
+    );
+    program.addOption(new Option('-m, --mnemonic <mnemonic>', 'mnemonic').env('MNEMONIC'));
+};
+
 module.exports = {
     ...exportedCliUtils,
     addBaseOptions,
     addEvmOptions,
+    addTopUpOptions,
 };

--- a/evm/top-up.js
+++ b/evm/top-up.js
@@ -1,0 +1,125 @@
+const { loadConfig, printInfo } = require('../common/index.js');
+const { addBaseOptions } = require('../common/cli-utils.js');
+const { addTopUpOptions } = require('./cli-utils.js');
+
+const { getWallet } = require('./sign-utils.js');
+const { getContractJSON, deriveAccounts, printWalletInfo } = require('./utils.js');
+
+const { Command } = require('commander');
+const ethers = require('ethers');
+
+const topUpAccounts = async (wallet, options, addressesToFund, decimals, token) => {
+    const { target, threshold, units } = options;
+
+    let targetUnits;
+    let thresholdUnits;
+
+    if (units) {
+        targetUnits = ethers.BigNumber.from(target);
+        thresholdUnits = ethers.BigNumber.from(threshold);
+    } else {
+        targetUnits = ethers.utils.parseUnits(target, decimals);
+        thresholdUnits = ethers.utils.parseUnits(threshold, decimals);
+    }
+
+    printInfo('Target balance', ethers.utils.formatUnits(targetUnits, decimals));
+    printInfo('Threshold', ethers.utils.formatUnits(thresholdUnits, decimals));
+
+    if (thresholdUnits.gt(targetUnits)) {
+        throw new Error('threshold must be less than or equal to target balance');
+    }
+
+    for (const address of addressesToFund) {
+        console.log('='.repeat(20));
+        printInfo(`Funding account with ${token ? 'ERC20 tokens' : 'native cryptocurrency'}`, address);
+
+        const balance = token ? await token.balanceOf(address) : await wallet.provider.getBalance(address);
+
+        printInfo('Current balance', ethers.utils.formatUnits(balance, decimals));
+
+        if (balance.gte(thresholdUnits)) {
+            printInfo('Account has sufficient balance. Skipping...');
+            continue;
+        }
+
+        const amount = targetUnits.sub(balance);
+
+        if (token) {
+            await token
+                .transfer(address, amount)
+                .then((tx) => tx.wait())
+                .then(() => printInfo(`Funded account with ERC20 tokens`, ethers.utils.formatUnits(amount, decimals)));
+        } else {
+            await wallet
+                .sendTransaction({
+                    to: address,
+                    value: amount,
+                })
+                .then((tx) => tx.wait())
+                .then(() => printInfo('Funded account with native cryptocurrency', ethers.utils.formatUnits(amount, decimals)));
+        }
+    }
+};
+
+const topUpNative = async (wallet, options, addressesToFund) => {
+    topUpAccounts(wallet, options, addressesToFund, 18, false);
+};
+
+const topUpToken = async (wallet, options, addressesToFund) => {
+    const { contract, decimals } = options;
+    const token = new ethers.Contract(contract, getContractJSON('ERC20').abi, wallet);
+    const tokenDecimals = decimals || (await token.decimals());
+
+    topUpAccounts(wallet, options, addressesToFund, tokenDecimals, token);
+};
+
+const mainProcessor = async (processor, options) => {
+    const { env, privateKey, chainNames, addressesToDerive, addresses, mnemonic } = options;
+    const config = loadConfig(env);
+
+    const rpc = config.chains[chainNames].rpc;
+    const provider = new ethers.providers.JsonRpcProvider(rpc);
+    const wallet = await getWallet(privateKey, provider);
+
+    await printWalletInfo(wallet, options);
+
+    let addressesToFund = addresses;
+
+    if (addressesToDerive) {
+        const derivedAccounts = await deriveAccounts(mnemonic, addressesToDerive);
+        addressesToFund = addressesToFund.concat(derivedAccounts.map((account) => account.address));
+    }
+
+    await processor(wallet, options, addressesToFund);
+};
+
+const programHandler = () => {
+    const program = new Command();
+    program.name('top-up').description('Top up multiple accounts with native cryptocurrency or ERC20 tokens from a single wallet');
+
+    const topUpNativeCmd = program
+        .command('native')
+        .description('Top up multiple accounts with native cryptocurrency from a single wallet')
+        .action((options) => {
+            mainProcessor(topUpNative, options);
+        });
+    addBaseOptions(topUpNativeCmd, {});
+    addTopUpOptions(topUpNativeCmd);
+
+    const topUpTokenCmd = program
+        .command('token')
+        .description('Top up multiple accounts with ERC20 tokens from a single wallet')
+        .requiredOption('--contract <contract>', 'ERC20 token contract address')
+        .option('-d, --decimals <decimals>', 'token decimals, if not provided, the contract will be queried for the decimals')
+        .action((options) => {
+            mainProcessor(topUpToken, options);
+        });
+    addBaseOptions(topUpTokenCmd, {});
+    addTopUpOptions(topUpTokenCmd);
+
+    program.parse();
+};
+
+if (require.main === module) {
+    programHandler();
+}

--- a/evm/top-up.js
+++ b/evm/top-up.js
@@ -44,20 +44,10 @@ const topUpAccounts = async (wallet, options, addressesToFund, decimals, token) 
 
         const amount = targetUnits.sub(balance);
 
-        if (token) {
-            await token
-                .transfer(address, amount)
-                .then((tx) => tx.wait())
-                .then(() => printInfo(`Funded account with ERC20 tokens`, ethers.utils.formatUnits(amount, decimals)));
-        } else {
-            await wallet
-                .sendTransaction({
-                    to: address,
-                    value: amount,
-                })
-                .then((tx) => tx.wait())
-                .then(() => printInfo('Funded account with native cryptocurrency', ethers.utils.formatUnits(amount, decimals)));
-        }
+        const tx = token ? await token.transfer(address, amount) : await wallet.sendTransaction({ to: address, value: amount });
+        await tx.wait();
+
+        printInfo('Amount transferred', ethers.utils.formatUnits(amount, decimals));
     }
 };
 

--- a/evm/utils.js
+++ b/evm/utils.js
@@ -5,10 +5,21 @@ const { ethers } = require('hardhat');
 const {
     ContractFactory,
     Contract,
-    utils: { computeAddress, getContractAddress, keccak256, isAddress, getCreate2Address, defaultAbiCoder, isHexString, hexZeroPad },
+    utils: {
+        computeAddress,
+        getContractAddress,
+        keccak256,
+        isAddress,
+        getCreate2Address,
+        defaultAbiCoder,
+        isHexString,
+        hexZeroPad,
+        HDNode,
+    },
     constants: { AddressZero, HashZero },
     getDefaultProvider,
     BigNumber,
+    Wallet,
 } = ethers;
 const fs = require('fs');
 const path = require('path');
@@ -1041,6 +1052,25 @@ const verifyContractByName = (env, chain, name, contract, args, options = {}) =>
 
 const isConsensusChain = (chain) => chain.contracts.AxelarGateway?.connectionType !== 'amplifier';
 
+const deriveAccounts = async (mnemonic, quantity) => {
+    const hdNode = HDNode.fromMnemonic(mnemonic);
+    const accounts = [];
+
+    for (let i = 0; i < quantity; i++) {
+        const path = `m/44'/60'/0'/0/${i}`;
+        const derivedNode = hdNode.derivePath(path);
+
+        const wallet = new Wallet(derivedNode.privateKey);
+
+        accounts.push({
+            address: wallet.address,
+            privateKey: wallet.privateKey,
+        });
+    }
+
+    return accounts;
+};
+
 module.exports = {
     ...require('../common/utils'),
     deployCreate,
@@ -1081,4 +1111,5 @@ module.exports = {
     getQualifiedContractName,
     verifyContractByName,
     isConsensusChain,
+    deriveAccounts,
 };


### PR DESCRIPTION
This is useful when performing stress tests, so that multiple accounts can be funded before the load test script is executed to generate transactions in parallel from these accounts

https://axelarnetwork.atlassian.net/browse/AXE-9496