### PR TITLE
chore(evm): add gas value scaling option

### DIFF
--- a/axelar-chains-config/info/devnet-amplifier.json
+++ b/axelar-chains-config/info/devnet-amplifier.json
@@ -1359,6 +1359,7 @@
         "url": "https://hashscan.io/testnet",
         "api": ""
       },
+      "gasScalingFactor": 10,
       "gasOptions": {
         "gasLimit": 8000000
       },

--- a/evm/interchainTokenFactory.js
+++ b/evm/interchainTokenFactory.js
@@ -18,6 +18,7 @@ const {
     printWalletInfo,
     printTokenInfo,
     isTrustedChain,
+    getValueForGasValue,
 } = require('./utils');
 const { validateChain } = require('../common/utils');
 const { addEvmOptions } = require('./cli-utils');
@@ -197,7 +198,7 @@ async function processCommand(_axelar, chain, chains, options) {
                 destinationChain,
                 gasValue,
                 {
-                    value: gasValue,
+                    value: getValueForGasValue(chain, gasValue),
                     ...gasOptions,
                 },
             );
@@ -240,7 +241,7 @@ async function processCommand(_axelar, chain, chains, options) {
                 tokenAddress,
                 destinationChain,
                 gasValue,
-                { value: gasValue, ...gasOptions },
+                { value: getValueForGasValue(chain, gasValue), ...gasOptions },
             );
 
             const tokenId = await interchainTokenFactory.canonicalInterchainTokenId(tokenAddress);
@@ -301,7 +302,7 @@ async function processCommand(_axelar, chain, chains, options) {
                 tokenManagerType,
                 linkParams,
                 gasValue,
-                { value: gasValue, ...gasOptions },
+                { value: getValueForGasValue(chain, gasValue), ...gasOptions },
             );
 
             const tokenId = await interchainTokenFactory.linkedTokenId(wallet.address, deploymentSalt);

--- a/evm/its.js
+++ b/evm/its.js
@@ -26,6 +26,7 @@ const {
     INTERCHAIN_TRANSFER_WITH_METADATA,
     isTrustedChain,
     loadConfig,
+    getValueForGasValue,
 } = require('./utils');
 const {
     getChainConfigByAxelarId,
@@ -359,7 +360,7 @@ async function processCommand(_axelar, chain, chains, action, options) {
                 amountInUnits,
                 metadata,
                 gasValue,
-                { value: gasValue, ...gasOptions },
+                { value: getValueForGasValue(chain, gasValue), ...gasOptions },
             );
             await handleTx(tx, chain, interchainTokenService, action, 'InterchainTransfer');
             return tx.hash;
@@ -370,7 +371,10 @@ async function processCommand(_axelar, chain, chains, action, options) {
             const { gasValue } = options;
             validateParameters({ isValidAddress: { tokenAddress }, isValidNumber: { gasValue } });
 
-            const tx = await interchainTokenService.registerTokenMetadata(tokenAddress, gasValue, { value: gasValue, ...gasOptions });
+            const tx = await interchainTokenService.registerTokenMetadata(tokenAddress, gasValue, {
+                value: getValueForGasValue(chain, gasValue),
+                ...gasOptions,
+            });
             await handleTx(tx, chain, interchainTokenService, action);
             break;
         }

--- a/evm/utils.js
+++ b/evm/utils.js
@@ -1096,6 +1096,22 @@ function detectITSVersion() {
     return ITSPackage.version;
 }
 
+// Adjust gas value based on chain's gas scaling factor
+// Most of the chains will not need scaling, but certain chains
+// like Hedera have different decimals accepted by their EVM RPCs.
+//
+// Example:
+// Gas value passed as an argument is 200 (tinybars, 8 decimals)
+// but the RPC will accept the value in wei (18 decimals), so the value
+// once scaled will be 200 * 10^10 = 20_000_000_000 wei
+function getValueForGasValue(chain, gasValue) {
+    if (typeof chain.gasScalingFactor === 'number') {
+        return BigNumber.from(gasValue).mul(10 ** chain.gasScalingFactor);
+    }
+
+    return gasValue;
+}
+
 module.exports = {
     ...require('../common/utils'),
     deployCreate,
@@ -1144,4 +1160,5 @@ module.exports = {
     isTrustedChain,
     detectITSVersion,
     getChains,
+    getValueForGasValue,
 };


### PR DESCRIPTION
This PR adds an option for a chain to "scale up" the `value` field in transactions that accept `gasValue` as an argument.

It is primarily needed for the Hedera chain, where `gasValue` would be denominated with 8 decimals, however the actual value sent to the Hedera RPC must be in wei (18 decimals). 

Example:

Gas value passed as an argument is 200 (tinybars, 8 decimals)
Actual value sent is 200 * 10^10 = 20_000_000_000 (wei, 18 decimals)