### PR TITLE
fix(sui): do not merge - update faucet test

### DIFF
--- a/sui/faucet.js
+++ b/sui/faucet.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { requestSuiFromFaucetV2, getFaucetHost } = require('@mysten/sui/faucet');
+const { requestSuiFromFaucetV0, requestSuiFromFaucetV2, getFaucetHost } = require('@mysten/sui/faucet');
 const { saveConfig, loadConfig, printInfo, printWarn, getChainConfig } = require('../common/utils');
 const { getWallet, printWalletInfo, addBaseOptions } = require('./utils');
 const { Command, Option } = require('commander');
@@ -18,13 +18,21 @@ async function processCommand(config, chain, options) {
         process.exit(0);
     }
 
-    const faucetHost = chain.faucetUrl || getFaucetHost(chain.networkType);
+    const faucetHost = getFaucetHost(chain.networkType);
 
     try {
-        await requestSuiFromFaucetV2({
-            host: faucetHost,
-            recipient,
-        });
+        // Use V0 for localnet, V2 for other networks
+        if (chain.networkType === 'localnet') {
+            await requestSuiFromFaucetV0({
+                host: faucetHost,
+                recipient,
+            });
+        } else {
+            await requestSuiFromFaucetV2({
+                host: faucetHost,
+                recipient,
+            });
+        }
         printInfo('Funds requested', recipient);
     } catch (error) {
         printWarn(`Failed to request funds from faucet at ${faucetHost}: ${error.message}`);


### PR DESCRIPTION
testing

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-09-23 19:39:58 UTC

<h3>Summary</h3>

Updated the SUI faucet functionality to use custom faucet URLs and improved error handling. The changes add support for configurable faucet hosts through `chain.faucetUrl` and wrap the faucet request in proper try-catch error handling with informative logging.

Key improvements:
- Added support for custom faucet URLs via `chain.faucetUrl` configuration
- Implemented proper error handling with try-catch around faucet requests
- Enhanced error messaging to include the specific faucet host when requests fail
- Maintained backward compatibility by falling back to `getFaucetHost(chain.networkType)` when no custom URL is provided

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-implemented improvements that add proper error handling and configuration flexibility. The code maintains backward compatibility and follows good practices for error handling. No critical issues or security concerns were identified.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | &nbsp;&nbsp;&nbsp;&nbsp; &nbsp;  Score &nbsp;&nbsp;&nbsp;&nbsp; &nbsp; | Overview |
|----------|-------|----------|
| sui/faucet.js | 4/5 | Added custom faucet URL support and proper error handling to faucet requests |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User as User/Script
    participant Faucet as faucet.js
    participant Client as SUI Client
    participant FaucetAPI as SUI Faucet API
    
    User->>Faucet: Request funds with options
    Faucet->>Client: Get wallet balance
    Client-->>Faucet: Return current balance
    
    alt Balance >= minBalance
        Faucet->>User: Skip faucet request (balance sufficient)
    else Balance < minBalance
        Faucet->>Faucet: Determine faucet host (custom URL or default)
        Faucet->>FaucetAPI: requestSuiFromFaucetV2(host, recipient)
        alt Success
            FaucetAPI-->>Faucet: Funds transferred
            Faucet->>User: Success: Funds requested
        else Error
            FaucetAPI-->>Faucet: Error response
            Faucet->>User: Warning: Failed to request funds
            Faucet->>User: Throw error
        end
    end
```

<!-- /greptile_comment -->