### PR TITLE
chore(devnet-amplifier): remove hedera-2 config

### DIFF
--- a/axelar-chains-config/info/devnet-amplifier.json
+++ b/axelar-chains-config/info/devnet-amplifier.json
@@ -1744,6 +1744,8 @@
           "domainSeparator": "0xde451736aa7e61c58baa7e02a0531c535a0dd8d3b5a04973d99336f34efad68b",
           "address": "axelar1xdg6lezehttusu8zfr5jnshn7d3k2jjzlmr43m6ssmxd048zjv6s4h5unj"
         },
+        "storeCodeProposalId": "82",
+        "storeCodeProposalCodeHash": "00428ef0483f103a6e1a5853c4b29466a83e5b180cc53a00d1ff9d022bc2f03a",
         "storeCodeProposalId": "1037",
         "storeCodeProposalCodeHash": "09a749a0bcd854fb64a2a5533cc6b0d5624bbd746c94e66e1f1ddbe32d495fb6"
       },


### PR DESCRIPTION
## why?

- to remove `hedera-2` from devnet-amplifier config
- _Task_: https://interoplabs.slack.com/archives/C08JH382V1T/p1757715941464099?thread_ts=1757623876.722389&cid=C08JH382V1T

## how?

- by removing `hedera-2` from the config

<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-15 22:28:44 UTC

This PR performs a comprehensive cleanup by removing the entire Hedera-2 testnet chain configuration from the devnet-amplifier environment. The change eliminates support for Hedera testnet (chain ID 296) by removing all associated configurations across both the EVM contracts section and the Axelar CosmWasm contracts section.

The removal includes the complete chain configuration with its RPC endpoints, explorer settings, and all deployed smart contracts including AxelarGateway, InterchainTokenService, AxelarGasService, and other core infrastructure contracts. Additionally, the corresponding Axelar network-side configurations are removed, including the VotingVerifier and MultisigProver contracts that handle cross-chain communication for Hedera.

This change fits into the broader pattern of environment rationalization within the Axelar ecosystem, where the devnet-amplifier configuration serves as a testing environment for new features and chain integrations. By removing Hedera-2, the team is likely consolidating their testing infrastructure, possibly due to resource optimization, redundancy with other test environments, or migration to different testing strategies. The change maintains the integrity of the configuration file by ensuring no orphaned references remain.

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| axelar-chains-config/info/devnet-amplifier.json | 5/5 | Complete removal of hedera-2 chain configuration including all EVM and CosmWasm contracts |

</details>

## Confidence score: 5/5

- This PR is safe to merge with minimal risk as it's a straightforward configuration removal
- Score reflects clean deletion with no breaking references or complex logic changes
- No files require special attention - the change is isolated to configuration cleanup

## Sequence Diagram
```mermaid
sequenceDiagram
```

<!-- /greptile_comment -->