### PR TITLE
chore: migrate sui rpc node from publicnode to blastapi

### DIFF
--- a/axelar-chains-config/info/mainnet.json
+++ b/axelar-chains-config/info/mainnet.json
@@ -2516,7 +2516,7 @@
       "name": "Sui",
       "axelarId": "sui",
       "networkType": "mainnet",
-      "rpc": "https://sui-rpc.publicnode.com",
+      "rpc": "https://sui-mainnet.public.blastapi.io",
       "tokenSymbol": "SUI",
       "decimals": 9,
       "chainType": "sui",

--- a/axelar-chains-config/info/stagenet.json
+++ b/axelar-chains-config/info/stagenet.json
@@ -1648,7 +1648,7 @@
       "name": "Sui",
       "axelarId": "sui",
       "networkType": "testnet",
-      "rpc": "https://sui-testnet-rpc.publicnode.com",
+      "rpc": "https://sui-testnet.public.blastapi.io",
       "tokenSymbol": "SUI",
       "decimals": 9,
       "chainType": "sui",

--- a/axelar-chains-config/info/testnet.json
+++ b/axelar-chains-config/info/testnet.json
@@ -2371,7 +2371,7 @@
       "name": "Sui",
       "axelarId": "sui",
       "networkType": "testnet",
-      "rpc": "https://sui-testnet-rpc.publicnode.com",
+      "rpc": "https://sui-testnet.public.blastapi.io",
       "tokenSymbol": "SUI",
       "decimals": 9,
       "chainType": "sui",


### PR DESCRIPTION
Publicnode's Sui RPC has been unstable lately. Sometimes it's just slow to respond, other times it's returning http 500 errors.

This PR migrates Sui RPC from [Publicnode](https://sui-rpc.publicnode.com/) to [Blastapi](https://blastapi.io/public-api/sui). 

After one day of tests, Blastapi has so far remained stable and seems generally faster.