### PR TITLE
chore: migrate service registery to v1.2.0 on devnet-amplfier

### DIFF
--- a/axelar-chains-config/info/devnet-amplifier.json
+++ b/axelar-chains-config/info/devnet-amplifier.json
@@ -1440,11 +1440,11 @@
     "contracts": {
       "ServiceRegistry": {
         "governanceAccount": "axelar1zlr7e5qf3sz7yf890rkh9tcnu87234k6k7ytd9",
-        "codeId": 852,
-        "lastUploadedCodeId": 852,
+        "codeId": 1505,
+        "lastUploadedCodeId": 1505,
         "address": "axelar1c9fkszt5lq34vvvlat3fxj6yv7ejtqapz04e97vtc9m5z9cwnamq8zjlhz",
-        "storeCodeProposalId": "75",
-        "storeCodeProposalCodeHash": "fcbd66ffc824fc52383132d7a57617e9bc40dd1521ecad77341726434f801406"
+        "storeCodeProposalId": "1050",
+        "storeCodeProposalCodeHash": "1ece3b2b765257ed931f9e151b936ae24b26b632990baf90f63306a9db55f714"
       },
       "Router": {
         "adminAddress": "axelar1zlr7e5qf3sz7yf890rkh9tcnu87234k6k7ytd9",

--- a/releases/cosmwasm/2025-08-ServiceRegistry-v1.2.0.md
+++ b/releases/cosmwasm/2025-08-ServiceRegistry-v1.2.0.md
@@ -1,13 +1,13 @@
 # Cosmwasm Service Registry v1.2.0
 
-|                | **Owner**                             |
-| -------------- | ------------------------------------- |
-| **Created By** | @cjcobb23 <cj@interoplabs.io>         |
-| **Deployment** | TBD                                   |
+|                | **Owner**                              |
+|----------------|----------------------------------------|
+| **Created By** | @cjcobb23 <cj@interoplabs.io>          |
+| **Deployment** | @blockchainguyy <ayush@interoplabs.io> |
 
 | **Network**          | **Deployment Status** | **Date**   |
-| -------------------- | --------------------- | ---------- |
-| **Devnet Amplifier** | Pending               |            |
+|----------------------|-----------------------|------------|
+| **Devnet Amplifier** | Deployed              | 2025-08-28 |
 | **Stagenet**         | Pending               |            |
 | **Testnet**          | Pending               |            |
 | **Mainnet**          | Pending               |            |


### PR DESCRIPTION
<!-- greptile_comment -->

## Greptile Summary

This PR migrates the ServiceRegistry contract to version 1.2.0 on the devnet-amplifier environment. The ServiceRegistry is a core component of the Axelar network that manages service registrations and configurations across the interchain ecosystem. 

The change updates the contract configuration in the `devnet-amplifier.json` file to point to the newer v1.2.0 codebase (code ID 1505) instead of the previous v1.0.0 version (code ID 852). This is a standard contract upgrade that maintains the same deployed contract address (`axelar1c9fkszt5lq34vvvlat3fxj6yv7ejtqapz04e97vtc9m5z9cwnamq8zjlhz`) and governance structure, indicating the upgrade was performed through the existing contract's upgrade mechanism rather than deploying a new contract instance.

The upgrade includes updating the store code proposal ID from 75 to 1050 and the corresponding code hash, which indicates this upgrade went through the proper Axelar governance process. Both `codeId` and `lastUploadedCodeId` are set to the same value (1505), confirming this is the most recent version available. This type of configuration update is typical in the Axelar ecosystem where contracts are upgraded to incorporate bug fixes, performance improvements, or new features while maintaining continuity of service.

## Important Files Changed

<details>
<summary>Files Modified</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| axelar-chains-config/info/devnet-amplifier.json | 5/5 | Updated ServiceRegistry contract configuration to migrate from v1.0.0 to v1.2.0 with new code ID and proposal details |

</details>

## Confidence score: 5/5

- This PR is safe to merge with minimal risk as it follows standard contract upgrade patterns
- Score reflects a routine configuration update for a well-established upgrade process with proper governance validation
- No files require special attention as this is a straightforward version migration

<!-- /greptile_comment -->