### PR TITLE
Feat/sui legacy tokens

### DIFF
--- a/sui/its.js
+++ b/sui/its.js
@@ -258,9 +258,7 @@ async function migrateCoinMetadata(keypair, client, config, contracts, args, opt
         await broadcastFromTxBuilder(txBuilder, keypair, 'Migrate Coin Metadata', options);
     } else {
         // Migrate all the coins. This might take a while.
-        const legacyCoins = (contracts.InterchainTokenService.legacyCoins) 
-            ? contracts.InterchainTokenService.legacyCoins 
-            : [];
+        const legacyCoins = contracts.InterchainTokenService.legacyCoins ? contracts.InterchainTokenService.legacyCoins : [];
         console.log(legacyCoins);
         legacyCoins.forEach(async (coin) => {
             await txBuilder.moveCall({

--- a/sui/its.js
+++ b/sui/its.js
@@ -255,7 +255,7 @@ async function migrateCoinMetadata(keypair, client, config, contracts, args, opt
             typeArguments: [tokenType],
         });
 
-        await broadcastFromTxBuilder(txBuilder, keypair, 'Migrate Coin Metadata', options);
+        await broadcastFromTxBuilder(txBuilder, keypair, `Migrate Coin Metadata (${symbol})`, options);
     } else {
         // Migrate all the coins. This might take a while.
         const legacyCoins = contracts.InterchainTokenService.legacyCoins ? contracts.InterchainTokenService.legacyCoins : [];
@@ -267,7 +267,7 @@ async function migrateCoinMetadata(keypair, client, config, contracts, args, opt
                 typeArguments: [coin.TokenType],
             });
 
-            await broadcastFromTxBuilder(txBuilder, keypair, `Migrate Coin Metadata ${coin.symbol}`, options);
+            await broadcastFromTxBuilder(txBuilder, keypair, `Migrate Coin Metadata (${coin.symbol})`, options);
         });
         contracts.legacyCoins = [];
     }

--- a/sui/its.js
+++ b/sui/its.js
@@ -259,7 +259,6 @@ async function migrateCoinMetadata(keypair, client, config, contracts, args, opt
     } else {
         // Migrate all the coins. This might take a while.
         const legacyCoins = contracts.InterchainTokenService.legacyCoins ? contracts.InterchainTokenService.legacyCoins : [];
-        console.log(legacyCoins);
         legacyCoins.forEach(async (coin) => {
             await txBuilder.moveCall({
                 target: `${itsConfig.address}::interchain_token_service::migrate_coin_metadata`,

--- a/sui/tokens.js
+++ b/sui/tokens.js
@@ -175,11 +175,67 @@ async function processListCommand(keypair, client, args, options) {
     await CoinManager.printCoins(client, coinTypeToCoins);
 }
 
+//here
+async function legacyCoinsCommand(keypair, client, args, options, contracts) {
+    const { InterchainTokenService: itsConfig } = contracts;
+    const { InterchainTokenServicev0 } = itsConfig.objects;
+
+    printInfo('Action', 'Generate Legacy Coins List');
+    
+    const itsObject = await client.getObject({
+        id: InterchainTokenServicev0, 
+        options:{ showContent: true }
+    });
+    
+    const registeredCoinsId = (itsObject.data) 
+        ? itsObject.data.content.fields.value.fields.registered_coins.fields.id.id 
+        : null;
+
+    if (!registeredCoinsId) throw new Error(`Unable to query ITS object at id ${InterchainTokenServicev0}`);
+
+    let hasNextPage = true, cursor, legacyCoins = [];
+    while (hasNextPage) {
+        try {
+            // Paging (batches of 50)
+            const params = { parentId: registeredCoinsId };
+            if (cursor) params.cursor = cursor;
+
+            // Fetch token data
+            const fields =  await client.getDynamicFields(params);
+            const coinIds = (fields.data) ? fields.data.map(coin => coin.objectId) : [];
+            const coinData = await client.multiGetObjects({
+                ids: coinIds,
+                options: { showContent: true }
+            });
+
+            // Target effected tokens by selecting only items with metadata !== null
+            legacyCoins = [...legacyCoins, ...coinData.filter((coin) => {
+                const coinMetadata = (coin.data) 
+                    ? coin.data.content.fields.value.fields.coin_info.fields.metadata
+                    : null;
+                return (coinMetadata) ? true : false;
+            }).map((coin) => {
+                return { 
+                    TokenId: coin.data.content.fields.name.fields.id,
+                    TokenType: coin.data.content.fields.value.fields.coin_info.fields.metadata.type,
+                    symbol: coin.data.content.fields.value.fields.coin_info.fields.metadata.fields.symbol
+                };
+            })];
+
+            hasNextPage = fields.hasNextPage;
+            cursor = (fields.nextCursor) ? fields.nextCursor : null;
+        } catch(e) {
+            throw new Error(e);
+        }
+    }
+    contracts.InterchainTokenService.legacyCoins = legacyCoins;
+}
+
 async function mainProcessor(options, processor, args = {}) {
     const config = loadConfig(options.env);
     const chain = getChainConfig(config.chains, options.chainName);
     const [keypair, client] = getWallet(chain, options);
-    await processor(keypair, client, args, options);
+    await processor(keypair, client, args, options, chain.contracts);
     saveConfig(config, options.env);
 }
 
@@ -193,6 +249,7 @@ if (require.main === module) {
         'Split coins into a new object. If no coin type is specified, SUI coins will be used by default.',
     );
     const listProgram = new Command('list').description('List all coins and balances');
+    const legacyCoinsProgram = new Command('legacy-coins').description('Save a list of legacy coins to be migrated to public coin metadata');
 
     // Define options, arguments, and actions for each sub-program
     mergeProgram.option('--coin-type <coinType>', 'Coin type to merge').action((options) => {
@@ -211,10 +268,15 @@ if (require.main === module) {
         mainProcessor(options, processListCommand);
     });
 
+    legacyCoinsProgram.action((options) => {
+        mainProcessor(options, legacyCoinsCommand);
+    })
+
     // Add sub-programs to the main program
     program.addCommand(mergeProgram);
     program.addCommand(splitProgram);
     program.addCommand(listProgram);
+    program.addCommand(legacyCoinsProgram);
 
     // Add base options to all sub-programs
     addOptionsToCommands(program, addBaseOptions);


### PR DESCRIPTION
This PR adds commands and functionality for migrating legacy tokens with metadata saved to Sui ITS.

The `legacy-coins` command is now provided in `sui/tokens.js`:

Usage:
```bash
# Save token ids and coin types to env config (e.g. for later migration)
ts-node sui/tokens legacy-coins
```

Additionally, an `--all` option is added to command `migrate-coin-metadata` in `sui/its.js`. This flag can be used to migrate the entire list of legacy tokens stored in the chain config that is produced by the `legacy-coins` command in `sui/tokens.js`

Usage:
```bash
# Migrate all the legacy tokens saved by the `legacy-coins` command
ts-node sui/its migrate-coin-metadata "legacy-coins" --all
```