### PR TITLE
docs(ampd): update ampd v1.12.0 release with v1.12.1

### DIFF
--- a/releases/ampd/2025-09-25-ampd-v1.12.1.md
+++ b/releases/ampd/2025-09-25-ampd-v1.12.1.md
@@ -1,4 +1,4 @@
-# Ampd v1.12.0
+# Ampd v1.12.1
 
 |                | **Owner**                         |
 | -------------- | --------------------------------- |
@@ -12,11 +12,11 @@
 | **Testnet**          | -                     | TBD      |
 | **Mainnet**          | -                     | TBD      |
 
-[Release](https://github.com/axelarnetwork/axelar-amplifier/releases/tag/ampd-v1.12.0)
+[Release](https://github.com/axelarnetwork/axelar-amplifier/releases/tag/ampd-v1.12.1)
 
 ## Background
 
-This ampd release fixes an issue with the account sequence management during high concurrency.
+This ampd release fixes an issue with the account sequence management during high concurrency. It also removes overhead by filtering out events before reaching each handler.
 
 ## Config change
 
@@ -39,7 +39,7 @@ tx_confirmation_queue_cap="1000"
 
 ## Deployment
 
-Restart ampd with the new binary. Binaries can be found [here](https://github.com/axelarnetwork/axelar-amplifier/releases/tag/ampd-v1.12.0)
+Restart ampd with the new binary. Binaries can be found [here](https://github.com/axelarnetwork/axelar-amplifier/releases/tag/ampd-v1.12.1)
 
 ### Checklist
 
@@ -47,7 +47,7 @@ Run the below command to output the version:
 
 ```
 $ ampd --version
-ampd 1.12.0
+ampd 1.12.1
 ```
 
 Check `ampd` logs to ensure it restarts fine. Monitor voting and signing for your verifier on axelarscan to verify it's operating correctly.


### PR DESCRIPTION
releasing 1.12.1 to fix an issue found on 1.12.0 that polluted the logs with a bunch of warnings because the metrics service got overwhelmed pretty fast

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-09-25 17:20:34 UTC

<h3>Summary</h3>

This PR adds a new release documentation file for ampd v1.12.1, which addresses performance issues found in v1.12.0 that caused excessive logging due to overwhelmed metrics services.

Key changes:
- New release documentation file with proper formatting and structure
- Documents bug fixes for account sequence management during high concurrency  
- Introduces new configuration parameters for better transaction handling
- Provides clear deployment instructions and verification steps

The documentation follows the established format used in previous ampd releases and includes all necessary information for operators to upgrade safely.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The PR only adds a new documentation file with no code changes. The documentation follows established patterns and contains clear, well-structured information for operators upgrading to ampd v1.12.1
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | &nbsp;&nbsp;&nbsp;&nbsp; &nbsp;  Score &nbsp;&nbsp;&nbsp;&nbsp; &nbsp; | Overview |
|----------|-------|----------|
| releases/ampd/2025-09-25-ampd-v1.12.1.md | 5/5 | New release documentation for ampd v1.12.1 with configuration changes and deployment instructions |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant Repo as Repository
    participant Ops as Operations Team
    participant Node as Ampd Node

    Dev->>Repo: Create v1.12.1 release documentation
    Note over Dev: Address v1.12.0 issues with metrics service
    
    Dev->>Repo: Document new configuration parameters
    Note over Dev: tx_broadcast_buffer_size, tx_confirmation_buffer_size, tx_confirmation_queue_cap
    
    Repo->>Ops: Release documentation available
    Note over Ops: Review deployment instructions
    
    Ops->>Node: Update ampd binary to v1.12.1
    Ops->>Node: Apply new configuration settings
    Node->>Node: Restart with new settings
    
    Ops->>Node: Verify version (ampd --version)
    Node-->>Ops: ampd 1.12.1
    
    Ops->>Node: Monitor logs and performance
    Note over Node: Check for reduced log noise and improved concurrency handling
```

<!-- /greptile_comment -->