### PR TITLE
chore(solana): devnet deployment

### DIFF
--- a/axelar-chains-config/info/devnet-amplifier.json
+++ b/axelar-chains-config/info/devnet-amplifier.json
@@ -630,9 +630,9 @@
       "finality": "finalized",
       "approxFinalityWaitTime": 1
     },
-    "solana": {
+    "solana-2": {
       "name": "Solana",
-      "axelarId": "solana",
+      "axelarId": "solana-2",
       "rpc": "https://api.devnet.solana.com",
       "chainType": "svm",
       "decimals": 9,
@@ -1479,7 +1479,7 @@
           "codeId": 854,
           "address": "axelar1a4e4aful6hchmxd3cffurz24pca52wmt3pf78rsmzglzujnueqgq7eypgl"
         },
-        "solana": {
+        "solana-2": {
           "governanceAddress": "axelar1zlr7e5qf3sz7yf890rkh9tcnu87234k6k7ytd9",
           "serviceName": "validators",
           "sourceGatewayAddress": "gtwi5T9x6rTWPtuuz6DA7ia1VmH8bdazm9QfDdi6DVp",
@@ -1559,7 +1559,7 @@
           "codeId": 848,
           "address": "axelar1unafus3vpt7nawfzdjf7u26g2rl855lpkqussxmtl5r2njaz39mqrmyv7g"
         },
-        "solana": {
+        "solana-2": {
           "codeId": 1426,
           "address": "axelar1n8yyn0s7w90k4axwegxnp7593vhzn0ea2rnntqgzd4563qnpd7sqqjzqz3"
         },
@@ -1698,7 +1698,7 @@
           "domainSeparator": "0x974a372dccb2a81196b546432ad388af9cb49d0a5e4567d444c51ea63edb62f9",
           "address": "axelar1mfn6hevkpj54qkkdy2rznp2azgvqff0rt2cegmflxgqfm0nqx20q6aqnp5"
         },
-        "solana": {
+        "solana-2": {
           "governanceAddress": "axelar1zlr7e5qf3sz7yf890rkh9tcnu87234k6k7ytd9",
           "adminAddress": "axelar1zlr7e5qf3sz7yf890rkh9tcnu87234k6k7ytd9",
           "signingThreshold": [

--- a/axelar-chains-config/info/devnet-amplifier.json
+++ b/axelar-chains-config/info/devnet-amplifier.json
@@ -1492,7 +1492,7 @@
           "msgIdFormat": "base58_solana_tx_signature_and_event_index",
           "addressFormat": "base58_solana",
           "codeId": 1425,
-          "address": "axelar1dfvjms4w6vrrg9nsa6exy9rmyw0jx22uv90ftsgsgesv0a94tg0q5dctke"
+          "address": "axelar1lts2hclvjcm898r53st0shr2qrlg3p2t3s8a8dkn2sxek9jh204ql0k8f6"
         },
         "monad": {
           "governanceAddress": "axelar1zlr7e5qf3sz7yf890rkh9tcnu87234k6k7ytd9",
@@ -1561,7 +1561,7 @@
         },
         "solana-2": {
           "codeId": 1426,
-          "address": "axelar1n8yyn0s7w90k4axwegxnp7593vhzn0ea2rnntqgzd4563qnpd7sqqjzqz3"
+          "address": "axelar178fcq0m477wg7q0sf79v822ju8sarpzkm3f829dpf2xsmh8elcesceu79q"
         },
         "monad": {
           "codeId": 848,
@@ -1711,7 +1711,7 @@
           "keyType": "ecdsa",
           "domainSeparator": "0x25175689654ca91a6e0a80f7716bb966a67bb1162c9b89889eed7cfc4f03a6af",
           "codeId": 1427,
-          "address": "axelar12cmtt8pl2gay7wzwf2w6ft7nvnd6rsk0jm8ed43fg6tjzymdap6s5vkhfn"
+          "address": "axelar109wjfgdx63num4xyvzhrt2djuvd7zdu3zv4m0hcjvt55r0mvhszssxl8gg"
         },
         "monad": {
           "governanceAddress": "axelar1zlr7e5qf3sz7yf890rkh9tcnu87234k6k7ytd9",

--- a/axelar-chains-config/info/devnet-amplifier.json
+++ b/axelar-chains-config/info/devnet-amplifier.json
@@ -646,6 +646,24 @@
       "contracts": {
         "AxelarGateway": {
           "address": "gtwi5T9x6rTWPtuuz6DA7ia1VmH8bdazm9QfDdi6DVp"
+        },
+        "AxelarGasService": {
+          "address": "gasd4em72NAm7faq5dvjN5GkXE59dUkTThWmYDX95bK",
+          "configAccount": "GQ3Yde4evoph1qnogmb8VASZgqzXUxbVKx4oxnNbcZK9"
+        },
+        "InterchainGovernance": {
+          "address": "govmXi41LqLpRpKUd79wvAh9MmpoMzXk7gG4Sqmucx9",
+          "configAccount": "Bj7r2VugtM6odjLX9YdWtDsrZfSKLQFbfoc5hTL9qVhe",
+          "upgradeAuthority": "upaLVW6xkpeVB2g3h2KBqqFCNrWdnrAb6J6PRcqKtTe",
+          "governanceAddress": "axelar10d07y265gmmuvt4z0w9aw880jnsr700j7v9daj",
+          "governanceChain": "Axelarnet",
+          "minimumTimeDelay": 3600
+        },
+        "InterchainTokenService": {
+          "address": "itsqybuNsChBo3LgVhCWWnTJVJdoVTUJaodmqQcG6z7",
+          "configAccount": "8JYHzvaw7EQdck2xus8rqxELRSfD5iqi4aQx7UMFkswZ",
+          "upgradeAuthority": "upaLVW6xkpeVB2g3h2KBqqFCNrWdnrAb6J6PRcqKtTe",
+          "operator": "gopDbjxoihakmMHEbNqyh32Fk3az3Pcuv9jeEhDTr3k"
         }
       }
     },
@@ -1366,6 +1384,10 @@
         },
         "stellar-2025-q1": {
           "maxUintBits": 127,
+          "maxDecimalsWhenTruncating": 255
+        },
+        "solana-2": {
+          "maxUintBits": 64,
           "maxDecimalsWhenTruncating": 255
         },
         "storeCodeProposalId": "989",

--- a/axelar-chains-config/info/devnet-amplifier.json
+++ b/axelar-chains-config/info/devnet-amplifier.json
@@ -645,25 +645,34 @@
       },
       "contracts": {
         "AxelarGateway": {
-          "address": "gtwi5T9x6rTWPtuuz6DA7ia1VmH8bdazm9QfDdi6DVp"
+          "address": "gtwi5T9x6rTWPtuuz6DA7ia1VmH8bdazm9QfDdi6DVp",
+          "connectionType": "amplifier",
+          "domainSeparator": "0x25175689654ca91a6e0a80f7716bb966a67bb1162c9b89889eed7cfc4f03a6af",
+          "minimumRotationDelay": 0,
+          "operator": "gopDbjxoihakmMHEbNqyh32Fk3az3Pcuv9jeEhDTr3k",
+          "previousSignersRetention": 15,
+          "upgradeAuthority": "upaFrJck9TeFUXW62r2dDJtBxcMa4ArVjQ49sJeGDVw"
         },
         "AxelarGasService": {
           "address": "gasd4em72NAm7faq5dvjN5GkXE59dUkTThWmYDX95bK",
           "configAccount": "GQ3Yde4evoph1qnogmb8VASZgqzXUxbVKx4oxnNbcZK9"
+          "operator": "gopDbjxoihakmMHEbNqyh32Fk3az3Pcuv9jeEhDTr3k",
+          "upgradeAuthority": "upaFrJck9TeFUXW62r2dDJtBxcMa4ArVjQ49sJeGDVw"
         },
         "InterchainGovernance": {
           "address": "govmXi41LqLpRpKUd79wvAh9MmpoMzXk7gG4Sqmucx9",
           "configAccount": "Bj7r2VugtM6odjLX9YdWtDsrZfSKLQFbfoc5hTL9qVhe",
-          "upgradeAuthority": "upaFrJck9TeFUXW62r2dDJtBxcMa4ArVjQ49sJeGDVw",
           "governanceAddress": "axelar10d07y265gmmuvt4z0w9aw880jnsr700j7v9daj",
           "governanceChain": "Axelarnet",
-          "minimumTimeDelay": 3600
+          "minimumTimeDelay": 3600,
+          "operator": "gopDbjxoihakmMHEbNqyh32Fk3az3Pcuv9jeEhDTr3k"
+          "upgradeAuthority": "upaFrJck9TeFUXW62r2dDJtBxcMa4ArVjQ49sJeGDVw"
         },
         "InterchainTokenService": {
           "address": "itsqybuNsChBo3LgVhCWWnTJVJdoVTUJaodmqQcG6z7",
           "configAccount": "8JYHzvaw7EQdck2xus8rqxELRSfD5iqi4aQx7UMFkswZ",
-          "upgradeAuthority": "upaLVW6xkpeVB2g3h2KBqqFCNrWdnrAb6J6PRcqKtTe",
-          "operator": "gopDbjxoihakmMHEbNqyh32Fk3az3Pcuv9jeEhDTr3k"
+          "operator": "gopDbjxoihakmMHEbNqyh32Fk3az3Pcuv9jeEhDTr3k",
+          "upgradeAuthority": "upaFrJck9TeFUXW62r2dDJtBxcMa4ArVjQ49sJeGDVw"
         }
       }
     },

--- a/axelar-chains-config/info/devnet-amplifier.json
+++ b/axelar-chains-config/info/devnet-amplifier.json
@@ -655,7 +655,7 @@
         },
         "AxelarGasService": {
           "address": "gasd4em72NAm7faq5dvjN5GkXE59dUkTThWmYDX95bK",
-          "configAccount": "GQ3Yde4evoph1qnogmb8VASZgqzXUxbVKx4oxnNbcZK9"
+          "configAccount": "GQ3Yde4evoph1qnogmb8VASZgqzXUxbVKx4oxnNbcZK9",
           "operator": "gopDbjxoihakmMHEbNqyh32Fk3az3Pcuv9jeEhDTr3k",
           "upgradeAuthority": "upaFrJck9TeFUXW62r2dDJtBxcMa4ArVjQ49sJeGDVw"
         },
@@ -665,7 +665,7 @@
           "governanceAddress": "axelar10d07y265gmmuvt4z0w9aw880jnsr700j7v9daj",
           "governanceChain": "Axelarnet",
           "minimumTimeDelay": 3600,
-          "operator": "gopDbjxoihakmMHEbNqyh32Fk3az3Pcuv9jeEhDTr3k"
+          "operator": "gopDbjxoihakmMHEbNqyh32Fk3az3Pcuv9jeEhDTr3k",
           "upgradeAuthority": "upaFrJck9TeFUXW62r2dDJtBxcMa4ArVjQ49sJeGDVw"
         },
         "InterchainTokenService": {

--- a/axelar-chains-config/info/devnet-amplifier.json
+++ b/axelar-chains-config/info/devnet-amplifier.json
@@ -654,7 +654,7 @@
         "InterchainGovernance": {
           "address": "govmXi41LqLpRpKUd79wvAh9MmpoMzXk7gG4Sqmucx9",
           "configAccount": "Bj7r2VugtM6odjLX9YdWtDsrZfSKLQFbfoc5hTL9qVhe",
-          "upgradeAuthority": "upaLVW6xkpeVB2g3h2KBqqFCNrWdnrAb6J6PRcqKtTe",
+          "upgradeAuthority": "upaFrJck9TeFUXW62r2dDJtBxcMa4ArVjQ49sJeGDVw",
           "governanceAddress": "axelar10d07y265gmmuvt4z0w9aw880jnsr700j7v9daj",
           "governanceChain": "Axelarnet",
           "minimumTimeDelay": 3600

--- a/axelar-chains-config/info/devnet-amplifier.json
+++ b/axelar-chains-config/info/devnet-amplifier.json
@@ -643,7 +643,11 @@
         "name": "Solana Explorer",
         "url": "https://explorer.solana.com/?cluster=devnet"
       },
-      "contracts": {}
+      "contracts": {
+        "AxelarGateway": {
+          "address": "gtwi5T9x6rTWPtuuz6DA7ia1VmH8bdazm9QfDdi6DVp"
+        }
+      }
     },
     "stellar-2025-q1": {
       "name": "Stellar",
@@ -1384,7 +1388,7 @@
           "codeId": 854,
           "address": "axelar1252ahkw208d08ls64atp2pql4cnl9naxy7ahhq3lrthvq3spseys26l8xj"
         },
-        "lastUploadedCodeId": 854,
+        "lastUploadedCodeId": 1425,
         "eth-sepolia": {
           "governanceAddress": "axelar1zlr7e5qf3sz7yf890rkh9tcnu87234k6k7ytd9",
           "serviceName": "validators",
@@ -1477,18 +1481,18 @@
         },
         "solana": {
           "governanceAddress": "axelar1zlr7e5qf3sz7yf890rkh9tcnu87234k6k7ytd9",
-          "serviceName": "amplifier",
+          "serviceName": "validators",
           "sourceGatewayAddress": "gtwi5T9x6rTWPtuuz6DA7ia1VmH8bdazm9QfDdi6DVp",
           "votingThreshold": [
-            "51",
-            "100"
+            "6",
+            "10"
           ],
           "blockExpiry": 10,
           "confirmationHeight": 31,
           "msgIdFormat": "base58_solana_tx_signature_and_event_index",
           "addressFormat": "base58_solana",
-          "codeId": 57,
-          "address": ""
+          "codeId": 1425,
+          "address": "axelar1dfvjms4w6vrrg9nsa6exy9rmyw0jx22uv90ftsgsgesv0a94tg0q5dctke"
         },
         "monad": {
           "governanceAddress": "axelar1zlr7e5qf3sz7yf890rkh9tcnu87234k6k7ytd9",
@@ -1520,15 +1524,15 @@
           "codeId": 854,
           "address": "axelar1uypvvkd820cs4t6y47hqszawegwyrxaxr9ehpla74e98g0rezr5sw9lj4z"
         },
-        "storeCodeProposalId": "78",
-        "storeCodeProposalCodeHash": "d9412440820a51bc48bf41a77ae39cfb33101ddc6562323845627ea2042bf708"
+        "storeCodeProposalId": "1005",
+        "storeCodeProposalCodeHash": "52af1024c7548a724ec97728a1748bd1ce4ccb80bfb5c2a0ed7e57ee5ce5275c"
       },
       "Gateway": {
         "avalanche-fuji": {
           "codeId": 848,
           "address": "axelar1agyunp32jwynnkrf92wuvac2xa7cvgthtk5yr3wh7jypg59zjjqqsqf36s"
         },
-        "lastUploadedCodeId": 848,
+        "lastUploadedCodeId": 1426,
         "eth-sepolia": {
           "codeId": 848,
           "address": "axelar18zrymnzgdmutdjhqlfsslzy4yvzw8uylysjwqlq4uk4muq3qx30qde39qz"
@@ -1545,8 +1549,8 @@
           "codeId": 848,
           "address": "axelar1tk4h84tv0tatkeyc9hpum4dr30xpmt09g0wdsc7tgdp7mlutlheqrwcxjz"
         },
-        "storeCodeProposalId": "64",
-        "storeCodeProposalCodeHash": "2ba600ee0d162184c9387eaf6fad655f1d75db548f93e379f0565cb2042d856f",
+        "storeCodeProposalId": "1006",
+        "storeCodeProposalCodeHash": "31572a174679ebbf31ac63fdfb99d7a99199d873b4558d61b8cfdf5800174fee",
         "stellar-2025-q1": {
           "codeId": 848,
           "address": "axelar1tatg2n9gsq6vkkafm6pv8hsunr236wgdk4gdc7lw0hs2e3cnspmsw75rld"
@@ -1556,8 +1560,8 @@
           "address": "axelar1unafus3vpt7nawfzdjf7u26g2rl855lpkqussxmtl5r2njaz39mqrmyv7g"
         },
         "solana": {
-          "codeId": 58,
-          "address": ""
+          "codeId": 1426,
+          "address": "axelar1n8yyn0s7w90k4axwegxnp7593vhzn0ea2rnntqgzd4563qnpd7sqqjzqz3"
         },
         "monad": {
           "codeId": 848,
@@ -1600,7 +1604,7 @@
           "codeId": 855,
           "address": "axelar1p22kz5jr7a9ruu8ypg40smual0uagl64dwvz5xt042vu8fa7l7dsl3wx8q"
         },
-        "lastUploadedCodeId": 855,
+        "lastUploadedCodeId": 1427,
         "eth-sepolia": {
           "governanceAddress": "axelar1zlr7e5qf3sz7yf890rkh9tcnu87234k6k7ytd9",
           "adminAddress": "axelar1zlr7e5qf3sz7yf890rkh9tcnu87234k6k7ytd9",
@@ -1698,16 +1702,16 @@
           "governanceAddress": "axelar1zlr7e5qf3sz7yf890rkh9tcnu87234k6k7ytd9",
           "adminAddress": "axelar1zlr7e5qf3sz7yf890rkh9tcnu87234k6k7ytd9",
           "signingThreshold": [
-            "51",
-            "100"
+            "6",
+            "10"
           ],
-          "serviceName": "amplifier",
+          "serviceName": "validators",
           "verifierSetDiffThreshold": 0,
           "encoder": "solana",
           "keyType": "ecdsa",
-          "codeId": 59,
-          "domainSeparator": "0x98a0e9190ca7659c70ba1f84df95eeb0932224611ec553ee9dc709aa46ac08f6",
-          "address": ""
+          "domainSeparator": "0x25175689654ca91a6e0a80f7716bb966a67bb1162c9b89889eed7cfc4f03a6af",
+          "codeId": 1427,
+          "address": "axelar12cmtt8pl2gay7wzwf2w6ft7nvnd6rsk0jm8ed43fg6tjzymdap6s5vkhfn"
         },
         "monad": {
           "governanceAddress": "axelar1zlr7e5qf3sz7yf890rkh9tcnu87234k6k7ytd9",
@@ -1739,8 +1743,8 @@
           "domainSeparator": "0xde451736aa7e61c58baa7e02a0531c535a0dd8d3b5a04973d99336f34efad68b",
           "address": "axelar1xdg6lezehttusu8zfr5jnshn7d3k2jjzlmr43m6ssmxd048zjv6s4h5unj"
         },
-        "storeCodeProposalId": "82",
-        "storeCodeProposalCodeHash": "00428ef0483f103a6e1a5853c4b29466a83e5b180cc53a00d1ff9d022bc2f03a"
+        "storeCodeProposalId": "1007",
+        "storeCodeProposalCodeHash": "20c38aff9c725424cd71e7f85e357fb8a078954c11302f6d5e325060de9dac5c"
       },
       "XrplVotingVerifier": {
         "xrpl-dev": {

--- a/releases/cosmwasm/2025-07-Solana-GMP-DRAFT.md
+++ b/releases/cosmwasm/2025-07-Solana-GMP-DRAFT.md
@@ -108,7 +108,7 @@ ts-node cosmwasm/submit-proposal.js store \
   -c MultisigProver \
   -t "Upload MultisigProver contract for Solana" \
   -d "Upload MultisigProver contract for Solana integration" \
-  -a "$ARTIFACT_PATH/multisig_prover.wasm" \
+  -a "$ARTIFACT_PATH/solana_multisig_prover.wasm" \
   --deposit $DEPOSIT_VALUE \
   --instantiateAddresses $INIT_ADDRESSES
 ```
@@ -124,8 +124,8 @@ ts-node cosmwasm/submit-proposal.js store \
 | **Testnet**          | `axelar10d07y265gmmuvt4z0w9aw880jnsr700j7v9daj` | `axelar17qafmnc4hrfa96cq37wg5l68sxh354pj6eky35` |
 | **Mainnet**          | `axelar10d07y265gmmuvt4z0w9aw880jnsr700j7v9daj` | `axelar1pczf792wf3p3xssk4dmwfxrh6hcqnrjp70danj` |
 
-| Network              | `serviceName` | `votingThreshold` | `signingThreshold` | 
-| -------------------- | ------------- | ----------------- | ------------------ | 
+| Network              | `serviceName` | `votingThreshold` | `signingThreshold` |
+| -------------------- | ------------- | ----------------- | ------------------ |
 | **Devnet-amplifier** | `validators`  | `["6", "10"]`     | `["6", "10"]`      |
 | **Stagenet**         | `amplifier`   | `["51", "100"]`   | `["51", "100"]`    |
 | **Testnet**          | `amplifier`   | `["51", "100"]`   | `["51", "100"]`    |
@@ -193,12 +193,12 @@ ts-node ./cosmwasm/deploy-contract.js instantiate -c MultisigProver --fetchCodeI
 - Network-specific environment variables: These variables need to be updated by the network.
 
 ```bash
-VOTING_VERIFIER=$(cat "./axelar-chains-config/info/\"$ENV\".json" | jq ".axelar.contracts.VotingVerifier[\"$CHAIN\"].address" | tr -d '"')
-GATEWAY=$(cat "./axelar-chains-config/info/\"$ENV\".json" | jq ".axelar.contracts.Gateway[\"$CHAIN\"].address" | tr -d '"')
-MULTISIG_PROVER=$(cat "./axelar-chains-config/info/\"$ENV\".json" | jq ".axelar.contracts.MultisigProver[\"$CHAIN\"].address" | tr -d '"')
-MULTISIG=$(cat "./axelar-chains-config/info/\"$ENV\".json" | jq ".axelar.contracts.Multisig.address" | tr -d '"')
-REWARDS=$(cat "./axelar-chains-config/info/\"$ENV\".json" | jq ".axelar.contracts.Rewards.address" | tr -d '"')
-ROUTER=$(cat "./axelar-chains-config/info/\"$ENV\".json" | jq ".axelar.contracts.Router.address" | tr -d '"')
+VOTING_VERIFIER=$(cat "./axelar-chains-config/info/${ENV}.json" | jq ".axelar.contracts.VotingVerifier[\"$CHAIN\"].address" | tr -d '"')
+GATEWAY=$(cat "./axelar-chains-config/info/${ENV}.json" | jq ".axelar.contracts.Gateway[\"$CHAIN\"].address" | tr -d '"')
+MULTISIG_PROVER=$(cat "./axelar-chains-config/info/${ENV}.json" | jq ".axelar.contracts.MultisigProver[\"$CHAIN\"].address" | tr -d '"')
+MULTISIG=$(cat "./axelar-chains-config/info/${ENV}.json" | jq ".axelar.contracts.Multisig.address" | tr -d '"')
+REWARDS=$(cat "./axelar-chains-config/info/${ENV}.json" | jq ".axelar.contracts.Rewards.address" | tr -d '"')
+ROUTER=$(cat "./axelar-chains-config/info/${ENV}.json" | jq ".axelar.contracts.Router.address" | tr -d '"')
 ```
 
 - Gov proposal environment variables. Update these for each network
@@ -230,7 +230,7 @@ ts-node cosmwasm/submit-proposal.js execute \
     \"register_chain\": {
       \"chain\": \"$CHAIN\",
       \"gateway_address\": \"$GATEWAY\",
-      \"msg_id_format\": \"base58_tx_signature_and_log_index\"
+      \"msg_id_format\": \"base58_solana_tx_signature_and_event_index\"
       }
     }"
 ```
@@ -250,7 +250,7 @@ axelard q wasm contract-state smart $ROUTER "{\"chain_info\": \"$CHAIN\"}" --out
       "address": "axelar1jah3ac59xke2r266yjhh45tugzsvnlzsefyvx6jgp0msk6tp7vqqaktuz2"
     },
     "frozen_status": 0,
-    "msg_id_format": "base58_tx_signature_and_log_index"
+    "msg_id_format": "base58_solana_tx_signature_and_event_index"
   }
 }
 ```

--- a/releases/solana/2025-07-GMP-v1.0.0.md
+++ b/releases/solana/2025-07-GMP-v1.0.0.md
@@ -9,7 +9,7 @@
 
 | **Network**          | **Deployment Status** | **Date**         |
 | -------------------- | --------------------- | ---------------- |
-| **Devnet Amplifier** | Pending               | <DEPLOY_DATE>    |
+| **Devnet Amplifier** | Completed             | 2025-07-23       |
 | **Stagenet**         | Pending               | <DEPLOY_DATE>    |
 | **Testnet**          | Pending               | <DEPLOY_DATE>    |
 | **Mainnet**          | Pending               | <DEPLOY_DATE>    |
@@ -41,7 +41,7 @@ This is the v1.0.0 Solana GMP release, introducing General Message Passing (GMP)
 The $UPGRADE_AUTHORITY_KEYPAIR_PATH and other required contract role related required keys were pre-generated for each environment. Here's
 the current list:
 
-| Environment |    Gateway Operator    |                    Governance Operator                    | Upgrade authority | 
+| Environment |    Gateway Operator    |                    Governance Operator                    | Upgrade authority |
 | :---------: | :-----------------: | :-------------------------------------------: | :---------------------:|
 |   Devnet    |  `gopDbjxoihakmMHEbNqyh32Fk3az3Pcuv9jeEhDTr3k`   | `upaFrJck9TeFUXW62r2dDJtBxcMa4ArVjQ49sJeGDVw`|`goprHUTruHRTs2Lhmxg5zMwH8fR2wBfmn5LAEbdTmYv`  |
 |   Stagenet    |  |  | |
@@ -228,6 +228,8 @@ solana-verify verify-from-repo --remote --base-image $BASE_IMAGE --commit-hash $
 
 ### Initialization Steps
 
+The initialization steps can only be performed by the upgrade authority.
+
 1. Initialize Gateway:
 
 | Network              | `minimumRotationDelay` | `previousSignersRetention` |
@@ -251,7 +253,7 @@ This will query the `MultisigProver` for the `VerifierSet`. Thus, the Solana `Mu
 
 ```sh
 solana/solana-axelar-cli send gas-service init \
-  --upgrade-authority <CONFIG_AUTHORITY_BASE58_PUBKEY> \
+  --operator <GASE_SERVICE_OPERATOR_BASE58_PUBKEY> \
   --salt <SALT_STRING>
 ```
 
@@ -267,53 +269,73 @@ solana/solana-axelar-cli send governance init \
 
 ## Checklist
 
-The following checks should be performed after the rollout:
+The following check should be performed after the rollout. It will send a GMP message from Solana to itself through the Axelar network.
 
-### Pre-requisites
 
-1. Clone repository [solana-axelar-scripts](https://github.com/eigerco/solana-axelar-scripts)
+### Prerequisites
 
-2. Prepare private evm key
-
-```sh
-PRIVATE_EVM_HEX_KEY=<EVM_DEPLOYER_KEY>
-```
-
-### Verify Solana → EVM GMP call
-
-1. Send a GMP call from the cloned repository
+1. Build and deploy the `Memo` program (ensure variables have the proper values):
 
 ```sh
-cargo script testnet solana-to-evm 
---memo-to-send "3" 
---destination-evm-private-key-hex <PRIVATE_EVM_HEX_KEY> 
---destination-evm-chain avalanche-fuji
+pushd solana-axelar/
+
+solana-verify build --base-image $BASE_IMAGE --library-name axelar_solana_memo_program -- --no-default-features --features $ENV
+
+popd
+
+MEMO_PROGRAM_KEYPAIR_PATH=<path/to/memo_program_keypair.json>
+MEMO_PROGRAM_PATH="solana-axelar/target/deploy/axelar_solana_memo_program.so"
+
+solana program deploy --program-id $MEMO_PROGRAM_KEYPAIR_PATH --upgrade-authority $UPGRADE_AUTHORITY_KEYPAIR_PATH $MEMO_PROGRAM_PATH
+
 ```
 
-2. If everything went ok, similar info should be shown
+2. Initialize the `Memo` program:
+
+```
+solana/solana-axelar-cli send memo init
+```
+
+You should see the `Memo` program id and it's `Counter Account` address in the output, as in the example below. You're going to need them in the next steps.
+
+```
+------------------------------------------
+✅ Memo program (memPJFxP6H6bjEKpUSJ4KC7C4dKAfNE3xWrTpJBKDwN) initialization details:
+   Counter Account: 3kKbQ5zXpzeigQLcw82durTRdhnQU7AjfvFhpjbbC8W6
+------------------------------------------
+```
+
+### Verify GMP calls
+
+1. Build a `Memo` program payload:
 
 ```sh
-2025-07-10T10:39:45.903776Z  INFO solana_to_evm: script::cli::cmd::testnet::solana_interactions: solana tx sent signature=3DPaMSxdzL6UZx8jH5qbP3uPWA5iut1droRuhx9m3MxTM7CWyE2LrteiPYJr2ZLwV3yLGdJuqNXRsw1g22CivWGG devnet_url="https://explorer.solana.com/tx/3DPaMSxdzL6UZx8jH5qbP3uPWA5iut1droRuhx9m3MxTM7CWyE2LrteiPYJr2ZLwV3yLGdJuqNXRsw1g22CivWGG?cluster=devnet"
+GMP_PAYLOAD=$(solana/solana-axelar-cli misc build-axelar-message \
+    --accounts "3kKbQ5zXpzeigQLcw82durTRdhnQU7AjfvFhpjbbC8W6:false:true" \ # Replace with the proper Counter Account
+    --payload "48656C6C6F21") # "Hello!" in hex.
 ```
 
-3. Confirm message approval in [axelar devnet explorer](https://devnet-amplifier.axelarscan.io/gmp/search)
-
-
-### Verify EVM → Solana GMP Call
-
-1. Send a GMP call from the cloned repository
+2. Perform the `call-contract` to the `Memo` program using the payload:
 
 ```sh
-cargo script testnet evm-to-solana 
---memo-to-send "aaahello🐪" 
---source-evm-private-key-hex <PRIVATE_EVM_HEX_KEY> 
---source-evm-chain avalanche-fuji
+solana/solana-axelar-cli send gateway call-contract \
+    --destination-chain $CHAIN_ID \
+    --destination-address memPJFxP6H6bjEKpUSJ4KC7C4dKAfNE3xWrTpJBKDwN \ # Replace with proper Memo program id
+    --payload $GMP_PAYLOAD
 ```
 
-2. If everything went ok, similar info should be shown
+2. If everything went well, you should see the broadcast information similar to the one below:
 
 ```sh
-2025-07-10T10:39:45.903776Z  INFO solana_to_evm: script::cli::cmd::testnet::solana_interactions: solana tx sent signature=3DPaMSxdzL6UZx8jH5qbP3uPWA5iut1droRuhx9m3MxTM7CWyE2LrteiPYJr2ZLwV3yLGdJuqNXRsw1g22CivWGG devnet_url="https://explorer.solana.com/tx/3DPaMSxdzL6UZx8jH5qbP3uPWA5iut1droRuhx9m3MxTM7CWyE2LrteiPYJr2ZLwV3yLGdJuqNXRsw1g22CivWGG?cluster=devnet"
+Simulating transaction before sending...
+Simulation used 5012 compute units
+Transaction 1: 3xESUsYRvwDFM19yWSMPnmCWpbYCZHoqsHAnweBNosbegPzAQeTT9PsFfyUCKXhU8sprMW1V7dJwwoNDjpmk1yFD
+------------------------------------------
+✅ Solana Transaction successfully broadcast and confirmed!
+   Transaction Signature (ID): 3xESUsYRvwDFM19yWSMPnmCWpbYCZHoqsHAnweBNosbegPzAQeTT9PsFfyUCKXhU8sprMW1V7dJwwoNDjpmk1yFD
+   RPC Endpoint: https://api.devnet.solana.com
+   Explorer Link: https://explorer.solana.com/tx/3xESUsYRvwDFM19yWSMPnmCWpbYCZHoqsHAnweBNosbegPzAQeTT9PsFfyUCKXhU8sprMW1V7dJwwoNDjpmk1yFD?cluster=devnet
+------------------------------------------
 ```
 
-3. Confirm message approval in [axelar devnet explorer](https://devnet-amplifier.axelarscan.io/gmp/search)
+3. Confirm message approval and execution on Axelarscan.

--- a/releases/solana/2025-07-GMP-v1.0.0.md
+++ b/releases/solana/2025-07-GMP-v1.0.0.md
@@ -25,7 +25,7 @@
 | **Devnet Amplifier** |  Multicall  | **Devnet**             | `mce2hozrGNRHP5qxScDvYyZ1TzhiH8tLLKxwo8DDNQT` |
 
 
-- [GitHub Release](<GITHUB_RELEASE_URL>)
+- [GitHub Release](https://github.com/eigerco/solana-axelar/releases/tag/v1.0.0)
 
 ## Background
 

--- a/releases/solana/2025-07-GMP-v1.0.0.md
+++ b/releases/solana/2025-07-GMP-v1.0.0.md
@@ -24,9 +24,6 @@
 | **Devnet Amplifier** | Governance  | **Devnet**             | `govmXi41LqLpRpKUd79wvAh9MmpoMzXk7gG4Sqmucx9` |
 | **Devnet Amplifier** |  Multicall  | **Devnet**             | `mce2hozrGNRHP5qxScDvYyZ1TzhiH8tLLKxwo8DDNQT` |
 
-* Deployer and upgrade authority is  `upaLVW6xkpeVB2g3h2KBqqFCNrWdnrAb6J6PRcqKtTe`
-* Operator role in contracts is `gopDbjxoihakmMHEbNqyh32Fk3az3Pcuv9jeEhDTr3k`
-
 
 - [GitHub Release](<GITHUB_RELEASE_URL>)
 
@@ -43,7 +40,7 @@ the current list:
 
 | Environment |    Gateway Operator    |                    Governance Operator                    | Upgrade authority |
 | :---------: | :-----------------: | :-------------------------------------------: | :---------------------:|
-|   Devnet    |  `gopDbjxoihakmMHEbNqyh32Fk3az3Pcuv9jeEhDTr3k`   | `upaFrJck9TeFUXW62r2dDJtBxcMa4ArVjQ49sJeGDVw`|`goprHUTruHRTs2Lhmxg5zMwH8fR2wBfmn5LAEbdTmYv`  |
+|   Devnet    |  `gopDbjxoihakmMHEbNqyh32Fk3az3Pcuv9jeEhDTr3k`   | `gopDbjxoihakmMHEbNqyh32Fk3az3Pcuv9jeEhDTr3k`|`upaFrJck9TeFUXW62r2dDJtBxcMa4ArVjQ49sJeGDVw`  |
 |   Stagenet    |  |  | |
 |   Testnet    |    |  | |
 |   Mainnet    |    |  | |

--- a/releases/solana/2025-07-GMP-v1.0.0.md
+++ b/releases/solana/2025-07-GMP-v1.0.0.md
@@ -38,13 +38,12 @@ This is the v1.0.0 Solana GMP release, introducing General Message Passing (GMP)
 The $UPGRADE_AUTHORITY_KEYPAIR_PATH and other required contract role related required keys were pre-generated for each environment. Here's
 the current list:
 
-| Environment |    Gateway Operator    |                    Governance Operator                    | Upgrade authority |
-| :---------: | :-----------------: | :-------------------------------------------: | :---------------------:|
-|   Devnet    |  `gopDbjxoihakmMHEbNqyh32Fk3az3Pcuv9jeEhDTr3k`   | `gopDbjxoihakmMHEbNqyh32Fk3az3Pcuv9jeEhDTr3k`|`upaFrJck9TeFUXW62r2dDJtBxcMa4ArVjQ49sJeGDVw`  |
-|   Stagenet    |  |  | |
-|   Testnet    |    |  | |
-|   Mainnet    |    |  | |
-
+| Environment | Gateway Operator | Governance Operator | GasService Operator | Upgrade authority |
+| :---------: | :--------------: | :-----------------: | :-----------------: | :---------------: |
+|   Devnet    | `gopDbjxoihakmMHEbNqyh32Fk3az3Pcuv9jeEhDTr3k` | `gopDbjxoihakmMHEbNqyh32Fk3az3Pcuv9jeEhDTr3k` | `gopDbjxoihakmMHEbNqyh32Fk3az3Pcuv9jeEhDTr3k` | `upaFrJck9TeFUXW62r2dDJtBxcMa4ArVjQ49sJeGDVw` |
+|   Stagenet  | | | | |
+|   Testnet   | | | | |
+|   Mainnet   | | | | |
 
 Access to private keys are secured and only maintainers have access to them.
 

--- a/releases/solana/2025-07-ITS-v1.0.0.md
+++ b/releases/solana/2025-07-ITS-v1.0.0.md
@@ -106,6 +106,8 @@ solana-keygen new
 
 In this case the wallet needs to be funded with real `SOL`.
 
+5. The [`spl-token`](https://crates.io/crates/spl-token-cli) CLI is installed.
+
 ### Deployment Steps
 
 1. Declare enviroment variables:
@@ -183,20 +185,7 @@ node evm/its.js set-trusted-chains ${CHAIN_ID} hub -n all
 
 The following checks should be performed after the rollout.
 
-### Execute Command
-
-The GMP call needs to be routed via Amplifier and proof submited to the gateway before the `execute` call.
-
 ### Solana to EVM
-
-- Note: The final execute step of the GMP call on EVM can be performed via:
-
-```sh
-# Change PRIVATE_KEY in .env to EVM
-PRIVATE_KEY=<EVM_DEPLOYER_KEY>
-
-node evm/gateway.js -n <DESTINATION_CHAIN> --action execute --payload <PAYLOAD> --sourceChain axelar --sourceAddress <ITS_HUB_ADDRESS> --messageId <MESSAGE_ID> --destination <DESTINATION_ADDRESS>
-```
 
 1. Deploy Native Interchain Token:
 
@@ -230,6 +219,9 @@ solana/solana-axelar-cli send its interchain-transfer \
 
 3. Deploy Remote Canonical Token:
 
+> [!NOTE]
+> Make sure you have an existing token with an associated Metaplex metadata account. You can create one using the [metaplex-foundation CLI](https://github.com/metaplex-foundation/cli).
+
 ```sh
 solana/solana-axelar-cli send its register-canonical-interchain-token \
   --mint <MINT_ADDRESS> \
@@ -257,16 +249,21 @@ solana/solana-axelar-cli send its interchain-transfer \
 
 ### EVM to Solana
 
-- Note: The final execute step of the GMP call on Solana can be performed via:
+> [!TIP]
+> You can get the mint address of an interchain token deployed on Solana using the `token_id` via:
+>
+> ```sh
+> solana/solana-axelar-cli query its token-manager <TOKEN_ID>
+> ```
 
-```sh
-solana/solana-axelar-cli send gateway execute \
-  --source-chain <SOURCE_CHAIN> \
-  --message-id <MESSAGE_ID> \
-  --source-address <SOURCE_ADDRESS> \
-  --payload <PAYLOAD> \
-  --destination <DESTINATION_ADDRESS>
-```
+> [!IMPORTANT]
+> When transferring tokens to Solana, the destination address should be a token account and not a wallet address. You can create a token account associated with a mint via:
+>
+> ```sh
+> spl-token create-account --fee-payer <PAYER_KEYPAIR> --owner <WALLET_ADDRESS> <MINT_ADDRESS>
+> ```
+>
+> When `--fee-payer` and/or `--owner` are omitted, the default Solana CLI keypair is used.
 
 1. Deploy Native Interchain Token:
 

--- a/releases/solana/2025-07-ITS-v1.0.0.md
+++ b/releases/solana/2025-07-ITS-v1.0.0.md
@@ -20,10 +20,6 @@
 | ---------------------- | ---------------------- | --------------------------------------------- |
 | ***Devnet Amplifier*** |     ***Devnet***       | `itsqybuNsChBo3LgVhCWWnTJVJdoVTUJaodmqQcG6z7` |
 
-* Deployer and upgrade authority is  `upaLVW6xkpeVB2g3h2KBqqFCNrWdnrAb6J6PRcqKtTe`
-
-* Operator role in contracts is `gopDbjxoihakmMHEbNqyh32Fk3az3Pcuv9jeEhDTr3k`
-
 - [Release](<GITHUB_RELEASE_URL>)
 
 ## Background
@@ -38,9 +34,9 @@ Ensure that [Solana GMP](./2025-05-GMP-v1.0.0.md) is deployed first.
 
 The $UPGRADE_AUTHORITY_KEYPAIR_PATH and other required contract role related required keys were pre-generated for each environment. Here's the current list for ITS:
 
-| Environment |                Upgrade authority                  |                    ConfigAuthority Operator (Gas service)                    |
+| Environment |                Upgrade authority                  |                    Operator                    |
 | :---------: | :------------------------------------: | :-------------------------------------------: |
-|   Devnet    |     `upaFrJck9TeFUXW62r2dDJtBxcMa4ArVjQ49sJeGDVw`                 | `cauVprMFFiqMGokt5cUQt3wmXRMj5mwtUXqMJVwBEah`  |
+|   Devnet    |     `upaFrJck9TeFUXW62r2dDJtBxcMa4ArVjQ49sJeGDVw`                 | `gopDbjxoihakmMHEbNqyh32Fk3az3Pcuv9jeEhDTr3k`  |
 |   Stagenet    |  |  |
 |   Testnet    |  |  |
 |   Mainnet    |  |  |

--- a/releases/solana/2025-07-ITS-v1.0.0.md
+++ b/releases/solana/2025-07-ITS-v1.0.0.md
@@ -20,7 +20,7 @@
 | ---------------------- | ---------------------- | --------------------------------------------- |
 | ***Devnet Amplifier*** |     ***Devnet***       | `itsqybuNsChBo3LgVhCWWnTJVJdoVTUJaodmqQcG6z7` |
 
-- [Release](<GITHUB_RELEASE_URL>)
+- [GitHub Release](https://github.com/eigerco/solana-axelar/releases/tag/v1.0.0)
 
 ## Background
 

--- a/releases/solana/2025-07-ITS-v1.0.0.md
+++ b/releases/solana/2025-07-ITS-v1.0.0.md
@@ -213,7 +213,6 @@ solana/solana-axelar-cli send its interchain-transfer \
   --destination-address <DESTINATION_ADDRESS> \
   --amount <AMOUNT> \
   --mint <MINT_ADDRESS> \
-  --token-program <TOKEN_PROGRAM> \
   --gas-value <GAS_VALUE>
 ```
 
@@ -224,8 +223,7 @@ solana/solana-axelar-cli send its interchain-transfer \
 
 ```sh
 solana/solana-axelar-cli send its register-canonical-interchain-token \
-  --mint <MINT_ADDRESS> \
-  --token-program <TOKEN_PROGRAM>
+  --mint <MINT_ADDRESS>
 
 solana/solana-axelar-cli send its deploy-remote-canonical-interchain-token \
   --mint <MINT_ADDRESS> \
@@ -243,7 +241,6 @@ solana/solana-axelar-cli send its interchain-transfer \
   --destination-address <DESTINATION_ADDRESS> \
   --amount <AMOUNT> \
   --mint <MINT_ADDRESS> \
-  --token-program <TOKEN_PROGRAM> \
   --gas-value <GAS_VALUE>
 ```
 

--- a/releases/solana/2025-07-ITS-v1.0.0.md
+++ b/releases/solana/2025-07-ITS-v1.0.0.md
@@ -9,7 +9,7 @@
 
 | **Network**          | **Deployment Status** | **Date**         |
 | -------------------- | --------------------- | ---------------- |
-| **Devnet Amplifier** | Pending               | <DEPLOY_DATE>    |
+| **Devnet Amplifier** | Completed             | 2025-07-23       |
 | **Stagenet**         | Pending               | <DEPLOY_DATE>    |
 | **Testnet**          | Pending               | <DEPLOY_DATE>    |
 | **Mainnet**          | Pending               | <DEPLOY_DATE>    |
@@ -144,6 +144,7 @@ ITS hub contract configuration in `axelar-chains-config/info/<devnet-amplifier|s
     }
   }
 }
+```
 
 
 - For mainnet, add a community post for the proposal.
@@ -152,7 +153,7 @@ ITS hub contract configuration in `axelar-chains-config/info/<devnet-amplifier|s
 node cosmwasm/submit-proposal.js \
     its-hub-register-chains "solana" \
     -t "Register solana on ITS Hub" \
-    -d "Register solana on ITS Hub" 
+    -d "Register solana on ITS Hub"
 ```
 
 5. Set up trusted chains on Solana:
@@ -175,7 +176,7 @@ solana/solana-axelar-cli send its set-trusted-chain <CHAIN_NAME>
 # Set PRIVATE_KEY in .env
 PRIVATE_KEY=<EVM_DEPLOYER_KEY>
 
-node evm/its.js trusted-address -n all solana
+node evm/its.js set-trusted-chains ${CHAIN_ID} hub -n all
 ```
 
 ## Checklist

--- a/releases/solana/2025-07-ITS-v1.0.0.md
+++ b/releases/solana/2025-07-ITS-v1.0.0.md
@@ -212,7 +212,6 @@ solana/solana-axelar-cli send its interchain-transfer \
   --destination-chain <DESTINATION_CHAIN_NAME> \
   --destination-address <DESTINATION_ADDRESS> \
   --amount <AMOUNT> \
-  --mint <MINT_ADDRESS> \
   --gas-value <GAS_VALUE>
 ```
 
@@ -240,7 +239,6 @@ solana/solana-axelar-cli send its interchain-transfer \
   --destination-chain <DESTINATION_CHAIN_NAME> \
   --destination-address <DESTINATION_ADDRESS> \
   --amount <AMOUNT> \
-  --mint <MINT_ADDRESS> \
   --gas-value <GAS_VALUE>
 ```
 

--- a/solana/Cargo.lock
+++ b/solana/Cargo.lock
@@ -719,6 +719,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "axelar-solana-memo-program"
+version = "0.1.0"
+source = "git+https://github.com/eigerco/solana-axelar.git?rev=3896176#38961762ed0dba80875697203548f5d744976eaf"
+dependencies = [
+ "axelar-executable",
+ "axelar-solana-encoding",
+ "axelar-solana-gateway",
+ "axelar-solana-its",
+ "borsh 1.5.7",
+ "mpl-token-metadata",
+ "program-utils",
+ "solana-program",
+]
+
+[[package]]
 name = "axelar-wasm-std"
 version = "1.0.0"
 source = "git+https://github.com/axelarnetwork/axelar-amplifier.git?rev=voting-verifier-v1.1.0#17792515ed9953ce6bd6ceabe59d2febe5eab2e7"
@@ -5345,6 +5360,7 @@ dependencies = [
  "axelar-solana-gateway",
  "axelar-solana-governance",
  "axelar-solana-its",
+ "axelar-solana-memo-program",
  "axelar-wasm-std",
  "base64 0.22.1",
  "bincode 2.0.1",

--- a/solana/Cargo.toml
+++ b/solana/Cargo.toml
@@ -7,6 +7,9 @@ edition = "2024"
 axelar-solana-gateway = { git = "https://github.com/eigerco/solana-axelar.git", rev = "3896176", features = [
     "no-entrypoint",
 ], default-features = false }
+axelar-solana-memo-program = { git = "https://github.com/eigerco/solana-axelar.git", rev = "3896176", features = [
+    "no-entrypoint",
+], default-features = false }
 axelar-solana-gas-service = { git = "https://github.com/eigerco/solana-axelar.git", rev = "3896176", features = [
     "no-entrypoint",
 ], default-features = false }
@@ -145,6 +148,7 @@ devnet-amplifier = [
     "axelar-solana-gateway/devnet-amplifier",
     "axelar-solana-governance/devnet-amplifier",
     "axelar-solana-its/devnet-amplifier",
+    "axelar-solana-memo-program/devnet-amplifier",
     "gateway-event-stack/devnet-amplifier",
     "its-instruction-builder/devnet-amplifier",
 ]
@@ -154,6 +158,7 @@ stagenet = [
     "axelar-solana-gateway/stagenet",
     "axelar-solana-governance/stagenet",
     "axelar-solana-its/stagenet",
+    "axelar-solana-memo-program/stagenet",
     "gateway-event-stack/stagenet",
     "its-instruction-builder/stagenet",
 ]
@@ -163,6 +168,7 @@ testnet = [
     "axelar-solana-gateway/testnet",
     "axelar-solana-governance/testnet",
     "axelar-solana-its/testnet",
+    "axelar-solana-memo-program/testnet",
     "gateway-event-stack/testnet",
     "its-instruction-builder/testnet",
 ]
@@ -172,6 +178,7 @@ mainnet = [
     "axelar-solana-gateway/mainnet",
     "axelar-solana-governance/mainnet",
     "axelar-solana-its/mainnet",
+    "axelar-solana-memo-program/mainnet",
     "gateway-event-stack/mainnet",
     "its-instruction-builder/mainnet",
 ]

--- a/solana/src/gas_service.rs
+++ b/solana/src/gas_service.rs
@@ -6,8 +6,8 @@ use solana_sdk::transaction::Transaction as SolanaTransaction;
 use crate::config::Config;
 use crate::types::{SerializableSolanaTransaction, SolanaTransactionParams};
 use crate::utils::{
-    ADDRESS_KEY, CHAINS_KEY, CONFIG_ACCOUNT_KEY, CONTRACTS_KEY, GAS_SERVICE_KEY,
-    fetch_latest_blockhash, read_json_file_from_path, write_json_to_file_path,
+    fetch_latest_blockhash, read_json_file_from_path, write_json_to_file_path, ADDRESS_KEY,
+    CHAINS_KEY, CONFIG_ACCOUNT_KEY, CONTRACTS_KEY, GAS_SERVICE_KEY, OPERATOR_KEY,
 };
 
 #[derive(Subcommand, Debug)]
@@ -84,7 +84,9 @@ fn init(
     let mut chains_info: serde_json::Value = read_json_file_from_path(&config.chains_info_file)?;
     chains_info[CHAINS_KEY][&config.chain_id][CONTRACTS_KEY][GAS_SERVICE_KEY] = serde_json::json!({
         ADDRESS_KEY: axelar_solana_gas_service::id().to_string(),
+        OPERATOR_KEY: init_args.operator.to_string(),
         CONFIG_ACCOUNT_KEY: config_pda.to_string(),
+        UPGRADE_AUTHORITY_KEY: fee_payer.to_string(),
     });
 
     write_json_to_file_path(&chains_info, &config.chains_info_file)?;

--- a/solana/src/gas_service.rs
+++ b/solana/src/gas_service.rs
@@ -6,7 +6,7 @@ use solana_sdk::transaction::Transaction as SolanaTransaction;
 use crate::config::Config;
 use crate::types::{SerializableSolanaTransaction, SolanaTransactionParams};
 use crate::utils::{
-    ADDRESS_KEY, CHAINS_KEY, CONFIG_ACCOUNT_KEY, CONTRACTS_KEY, GAS_SERVICE_KEY, SOLANA_CHAIN_KEY,
+    ADDRESS_KEY, CHAINS_KEY, CONFIG_ACCOUNT_KEY, CONTRACTS_KEY, GAS_SERVICE_KEY,
     fetch_latest_blockhash, read_json_file_from_path, write_json_to_file_path,
 };
 
@@ -18,10 +18,10 @@ pub(crate) enum Commands {
 
 #[derive(Parser, Debug)]
 pub(crate) struct InitArgs {
-    /// The account to set as authority of the AxelarGasService program. This account will be able
+    /// The account to set as operator of the AxelarGasService program. This account will be able
     /// to withdraw funds from the AxelarGasService program and update the configuration.
     #[clap(short, long)]
-    authority: Pubkey,
+    operator: Pubkey,
 
     /// The salt used to derive the config PDA. This should be a unique value for each deployment.
     #[clap(short, long)]
@@ -79,10 +79,10 @@ fn init(
     let program_id = axelar_solana_gas_service::id();
     let salt_hash = solana_sdk::keccak::hashv(&[init_args.salt.as_bytes()]).0;
     let (config_pda, _bump) =
-        axelar_solana_gas_service::get_config_pda(&program_id, &salt_hash, &init_args.authority);
+        axelar_solana_gas_service::get_config_pda(&program_id, &salt_hash, &init_args.operator);
 
     let mut chains_info: serde_json::Value = read_json_file_from_path(&config.chains_info_file)?;
-    chains_info[CHAINS_KEY][SOLANA_CHAIN_KEY][CONTRACTS_KEY][GAS_SERVICE_KEY] = serde_json::json!({
+    chains_info[CHAINS_KEY][&config.chain_id][CONTRACTS_KEY][GAS_SERVICE_KEY] = serde_json::json!({
         ADDRESS_KEY: axelar_solana_gas_service::id().to_string(),
         CONFIG_ACCOUNT_KEY: config_pda.to_string(),
     });
@@ -92,7 +92,7 @@ fn init(
     Ok(vec![axelar_solana_gas_service::instructions::init_config(
         &program_id,
         fee_payer,
-        &init_args.authority,
+        &init_args.operator,
         &config_pda,
         salt_hash,
     )?])

--- a/solana/src/gateway.rs
+++ b/solana/src/gateway.rs
@@ -9,9 +9,9 @@ use axelar_solana_encoding::types::messages::{CrossChainId, Message, Messages};
 use axelar_solana_encoding::types::payload::Payload;
 use axelar_solana_encoding::types::pubkey::{PublicKey, Signature};
 use axelar_solana_encoding::types::verifier_set::VerifierSet;
+use axelar_solana_gateway::BytemuckedPda;
 use axelar_solana_gateway::state::config::RotationDelaySecs;
 use axelar_solana_gateway::state::incoming_message::command_id;
-use axelar_solana_gateway::BytemuckedPda;
 use clap::{ArgGroup, Args, Parser, Subcommand};
 use cosmrs::proto::cosmwasm::wasm::v1::query_client;
 use eyre::eyre;
@@ -31,17 +31,17 @@ use solana_sdk::transaction::Transaction as SolanaTransaction;
 use solana_transaction_status::UiTransactionEncoding;
 
 use crate::config::Config;
-use crate::multisig_prover_types::msg::ProofStatus;
 use crate::multisig_prover_types::Uint128Extensions;
+use crate::multisig_prover_types::msg::ProofStatus;
 use crate::types::{
     LocalSigner, SerializableSolanaTransaction, SerializeableVerifierSet, SigningVerifierSet,
     SolanaTransactionParams,
 };
 use crate::utils::{
-    self, domain_separator, fetch_latest_blockhash, read_json_file_from_path,
-    write_json_to_file_path, ADDRESS_KEY, AXELAR_KEY, CHAINS_KEY, CONTRACTS_KEY,
-    DOMAIN_SEPARATOR_KEY, GATEWAY_KEY, GRPC_KEY, MINIMUM_ROTATION_DELAY_KEY, MULTISIG_PROVER_KEY,
-    OPERATOR_KEY, PREVIOUS_SIGNERS_RETENTION_KEY, UPGRADE_AUTHORITY_KEY,
+    self, ADDRESS_KEY, AXELAR_KEY, CHAINS_KEY, CONTRACTS_KEY, DOMAIN_SEPARATOR_KEY, GATEWAY_KEY,
+    GRPC_KEY, MINIMUM_ROTATION_DELAY_KEY, MULTISIG_PROVER_KEY, OPERATOR_KEY,
+    PREVIOUS_SIGNERS_RETENTION_KEY, UPGRADE_AUTHORITY_KEY, domain_separator,
+    fetch_latest_blockhash, read_json_file_from_path, write_json_to_file_path,
 };
 
 #[derive(Subcommand, Debug)]
@@ -493,7 +493,6 @@ async fn init(
     )
     .await?;
     let domain_separator = domain_separator(&chains_info, config.network_type, &config.chain_id)?;
-    println!("{}", hex::encode(&domain_separator));
     let verifier_set_hash = axelar_solana_encoding::types::verifier_set::verifier_set_hash::<
         NativeHasher,
     >(&verifier_set, &domain_separator)?;

--- a/solana/src/gateway.rs
+++ b/solana/src/gateway.rs
@@ -492,7 +492,8 @@ async fn init(
         &chains_info,
     )
     .await?;
-    let domain_separator = domain_separator(&chains_info, config.network_type)?;
+    let domain_separator = domain_separator(&chains_info, config.network_type, &config.chain_id)?;
+    println!("{}", hex::encode(&domain_separator));
     let verifier_set_hash = axelar_solana_encoding::types::verifier_set::verifier_set_hash::<
         NativeHasher,
     >(&verifier_set, &domain_separator)?;
@@ -569,7 +570,7 @@ fn approve(
     let mut instructions = vec![];
     let chains_info: serde_json::Value = read_json_file_from_path(&config.chains_info_file)?;
     let signer_set = build_signing_verifier_set(approve_args.signer.clone(), approve_args.nonce);
-    let domain_separator = domain_separator(&chains_info, config.network_type)?;
+    let domain_separator = domain_separator(&chains_info, config.network_type, &config.chain_id)?;
     let payload_bytes = hex::decode(
         approve_args
             .payload
@@ -642,7 +643,7 @@ async fn rotate(
         &chains_info,
     )
     .await?;
-    let domain_separator = domain_separator(&chains_info, config.network_type)?;
+    let domain_separator = domain_separator(&chains_info, config.network_type, &config.chain_id)?;
     let verifier_set_hash = axelar_solana_encoding::types::verifier_set::verifier_set_hash::<
         NativeHasher,
     >(&signer_set.verifier_set(), &domain_separator)?;

--- a/solana/src/governance.rs
+++ b/solana/src/governance.rs
@@ -8,12 +8,11 @@ use solana_sdk::transaction::Transaction as SolanaTransaction;
 
 use crate::config::Config;
 use crate::types::{SerializableSolanaTransaction, SolanaTransactionParams};
-use crate::utils::SOLANA_CHAIN_KEY;
 use crate::utils::{
+    ADDRESS_KEY, CHAINS_KEY, CONFIG_ACCOUNT_KEY, CONTRACTS_KEY, GOVERNANCE_ADDRESS_KEY,
+    GOVERNANCE_CHAIN_KEY, GOVERNANCE_KEY, MINIMUM_PROPOSAL_ETA_DELAY_KEY, UPGRADE_AUTHORITY_KEY,
     fetch_latest_blockhash, parse_account_meta_string, read_json_file_from_path,
-    write_json_to_file_path, ADDRESS_KEY, CHAINS_KEY, CONFIG_ACCOUNT_KEY, CONTRACTS_KEY,
-    GOVERNANCE_ADDRESS_KEY, GOVERNANCE_CHAIN_KEY, GOVERNANCE_KEY, MINIMUM_PROPOSAL_ETA_DELAY_KEY,
-    UPGRADE_AUTHORITY_KEY,
+    write_json_to_file_path,
 };
 
 #[derive(Subcommand, Debug)]
@@ -31,19 +30,19 @@ pub(crate) enum Commands {
 #[derive(Args, Debug)]
 pub(crate) struct InitArgs {
     /// The name of the chain in charge of the governance
-    #[clap(short, long)]
+    #[clap(long)]
     governance_chain: String,
 
     /// The address of the governance contract on the governance chain
-    #[clap(short, long)]
+    #[clap(long)]
     governance_address: String,
 
     /// Minimum value (in seconds) for a proposal ETA
-    #[clap(short, long)]
+    #[clap(long)]
     minimum_proposal_eta_delay: u32,
 
     /// The account to receive the operator role on the Interchain Governance program on Solana
-    #[clap(short, long)]
+    #[clap(long)]
     operator: Pubkey,
 }
 
@@ -169,7 +168,7 @@ fn init(
     );
 
     let mut chains_info: serde_json::Value = read_json_file_from_path(&config.chains_info_file)?;
-    chains_info[CHAINS_KEY][SOLANA_CHAIN_KEY][CONTRACTS_KEY][GOVERNANCE_KEY] = serde_json::json!({
+    chains_info[CHAINS_KEY][&config.chain_id][CONTRACTS_KEY][GOVERNANCE_KEY] = serde_json::json!({
         ADDRESS_KEY: axelar_solana_governance::id().to_string(),
         CONFIG_ACCOUNT_KEY: config_pda.to_string(),
         UPGRADE_AUTHORITY_KEY: fee_payer.to_string(),
@@ -180,9 +179,11 @@ fn init(
 
     write_json_to_file_path(&chains_info, &config.chains_info_file)?;
 
-    Ok(vec![IxBuilder::new()
-        .initialize_config(fee_payer, config_pda, governance_config)
-        .build()])
+    Ok(vec![
+        IxBuilder::new()
+            .initialize_config(fee_payer, config_pda, governance_config)
+            .build(),
+    ])
 }
 
 fn execute_proposal(
@@ -233,7 +234,9 @@ fn execute_operator_proposal(
         calldata_bytes,
     );
 
-    Ok(vec![builder
-        .execute_operator_proposal(fee_payer, config_pda, &args.operator)
-        .build()])
+    Ok(vec![
+        builder
+            .execute_operator_proposal(fee_payer, config_pda, &args.operator)
+            .build(),
+    ])
 }

--- a/solana/src/governance.rs
+++ b/solana/src/governance.rs
@@ -8,11 +8,12 @@ use solana_sdk::transaction::Transaction as SolanaTransaction;
 
 use crate::config::Config;
 use crate::types::{SerializableSolanaTransaction, SolanaTransactionParams};
+use crate::utils::OPERATOR_KEY;
 use crate::utils::{
-    ADDRESS_KEY, CHAINS_KEY, CONFIG_ACCOUNT_KEY, CONTRACTS_KEY, GOVERNANCE_ADDRESS_KEY,
-    GOVERNANCE_CHAIN_KEY, GOVERNANCE_KEY, MINIMUM_PROPOSAL_ETA_DELAY_KEY, UPGRADE_AUTHORITY_KEY,
     fetch_latest_blockhash, parse_account_meta_string, read_json_file_from_path,
-    write_json_to_file_path,
+    write_json_to_file_path, ADDRESS_KEY, CHAINS_KEY, CONFIG_ACCOUNT_KEY, CONTRACTS_KEY,
+    GOVERNANCE_ADDRESS_KEY, GOVERNANCE_CHAIN_KEY, GOVERNANCE_KEY, MINIMUM_PROPOSAL_ETA_DELAY_KEY,
+    UPGRADE_AUTHORITY_KEY,
 };
 
 #[derive(Subcommand, Debug)]
@@ -171,19 +172,18 @@ fn init(
     chains_info[CHAINS_KEY][&config.chain_id][CONTRACTS_KEY][GOVERNANCE_KEY] = serde_json::json!({
         ADDRESS_KEY: axelar_solana_governance::id().to_string(),
         CONFIG_ACCOUNT_KEY: config_pda.to_string(),
-        UPGRADE_AUTHORITY_KEY: fee_payer.to_string(),
         GOVERNANCE_ADDRESS_KEY: init_args.governance_address,
         GOVERNANCE_CHAIN_KEY: init_args.governance_chain,
         MINIMUM_PROPOSAL_ETA_DELAY_KEY: init_args.minimum_proposal_eta_delay,
+        OPERATOR_KEY: init_args.operator.to_string(),
+        UPGRADE_AUTHORITY_KEY: fee_payer.to_string(),
     });
 
     write_json_to_file_path(&chains_info, &config.chains_info_file)?;
 
-    Ok(vec![
-        IxBuilder::new()
-            .initialize_config(fee_payer, config_pda, governance_config)
-            .build(),
-    ])
+    Ok(vec![IxBuilder::new()
+        .initialize_config(fee_payer, config_pda, governance_config)
+        .build()])
 }
 
 fn execute_proposal(
@@ -234,9 +234,7 @@ fn execute_operator_proposal(
         calldata_bytes,
     );
 
-    Ok(vec![
-        builder
-            .execute_operator_proposal(fee_payer, config_pda, &args.operator)
-            .build(),
-    ])
+    Ok(vec![builder
+        .execute_operator_proposal(fee_payer, config_pda, &args.operator)
+        .build()])
 }

--- a/solana/src/its.rs
+++ b/solana/src/its.rs
@@ -895,8 +895,8 @@ fn init(
     chains_info[CHAINS_KEY][&config.chain_id][CONTRACTS_KEY][ITS_KEY] = serde_json::json!({
         ADDRESS_KEY: axelar_solana_its::id().to_string(),
         CONFIG_ACCOUNT_KEY: its_root_config.to_string(),
-        UPGRADE_AUTHORITY_KEY: fee_payer.to_string(),
         OPERATOR_KEY: init_args.operator.to_string(),
+        UPGRADE_AUTHORITY_KEY: fee_payer.to_string(),
     });
 
     write_json_to_file_path(&chains_info, &config.chains_info_file)?;

--- a/solana/src/its.rs
+++ b/solana/src/its.rs
@@ -16,9 +16,9 @@ use solana_sdk::transaction::Transaction as SolanaTransaction;
 use crate::config::Config;
 use crate::types::{SerializableSolanaTransaction, SolanaTransactionParams};
 use crate::utils::{
-    ADDRESS_KEY, AXELAR_KEY, CHAINS_KEY, CONFIG_ACCOUNT_KEY, CONTRACTS_KEY, GAS_SERVICE_KEY,
-    ITS_KEY, OPERATOR_KEY, UPGRADE_AUTHORITY_KEY, decode_its_destination, fetch_latest_blockhash,
-    read_json_file_from_path, write_json_to_file_path,
+    decode_its_destination, fetch_latest_blockhash, read_json_file_from_path,
+    write_json_to_file_path, ADDRESS_KEY, AXELAR_KEY, CHAINS_KEY, CONFIG_ACCOUNT_KEY,
+    CONTRACTS_KEY, GAS_SERVICE_KEY, ITS_KEY, OPERATOR_KEY, UPGRADE_AUTHORITY_KEY,
 };
 
 #[derive(Subcommand, Debug)]
@@ -728,7 +728,6 @@ fn try_infer_gas_service_id(maybe_arg: Option<Pubkey>, config: &Config) -> eyre:
                 [GAS_SERVICE_KEY][ADDRESS_KEY],
             )?
         )
-        .inspect_err(|e| println!("errr {e}"))
         .map_err(|_| eyre!(
             "Could not get the gas service id from the chains info JSON file. Is it already deployed? \
             Please update the file or pass a value to --gas-service"))?;

--- a/solana/src/its.rs
+++ b/solana/src/its.rs
@@ -1510,7 +1510,7 @@ fn get_token_manager(args: TokenManagerArgs, config: &Config) -> eyre::Result<()
     let (its_root_pda, _) = axelar_solana_its::find_its_root_pda();
     let token_id: [u8; 32] = hex::decode(args.token_id.trim_start_matches("0x"))?
         .try_into()
-        .expect("invalid token_id");
+        .map_err(|vec| eyre!("invalid token id: {vec:?}"))?;
     let (token_manager_pda, _) =
         axelar_solana_its::find_token_manager_pda(&its_root_pda, &token_id);
     let account = rpc_client.get_account(&token_manager_pda)?;

--- a/solana/src/main.rs
+++ b/solana/src/main.rs
@@ -6,6 +6,7 @@ mod gateway;
 mod generate;
 mod governance;
 mod its;
+mod memo;
 mod misc;
 mod multisig_prover_types;
 mod send;
@@ -106,6 +107,7 @@ struct SendCommandArgs {
     fee_payer: Option<String>,
 
     /// List of signing key identifiers (path for keypair file or usb ledger)
+    #[clap(long, short)]
     signer_keys: Vec<String>,
 
     #[clap(subcommand)]
@@ -151,6 +153,10 @@ enum InstructionSubcommand {
     /// Commands to interface with the InterchainGovernance program on Solana
     #[clap(subcommand)]
     Governance(governance::Commands),
+
+    /// Commands to interface with the AxelarMemo program on Solana
+    #[clap(subcommand)]
+    Memo(memo::Commands),
 }
 
 #[derive(Parser, Debug)]
@@ -340,6 +346,9 @@ async fn build_transaction(
         InstructionSubcommand::Its(command) => its::build_transaction(fee_payer, command, config),
         InstructionSubcommand::Governance(command) => {
             governance::build_transaction(fee_payer, command, config)
+        }
+        InstructionSubcommand::Memo(command) => {
+            memo::build_transaction(fee_payer, command, config)
         }
     }
 }

--- a/solana/src/main.rs
+++ b/solana/src/main.rs
@@ -23,7 +23,7 @@ use combine::CombineArgs;
 use dotenvy::dotenv;
 use eyre::eyre;
 use generate::GenerateArgs;
-use send::{sign_and_send_transactions, SendArgs};
+use send::{SendArgs, sign_and_send_transactions};
 use sign::SignArgs;
 use solana_clap_v3_utils::input_parsers::parse_url_or_moniker;
 use solana_clap_v3_utils::keypair::signer_from_path;
@@ -103,7 +103,7 @@ enum Command {
 struct SendCommandArgs {
     /// Signing key identifier (path for keypair file or usb ledger). Defaults to the keypair
     /// set in the Solana CLI config.
-    #[clap(long, env = "PRIVATE_KEY")]
+    #[clap(long, env = "SOLANA_PRIVATE_KEY")]
     fee_payer: Option<String>,
 
     /// List of signing key identifiers (path for keypair file or usb ledger)
@@ -219,6 +219,10 @@ enum QueryInstructionSubcommand {
     /// Commands to query data from the AxelarGateway program on Solana
     #[clap(subcommand)]
     Gateway(gateway::QueryCommands),
+
+    // Commands to query data from InterchainTokenService program on Solana
+    #[clap(subcommand)]
+    Its(its::QueryCommands),
 }
 
 #[tokio::main]
@@ -326,6 +330,9 @@ async fn run() -> eyre::Result<()> {
             QueryInstructionSubcommand::Gateway(command) => {
                 gateway::query(command, &config)?;
             }
+            QueryInstructionSubcommand::Its(command) => {
+                its::query(command, &config)?;
+            }
         },
     }
     Ok(())
@@ -347,8 +354,6 @@ async fn build_transaction(
         InstructionSubcommand::Governance(command) => {
             governance::build_transaction(fee_payer, command, config)
         }
-        InstructionSubcommand::Memo(command) => {
-            memo::build_transaction(fee_payer, command, config)
-        }
+        InstructionSubcommand::Memo(command) => memo::build_transaction(fee_payer, command, config),
     }
 }

--- a/solana/src/memo.rs
+++ b/solana/src/memo.rs
@@ -1,0 +1,66 @@
+use clap::Subcommand;
+use solana_sdk::instruction::Instruction;
+use solana_sdk::pubkey::Pubkey;
+use solana_sdk::transaction::Transaction as SolanaTransaction;
+
+use crate::config::Config;
+use crate::types::{SerializableSolanaTransaction, SolanaTransactionParams};
+use crate::utils::fetch_latest_blockhash;
+
+#[derive(Subcommand, Debug)]
+pub(crate) enum Commands {
+    /// Initialize the AxelarMemo program on Solana
+    Init,
+}
+
+pub(crate) fn build_transaction(
+    fee_payer: &Pubkey,
+    command: Commands,
+    config: &Config,
+) -> eyre::Result<Vec<SerializableSolanaTransaction>> {
+    let instructions = match command {
+        Commands::Init => init(fee_payer, config)?,
+    };
+
+    let blockhash = fetch_latest_blockhash(&config.url)?;
+    let mut serializable_transactions = Vec::with_capacity(instructions.len());
+
+    for instruction in instructions {
+        let message = solana_sdk::message::Message::new_with_blockhash(
+            &[instruction],
+            Some(fee_payer),
+            &blockhash,
+        );
+        let transaction = SolanaTransaction::new_unsigned(message);
+
+        let params = SolanaTransactionParams {
+            fee_payer: fee_payer.to_string(),
+            recent_blockhash: Some(blockhash.to_string()),
+            nonce_account: None,
+            nonce_authority: None,
+            blockhash_for_message: blockhash.to_string(),
+        };
+
+        let serializable_tx = SerializableSolanaTransaction::new(transaction, params);
+        serializable_transactions.push(serializable_tx);
+    }
+
+    Ok(serializable_transactions)
+}
+
+fn init(fee_payer: &Pubkey, _config: &Config) -> eyre::Result<Vec<Instruction>> {
+    let counter_pda = axelar_solana_memo_program::get_counter_pda();
+
+    let init_instruction =
+        axelar_solana_memo_program::instruction::initialize(fee_payer, &counter_pda)?;
+
+    println!("------------------------------------------");
+    println!(
+        "\u{2705} Memo program ({}) initialization details:",
+        axelar_solana_memo_program::id()
+    );
+    println!("   Counter Account: {}", counter_pda.0);
+    println!("------------------------------------------");
+
+    Ok(vec![init_instruction])
+}

--- a/solana/src/utils.rs
+++ b/solana/src/utils.rs
@@ -42,6 +42,7 @@ pub(crate) const AXELAR_KEY: &str = "axelar";
 pub(crate) const CHAINS_KEY: &str = "chains";
 pub(crate) const CHAIN_TYPE_KEY: &str = "chainType";
 pub(crate) const CONFIG_ACCOUNT_KEY: &str = "configAccount";
+pub(crate) const CONNECTION_TYPE_KEY: &str = "connectionType";
 pub(crate) const CONTRACTS_KEY: &str = "contracts";
 pub(crate) const DOMAIN_SEPARATOR_KEY: &str = "domainSeparator";
 pub(crate) const GAS_SERVICE_KEY: &str = "AxelarGasService";

--- a/solana/src/utils.rs
+++ b/solana/src/utils.rs
@@ -14,7 +14,6 @@ use solana_sdk::account_utils::StateMut;
 use solana_sdk::compute_budget::ComputeBudgetInstruction;
 use solana_sdk::hash::Hash;
 use solana_sdk::instruction::Instruction;
-use solana_sdk::keccak::hashv;
 use solana_sdk::nonce::state::Versions;
 use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::Signature;
@@ -39,10 +38,8 @@ pub(crate) fn create_compute_budget_instructions(
 }
 
 pub(crate) const ADDRESS_KEY: &str = "address";
-pub(crate) const AXELAR_ID_KEY: &str = "axelarId";
 pub(crate) const AXELAR_KEY: &str = "axelar";
 pub(crate) const CHAINS_KEY: &str = "chains";
-pub(crate) const CHAIN_ID_KEY: &str = "chainId";
 pub(crate) const CHAIN_TYPE_KEY: &str = "chainType";
 pub(crate) const CONFIG_ACCOUNT_KEY: &str = "configAccount";
 pub(crate) const CONTRACTS_KEY: &str = "contracts";
@@ -59,8 +56,6 @@ pub(crate) const MINIMUM_ROTATION_DELAY_KEY: &str = "minimumRotationDelay";
 pub(crate) const MULTISIG_PROVER_KEY: &str = "MultisigProver";
 pub(crate) const OPERATOR_KEY: &str = "operator";
 pub(crate) const PREVIOUS_SIGNERS_RETENTION_KEY: &str = "previousSignersRetention";
-pub(crate) const ROUTER_KEY: &str = "Router";
-pub(crate) const SOLANA_CHAIN_KEY: &str = "solana";
 pub(crate) const UPGRADE_AUTHORITY_KEY: &str = "upgradeAuthority";
 
 pub(crate) fn read_json_file<T: DeserializeOwned>(file: &File) -> eyre::Result<T> {
@@ -208,23 +203,22 @@ pub(crate) fn print_transaction_result(
 pub(crate) fn domain_separator(
     chains_info: &serde_json::Value,
     network_type: NetworkType,
+    chain_id: &str,
 ) -> eyre::Result<[u8; 32]> {
     if network_type == NetworkType::Local {
         return Ok([0; 32]);
     }
 
-    let axelar_id = String::deserialize(&chains_info[CHAINS_KEY][SOLANA_CHAIN_KEY][AXELAR_ID_KEY])?;
-    let router_address = String::deserialize(
-        &chains_info[CHAINS_KEY][AXELAR_KEY][CONTRACTS_KEY][ROUTER_KEY][ADDRESS_KEY],
+    let from_multisig_prover = String::deserialize(
+        &chains_info[AXELAR_KEY][CONTRACTS_KEY][MULTISIG_PROVER_KEY][chain_id]
+            [DOMAIN_SEPARATOR_KEY],
     )?;
-    let chain_id = String::deserialize(&chains_info[CHAINS_KEY][AXELAR_KEY][CHAIN_ID_KEY])?;
 
-    Ok(hashv(&[
-        axelar_id.as_bytes(),
-        router_address.as_bytes(),
-        chain_id.as_bytes(),
-    ])
-    .to_bytes())
+    let domain_separator: [u8; 32] = hex::decode(from_multisig_prover.trim_start_matches("0x"))?
+        .try_into()
+        .expect("invalid domain separator");
+
+    Ok(domain_separator)
 }
 
 pub(crate) fn parse_secret_key(raw: &str) -> eyre::Result<SecretKey> {


### PR DESCRIPTION
Several changes were required to the scripts and some instructions as well, here's the rationale:

- There was a recent change done earlier related to the chain id (because it can be `solana-2` for instance and not always `solana`). It's changed to be taken as input and not inferred anymore, but it wasn't updated properly in all places where we were using it to index the json file. Thus I had to fix it during the deployment.
- The gas service program used to take an "authority", the terminology was recently updated in the contract to "operator", thus I updated here to be consistent.
- We were calculating the domain separator in the scripts for gateway initialization, but because of the issue we had where the `MultisigProver` was instantiated with the domain separator calculated with `solana` instead of `solana-2`, I updated the script to take the domain separator from the json file instead.
- Added output messages to some ITS token deployment/registration instructions to show the `token_id` generated.
- Added command to query for `TokenManager` details (mentioned above in a previous message: so we can get the mint address associated with the `token_id` without having to go on the explorer).
- Removed `token-program` as input argument for ITS related commands as we can query it from RPC.
- Updated `PRIVATE_KEY` env var to `SOLANA_PRIVATE_KEY` to avoid the `solana-axelar-cli` from picking up EVM private key when performing checks involving both CLIs.
- For the GMP Checklist, we had instructions to use the `solana-axelar-scripts` tool, but using that is not straightforward. It required having the `Memo` program deployed on the EVM additionally to Solana, required updating config files of the tool, etc. I also believe that using yet another external custom tool beats the purpose of the scripts we're adding to `axelar-contracts-deployment`. Therefore I added instructions on building and deploying the `AxelarMemo` program on Solana, which follows the exact same steps as the other programs, and also a command to initialize it. Then updated the instructions to use `call-contract` from the scripts directly to call it and check GMP works.