### PR TITLE
feat(stellar): add is trusted chain function

### DIFF
--- a/stellar/README.md
+++ b/stellar/README.md
@@ -253,6 +253,15 @@ ts-node stellar/its.js add-trusted-chains avalanche sui
 ts-node stellar/its.js remove-trusted-chains <sourceChain> <sourceChain2> ...
 ```
 
+#### Check if Chain is Trusted
+
+```bash
+ts-node stellar/its.js is-trusted-chain <chain>
+
+# Example
+ts-node stellar/its.js is-trusted-chain avalanche
+```
+
 #### Deploy Interchain Token
 
 ```bash

--- a/stellar/its.js
+++ b/stellar/its.js
@@ -31,18 +31,19 @@ const {
 } = require('./utils');
 const { prompt, parseTrustedChains, encodeITSDestination, tokenManagerTypes, validateLinkType } = require('../common/utils');
 
+async function checkTrustedChain(wallet, chain, contract, trustedChainScVal, options) {
+    return (await broadcast(contract.call('is_trusted_chain', trustedChainScVal), wallet, chain, 'Is trusted chain', options)).value();
+}
+
 async function manageTrustedChains(action, wallet, config, chain, contract, args, options) {
     const trustedChains = parseTrustedChains(config.chains, args);
 
     for (const trustedChain of trustedChains) {
         printInfo(action, trustedChain);
 
-        const trustedChainScVal = nativeToScVal(trustedChain, { type: 'string' });
-
         try {
-            const isTrusted = (
-                await broadcast(contract.call('is_trusted_chain', trustedChainScVal), wallet, chain, 'Is trusted chain', options)
-            ).value();
+            const trustedChainScVal = nativeToScVal(trustedChain, { type: 'string' });
+            const isTrusted = await checkTrustedChain(wallet, chain, contract, trustedChainScVal, options);
 
             if (isTrusted && action === 'set_trusted_chain') {
                 printWarn('The chain is already trusted', trustedChain);
@@ -68,6 +69,27 @@ async function addTrustedChains(wallet, config, chain, contract, args, options) 
 
 async function removeTrustedChains(wallet, config, chain, contract, args, options) {
     await manageTrustedChains('remove_trusted_chain', wallet, config, chain, contract, args, options);
+}
+
+async function isTrustedChain(wallet, _config, chain, contract, args, options) {
+    const [trustedChain] = args;
+
+    validateParameters({
+        isNonEmptyString: { trustedChain },
+    });
+
+    try {
+        const trustedChainScVal = nativeToScVal(trustedChain, { type: 'string' });
+        const isTrusted = await checkTrustedChain(wallet, chain, contract, trustedChainScVal, options);
+
+        if (isTrusted) {
+            printInfo(`${trustedChain} is a trusted chain`);
+        } else {
+            printInfo(`${trustedChain} is not a trusted chain`);
+        }
+    } catch (error) {
+        printError(`Failed to check trusted chain`, trustedChain, error);
+    }
 }
 
 async function deployInterchainToken(wallet, _config, chain, contract, args, options) {
@@ -467,6 +489,13 @@ if (require.main === module) {
         .description(`Remove trusted chains. The <trusted-chains> can be a list of chains separated by whitespaces or special tag 'all'`)
         .action((trustedChains, options) => {
             mainProcessor(removeTrustedChains, trustedChains, options);
+        });
+
+    program
+        .command('is-trusted-chain <trusted-chain>')
+        .description('Check if a chain is trusted')
+        .action((trustedChain, options) => {
+            mainProcessor(isTrustedChain, [trustedChain], options);
         });
 
     program

--- a/stellar/its.js
+++ b/stellar/its.js
@@ -39,7 +39,9 @@ async function manageTrustedChains(action, wallet, config, chain, contract, args
 
         try {
             const trustedChainScVal = nativeToScVal(trustedChain, { type: 'string' });
-            const isTrusted = (await broadcast(contract.call('is_trusted_chain', trustedChainScVal), wallet, chain, 'Is trusted chain', options)).value();
+            const isTrusted = (
+                await broadcast(contract.call('is_trusted_chain', trustedChainScVal), wallet, chain, 'Is trusted chain', options)
+            ).value();
 
             if (isTrusted && action === 'set_trusted_chain') {
                 printWarn('The chain is already trusted', trustedChain);
@@ -76,7 +78,9 @@ async function isTrustedChain(wallet, _config, chain, contract, args, options) {
 
     try {
         const trustedChainScVal = nativeToScVal(trustedChain, { type: 'string' });
-        const isTrusted = (await broadcast(contract.call('is_trusted_chain', trustedChainScVal), wallet, chain, 'Is trusted chain', options)).value();
+        const isTrusted = (
+            await broadcast(contract.call('is_trusted_chain', trustedChainScVal), wallet, chain, 'Is trusted chain', options)
+        ).value();
 
         if (isTrusted) {
             printInfo(`${trustedChain} is a trusted chain`);

--- a/stellar/its.js
+++ b/stellar/its.js
@@ -31,10 +31,6 @@ const {
 } = require('./utils');
 const { prompt, parseTrustedChains, encodeITSDestination, tokenManagerTypes, validateLinkType } = require('../common/utils');
 
-async function checkTrustedChain(wallet, chain, contract, trustedChainScVal, options) {
-    return (await broadcast(contract.call('is_trusted_chain', trustedChainScVal), wallet, chain, 'Is trusted chain', options)).value();
-}
-
 async function manageTrustedChains(action, wallet, config, chain, contract, args, options) {
     const trustedChains = parseTrustedChains(config.chains, args);
 
@@ -43,7 +39,7 @@ async function manageTrustedChains(action, wallet, config, chain, contract, args
 
         try {
             const trustedChainScVal = nativeToScVal(trustedChain, { type: 'string' });
-            const isTrusted = await checkTrustedChain(wallet, chain, contract, trustedChainScVal, options);
+            const isTrusted = (await broadcast(contract.call('is_trusted_chain', trustedChainScVal), wallet, chain, 'Is trusted chain', options)).value();
 
             if (isTrusted && action === 'set_trusted_chain') {
                 printWarn('The chain is already trusted', trustedChain);
@@ -80,7 +76,7 @@ async function isTrustedChain(wallet, _config, chain, contract, args, options) {
 
     try {
         const trustedChainScVal = nativeToScVal(trustedChain, { type: 'string' });
-        const isTrusted = await checkTrustedChain(wallet, chain, contract, trustedChainScVal, options);
+        const isTrusted = (await broadcast(contract.call('is_trusted_chain', trustedChainScVal), wallet, chain, 'Is trusted chain', options)).value();
 
         if (isTrusted) {
             printInfo(`${trustedChain} is a trusted chain`);


### PR DESCRIPTION
[AXE-10002](https://axelarnetwork.atlassian.net/browse/AXE-10002)

[AXE-10002]: https://axelarnetwork.atlassian.net/browse/AXE-10002?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- greptile_comment -->

## Greptile Summary

This PR adds a new `is-trusted-chain` command to the Stellar Interchain Token Service (ITS) implementation. The primary change introduces a standalone function to check whether a specific chain is configured as trusted in the ITS contract, which was previously only available as part of the chain management operations.

The implementation follows established patterns in the codebase:

1. **Code Organization**: The change extracts the trusted chain checking logic into a reusable `checkTrustedChain` helper function, eliminating code duplication from the existing `manageTrustedChains` function
2. **New Function**: Adds `isTrustedChain` function that validates input parameters, calls the helper function, and provides user-friendly output indicating whether the chain is trusted or not
3. **CLI Integration**: Registers a new command `is-trusted-chain <trusted-chain>` that follows the same pattern as other ITS commands
4. **Documentation**: Updates the README.md with usage instructions and examples for the new command

This fits well within the existing ITS module structure on Stellar, which operates in Hub mode where trusted chains must be explicitly configured. The new functionality provides a query-only operation that complements the existing `add-trusted-chains` and `remove-trusted-chains` commands, making it easier for users to verify chain trust status without modifying configurations.

## Important Files Changed

<details>
<summary>File Changes Summary</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| stellar/its.js | 5/5 | Adds `is-trusted-chain` command with proper validation, error handling, and code reuse |
| stellar/README.md | 5/5 | Documents the new command with usage examples following existing documentation patterns |

</details>

## Confidence score: 5/5

- This PR is safe to merge with minimal risk
- Score reflects simple, well-structured changes that follow existing patterns and include proper validation
- No files require special attention - both changes are straightforward additions with good practices

## Sequence Diagram
```mermaid
sequenceDiagram
    participant User
    participant CLI as "its.js CLI"
    participant Processor as "mainProcessor"
    participant Config as "Config System"
    participant Wallet as "Stellar Wallet"
    participant Contract as "ITS Contract"
    participant Blockchain as "Stellar Network"

    User->>CLI: "ts-node stellar/its.js is-trusted-chain <chain>"
    CLI->>Processor: "mainProcessor(isTrustedChain, [trustedChain], options)"
    
    Processor->>Config: "loadConfig(options.env)"
    Config-->>Processor: "config"
    
    Processor->>Config: "getChainConfig(config.chains, options.chainName)"
    Config-->>Processor: "chain config"
    
    Processor->>Wallet: "getWallet(chain, options)"
    Wallet-->>Processor: "wallet instance"
    
    Processor->>Processor: "validate InterchainTokenService contract exists"
    Processor->>Contract: "new Contract(contractAddress)"
    Contract-->>Processor: "contract instance"
    
    Processor->>CLI: "isTrustedChain(wallet, config, chain, contract, args, options)"
    
    CLI->>CLI: "validateParameters({ isNonEmptyString: { trustedChain } })"
    CLI->>CLI: "nativeToScVal(trustedChain, { type: 'string' })"
    CLI->>CLI: "checkTrustedChain(wallet, chain, contract, trustedChainScVal, options)"
    
    CLI->>Contract: "contract.call('is_trusted_chain', trustedChainScVal)"
    Contract->>Blockchain: "invoke is_trusted_chain method"
    Blockchain-->>Contract: "boolean result"
    Contract-->>CLI: "broadcast response"
    
    CLI->>CLI: "response.value()"
    
    alt Chain is trusted
        CLI->>User: "printInfo: '<chain> is a trusted chain'"
    else Chain is not trusted
        CLI->>User: "printInfo: '<chain> is not a trusted chain'"
    end
    
    Note over CLI,User: Error handling occurs if chain validation fails
```

<!-- /greptile_comment -->