### PR TITLE
fix(xrpl): encoding of xrpl address for its

### DIFF
--- a/common/utils.js
+++ b/common/utils.js
@@ -629,6 +629,10 @@ function encodeITSDestination(config, destinationChain, destinationAddress) {
             validateParameters({ isValidStellarAddress: { destinationAddress } });
             return asciiToBytes(destinationAddress);
 
+        case 'xrpl':
+            // TODO: validate XRPL address format
+            return asciiToBytes(destinationAddress);
+
         case 'evm':
         case 'sui':
         default: // EVM, Sui, and other chains (return as-is)

--- a/common/utils.js
+++ b/common/utils.js
@@ -613,7 +613,7 @@ function asciiToBytes(string) {
 /**
  * Encodes the destination address for Interchain Token Service (ITS) transfers.
  * This function ensures proper encoding of the destination address based on the destination chain type.
- * Note: - Stellar addresses are converted to ASCII byte arrays.
+ * Note: - Stellar and XRPL addresses are converted to ASCII byte arrays.
  *       - EVM and Sui addresses are returned as-is (default behavior).
  *       - Additional encoding logic can be added for new chain types.
  */


### PR DESCRIPTION
Correctly encode `xrpl` destination address for evm to xrpl its

```sh
node evm/its.js interchain-transfer -n xrpl-evm xrpl 0xb...4f r9...uN 1 --gasValue 100000000000000000
```