### PR TITLE
chore: add gateway address check for voting verifier init

### DIFF
--- a/cosmwasm/utils.js
+++ b/cosmwasm/utils.js
@@ -409,7 +409,7 @@ const makeVotingVerifierInstantiateMsg = (config, options, contractConfig) => {
         throw new Error(`Missing or invalid VotingVerifier[${chainName}].sourceGatewayAddress in axelar info`);
     }
 
-    if (gatewayAddress && gatewayAddress !== sourceGatewayAddress) {
+    if (gatewayAddress !== undefined && gatewayAddress !== sourceGatewayAddress) {
         throw new Error(
             `Address mismatch for [${chainName}] in config:\n` +
             `- [${chainName}].contracts.AxelarGateway.address: ${gatewayAddress}\n` +


### PR DESCRIPTION
There's a case where the AxelarGateway address could be `undefined` during the integration test.
Adding an additional check to prevent this.
```
Expected contract address: axelar192qh24g4agt8969tu3uzdh2ate8hnsggxneq8kxglcd6a2nnd8hsrkhx4z
/home/runner/work/axelarate/axelarate/axelar-contract-deployments/cosmwasm/utils.js:413

        throw new Error(
Using code id: 8
              ^

Error: Address mismatch for [ganache-2] in config:
- [ganache-2].contracts.AxelarGateway.address: undefined
- axelar.contracts.VotingVerifier[ganache-2].sourceGatewayAddress: 0xaEf4a125C64544ED5cE84f3c9c896411Dc7e8089

    at Object.makeVotingVerifierInstantiateMsg [as makeInstantiateMsg] (/home/runner/work/axelarate/axelarate/axelar-contract-deployments/cosmwasm/utils.js:413:15)
    at instantiate (/home/runner/work/axelarate/axelarate/axelar-contract-deployments/cosmwasm/deploy-contract.js:60:51)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async uploadInstantiate (/home/runner/work/axelarate/axelarate/axelar-contract-deployments/cosmwasm/deploy-contract.js:70:5)
    at async mainProcessor (/home/runner/work/axelarate/axelarate/axelar-contract-deployments/cosmwasm/deploy-contract.js:99:5)
```
- https://github.com/axelarnetwork/axelarate/actions/runs/15885384911/job/44798957560