### PR TITLE
chore(stellar): upgrade mainnet ITS to v1.4.1

### DIFF
--- a/axelar-chains-config/info/mainnet.json
+++ b/axelar-chains-config/info/mainnet.json
@@ -2852,7 +2852,7 @@
         "InterchainTokenService": {
           "address": "CBDBMIOFHGWUFRYH3D3STI2DHBOWGDDBCRKQEUB4RGQEBVG74SEED6C6",
           "deployer": "GC2SJ4YXCMP2LYXMXBNJMK6SNK4XUR7TGJXY4GA3VACNMCZVCQ6VFGG3",
-          "wasmHash": "28aeee6baad2b799bc136080f3bbdf4be65fd0a6cfad81725ef63f5b08c83ea4",
+          "wasmHash": "827225d8911a0034b6059f6279453b8d6a09a9510b061026bdcbdbe19f918d0d",
           "initializeArgs": {
             "owner": "GC2SJ4YXCMP2LYXMXBNJMK6SNK4XUR7TGJXY4GA3VACNMCZVCQ6VFGG3",
             "operator": "GC2SJ4YXCMP2LYXMXBNJMK6SNK4XUR7TGJXY4GA3VACNMCZVCQ6VFGG3",
@@ -2864,7 +2864,7 @@
             "interchainTokenWasmHash": "85693704d656eb99af464d553a0a8d99b62d039223e72e86b98655def0d345ca",
             "tokenManagerWasmHash": "4164f47872741793bc682f6fb124623c6c1eb64e342b73319c11d05c2e0e39b0"
           },
-          "version": "1.4.0"
+          "version": "1.4.1"
         },
         "Multicall": {
           "address": "CC5LVKQA73ZVVUBAOCV5INV4TXPMELBFJ6XTQUBJTP4O2LSUKAA7VHLZ",


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

This PR upgrades the Stellar mainnet InterchainTokenService (ITS) from version 1.4.0 to 1.4.1. The change involves updating two critical fields in the mainnet configuration file: the `wasmHash` is updated to `827225d8911a0034b6059f6279453b8d6a09a9510b061026bdcbdbe19f918d0d` and the `version` field is bumped to `1.4.1`.

This upgrade follows Stellar's contract upgrade pattern where new WASM bytecode is deployed (identified by the new wasmHash) while maintaining the same contract address and configuration. According to the release notes, version 1.4.1 specifically addresses a bug fix to add mint/burn functionality when receiving messages from the hub, which is a critical feature for the InterchainTokenService's cross-chain token operations.

The change integrates with the broader Axelar network deployment infrastructure by updating the mainnet chain configuration that other components rely on for contract interaction. This follows the established pattern seen in other network upgrades within the codebase, where version updates are coordinated across different environments and documented through structured release processes.

## Important Files Changed

<details>
<summary>File Changes</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| axelar-chains-config/info/mainnet.json | 5/5 | Updates Stellar ITS contract hash and version for v1.4.1 upgrade with mint/burn bug fix |

</details>

## Confidence score: 5/5

- This PR is safe to merge with minimal risk as it follows established upgrade patterns
- Score reflects a straightforward configuration update for a well-documented bug fix release
- No files require special attention - the change is isolated and follows standard procedures

## Sequence Diagram
```mermaid
sequenceDiagram
    participant User
    participant MainnetConfig as "mainnet.json"
    participant StellarITS as "Stellar ITS Contract"
    
    User->>MainnetConfig: "Update Stellar ITS version to 1.4.1"
    MainnetConfig->>StellarITS: "Set version field to 1.4.1"
    StellarITS-->>MainnetConfig: "Contract version updated"
    MainnetConfig-->>User: "Configuration updated successfully"
```

<!-- /greptile_comment -->