### PR TITLE
chore(stellar): update stellar transaction timeout

### DIFF
--- a/stellar/utils.ts
+++ b/stellar/utils.ts
@@ -25,7 +25,7 @@ const ASSET_TYPE_NATIVE = 'native';
 
 const AXELAR_R2_BASE_URL = 'https://static.axelar.network';
 
-const TRANSACTION_TIMEOUT = 30;
+const TRANSACTION_TIMEOUT = 300;
 const RETRY_WAIT = 1000; // 1 sec
 const MAX_RETRIES = 30;
 


### PR DESCRIPTION

I noticed that using a timeout of 30 occasionally results in a `txTooLate` error.

```
stellar Error: Response: {
  "status": "ERROR",
  "hash": "856f5abe9753aab615eee19964a6499b1e3d34e82b15f2bf7eecdc86d727d58c",
  "latestLedger": 1527302,
  "latestLedgerCloseTime": "1750048716",
  "errorResult": {
    "_attributes": {
      "feeCharged": {
        "_value": "133417"
      },
      "result": {
        "_switch": {
          "name": "txTooLate",
          "value": -3
        }
      },
      "ext": {
        "_switch": 0
      }
    }
  }
}
```

`txTooLate (-3)` means the transaction’s maxTime (deadline) was already in the past when it was submitted. The timeout value `setTimeout(30)` was too short.

`.setTimeout(300)` is much safer, as it gives the transaction a 5-minute window before expiring.