### PR TITLE
fix(cosmwasm): add coordinator to multisig instantiation message

### DIFF
--- a/cosmwasm/utils.js
+++ b/cosmwasm/utils.js
@@ -224,6 +224,7 @@ const makeMultisigInstantiateMsg = (config, _options, contractConfig) => {
     } = config;
     const {
         Rewards: { address: rewardsAddress },
+        Coordinator: { address: coordinatorAddress },
     } = contracts;
     const { adminAddress, governanceAddress, blockExpiry } = contractConfig;
 
@@ -243,11 +244,16 @@ const makeMultisigInstantiateMsg = (config, _options, contractConfig) => {
         throw new Error(`Missing or invalid Multisig.blockExpiry in axelar info`);
     }
 
+    if (!validateAddress(coordinatorAddress)) {
+        throw new Error('Missing or invalid Coordinator.address in axelar info');
+    }
+
     return {
         admin_address: adminAddress,
         governance_address: governanceAddress,
         rewards_address: rewardsAddress,
         block_expiry: toBigNumberString(blockExpiry),
+        coordinator_address: coordinatorAddress,
     };
 };
 


### PR DESCRIPTION
This PR adds the coordinator's address to the multisig contract's instantiate message. Please see https://github.com/axelarnetwork/axelar-amplifier/pull/953 for reference