### PR TITLE
fix(xrpl): handle raw hex format in XRPL faucet script

### DIFF
--- a/xrpl/cli-utils.js
+++ b/xrpl/cli-utils.js
@@ -34,7 +34,7 @@ const addBaseOptions = (program, _options = {}) => {
     program.addOption(
         new Option('--privateKeyType <privateKeyType>', 'private key type')
             .makeOptionMandatory(true)
-            .choices(['seed'])
+            .choices(['seed', 'hex'])
             .default('seed')
             .env('PRIVATE_KEY_TYPE'),
     );

--- a/xrpl/utils.js
+++ b/xrpl/utils.js
@@ -19,6 +19,12 @@ function generateWallet(options) {
 }
 
 function getWallet(options) {
+    if (options.privateKeyType === 'hex' || (options.privateKey && /^[0-9A-Fa-f]{64,}$/.test(options.privateKey))) {
+        const entropy = Buffer.from(options.privateKey, 'hex').slice(0, 16);
+        return xrpl.Wallet.fromEntropy(entropy, {
+            algorithm: options.walletKeyType,
+        });
+    }
     return xrpl.Wallet.fromSeed(options.privateKey, {
         algorithm: options.walletKeyType,
     });


### PR DESCRIPTION
When using `xrpl/faucet.js` script with a raw private key output from `xrpl/generate-wallet.js` I was getting:
```
/Users/roman/projects/axelar-contract-deployments/node_modules/@scure/base/lib/index.js:94
                    throw new Error(`Unknown letter: "${letter}". Allowed: ${letters}`);
                          ^

Error: Unknown letter: "0". Allowed: rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz
    at /Users/roman/projects/axelar-contract-deployments/node_modules/@scure/base/lib/index.js:94:27
    at Array.map (<anonymous>)
    at decode (/Users/roman/projects/axelar-contract-deployments/node_modules/@scure/base/lib/index.js:90:26)
    at /Users/roman/projects/axelar-contract-deployments/node_modules/@scure/base/lib/index.js:60:37
    at Object.decode (/Users/roman/projects/axelar-contract-deployments/node_modules/@scure/base/lib/index.js:60:35)
....
```

The issue lied in the format that was expected by default - faucet.js expectes base58 private key instead of raw hex. However, this is a bad developer experience to have to know about this when you just use defaults and copy-paste things.

This change:
  1. Auto-detect hex format private keys (64+ hex characters) and support an explicit `--privateKeyType` hex option
  2. If hex is detected, use the `fromEntropy` method

<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-08 03:22:49 UTC

This PR enhances the XRPL faucet script's private key handling to improve developer experience. The change addresses a compatibility issue where users copying hex-formatted private keys from `xrpl/generate-wallet.js` would encounter base58 decoding errors when using them with `xrpl/faucet.js`.

The fix introduces intelligent format detection and adds support for hex-formatted private keys alongside the existing base58 seed format. The implementation expands the `--privateKeyType` CLI option to accept both 'seed' and 'hex' values, with auto-detection logic that recognizes hex format keys (64+ hex characters) and uses the appropriate XRPL library method (`fromEntropy` for hex vs the default for seeds). This maintains backward compatibility while eliminating the need for users to manually convert between key formats or understand the encoding differences.

The change integrates well with the existing CLI utilities framework used throughout the codebase, following the established pattern of using commander.js options and environment variable support. This fix specifically targets the XRPL module's wallet functionality without affecting other blockchain integrations in the repository.

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| xrpl/cli-utils.js | 4/5 | Expands privateKeyType option to support both 'seed' and 'hex' formats with auto-detection |
| xrpl/utils.js | 4/5 | Adds intelligent hex format detection and uses fromEntropy method for hex private keys |

</details>

## Confidence score: 4/5

- This PR is safe to merge with low risk as it adds backward-compatible functionality
- Score reflects well-structured changes that follow existing patterns and maintain compatibility
- Pay close attention to the auto-detection logic in utils.js to ensure it correctly identifies hex format

## Sequence Diagram
```mermaid
sequenceDiagram
    participant User
    participant "xrpl/faucet.js"
    participant "xrpl/cli-utils.js"
    participant "xrpl/utils.js"
    participant "xrpl library"

    User->>+"xrpl/faucet.js": "Execute faucet script with --privateKey (hex format)"
    "xrpl/faucet.js"->>+"xrpl/cli-utils.js": "Parse command line options"
    "xrpl/cli-utils.js"->>-"xrpl/faucet.js": "Return options with privateKey and privateKeyType"
    "xrpl/faucet.js"->>+"xrpl/utils.js": "getWallet(options)"
    "xrpl/utils.js"->>+"xrpl/utils.js": "Check if privateKeyType === 'hex' || hex pattern match"
    alt Hex format detected
        "xrpl/utils.js"->>+"xrpl library": "Buffer.from(privateKey, 'hex')"
        "xrpl library"->>-"xrpl/utils.js": "Return entropy buffer"
        "xrpl/utils.js"->>+"xrpl library": "Wallet.fromEntropy(entropy, {algorithm})"
        "xrpl library"->>-"xrpl/utils.js": "Return wallet instance"
    else Seed format (default)
        "xrpl/utils.js"->>+"xrpl library": "Wallet.fromSeed(privateKey, {algorithm})"
        "xrpl library"->>-"xrpl/utils.js": "Return wallet instance"
    end
    "xrpl/utils.js"->>-"xrpl/faucet.js": "Return wallet"
    "xrpl/faucet.js"->>-User: "Wallet created successfully"
```

<!-- /greptile_comment -->