### PR TITLE
fix(sui): fix support for mint_burn tokens in sui its scripts

### DIFF
--- a/releases/sui/2025-09-ITS-v1.2.0.md
+++ b/releases/sui/2025-09-ITS-v1.2.0.md
@@ -130,15 +130,7 @@ ts-node sui/its check-version-control 0
 
 ### Re-deploy Example contract
 
-1. Update the move contracts locally
-
-```bash
-ts-node sui/deploy-contract sync
-```
-
-- Note: this will ensure the `Move.toml` and `Move.lock` don't need to be manually edited
-
-2. Now, you can re-deploy the Example contract:
+1. Re-deploy the Example contract:
 
 - Note: use PRIVATE_KEY of deployer 
 
@@ -160,7 +152,7 @@ ts-node sui/its migrate-coin-metadata-all --batch 10 --logging 10
 
 ### Test ITS token deployment and transfers
 
-Test Sui Token Deployment using either lock / unlock or mint / burn token manager
+1. Test Sui Token Deployment using either lock / unlock or mint / burn token manager
 
 ```bash
 # Register token with manager type: lock / unlock
@@ -195,7 +187,7 @@ ts-node evm/its interchain-transfer sui [token-id] [recipient] [amount-to-send] 
 
 ### Test custom token linking
 
-Deploy a custom token and link it to the token on the origin chain. 
+1. Deploy a custom token and link it to the token on the origin chain. 
 
 - Note: test for both lock / unlock and mint / burn tokens
 
@@ -203,8 +195,8 @@ Deploy a custom token and link it to the token on the origin chain.
 ts-node sui/its link-coin [coin-symbol] [coin-description] [coin-decimals] [destination-chain] [destination-token-address] --tokenManagerMode ['lock_unlock' | 'mint_burn'] --destinationOperator [address]
 
 # Example (lock / unlock)
-# ts-node sui/its link-coin LNKL "Custom link coin" 10 ethereum-sepolia 0x3fc29836e84e471a053d2d9e80494a867d670ead
+# ts-node sui/its link-coin LNKL --tokenManagerMode lock_unlock "Custom link coin (lock / unlock)" 10 ethereum-sepolia 0x3fc29836e84e471a053d2d9e80494a867d670ead
 
 # Example (mint / burn)
-# ts-node sui/its link-coin LNKM "Custom link coin" 10 ethereum-sepolia 0x3fc29836e84e471a053d2d9e80494a867d670ead --tokenManagerMode mint_burn --destinationOperator 0x13f8C723AeB8CA762c652c553a11a11483846d8B
+# ts-node sui/its link-coin --tokenManagerMode mint_burn --destinationOperator 0x13f8C723AeB8CA762c652c553a11a11483846d8B LNKM "Custom link coin (mint / burn)" 10 ethereum-sepolia 0x3fc29836e84e471a053d2d9e80494a867d670ead
 ```

--- a/releases/sui/2025-09-ITS-v1.2.0.md
+++ b/releases/sui/2025-09-ITS-v1.2.0.md
@@ -167,7 +167,7 @@ Test Sui Token Deployment using either lock / unlock or mint / burn token manage
 ts-node sui/its-example deploy-token --origin LOCK "Test Token" 9
 
 # Register token with manager type: mint / burn
-ts-node sui/its-example deploy-token --tokenManagerMode "mint_burn" --origin MINT "Test Token" 9
+ts-node sui/its-example deploy-token --tokenManagerMode "mint_burn" --mintAmount 100 --origin MINT "Test Token" 9
 ```
 
 Testing Sui <-> EVM transfers
@@ -200,7 +200,7 @@ Deploy a custom token and link it to the token on the origin chain.
 - Note: test for both lock / unlock and mint / burn tokens
 
 ```bash
-ts-node sui/its link-coin [coin-symbol] [coin-description] [coin-decimals] [destination-chain] [destination-token-address] --tokenManagerMode ['lock_unlock' | 'mint_burn'] --destinationDeployer [address]
+ts-node sui/its link-coin [coin-symbol] [coin-description] [coin-decimals] [destination-chain] [destination-token-address] --tokenManagerMode ['lock_unlock' | 'mint_burn'] --destinationOperator [address]
 # Example
-# ts-node sui/its link-coin LINK "Custom link coin" 10 ethereum-sepolia 0x3fc29836e84e471a053d2d9e80494a867d670ead --tokenManagerMode mint_burn --destinationDeployer 0x13f8C723AeB8CA762c652c553a11a11483846d8B --mintAmount 1000
+# ts-node sui/its link-coin LINK "Custom link coin" 10 ethereum-sepolia 0x3fc29836e84e471a053d2d9e80494a867d670ead --tokenManagerMode mint_burn --destinationOperator 0x13f8C723AeB8CA762c652c553a11a11483846d8B
 ```

--- a/releases/sui/2025-09-ITS-v1.2.0.md
+++ b/releases/sui/2025-09-ITS-v1.2.0.md
@@ -200,7 +200,7 @@ Deploy a custom token and link it to the token on the origin chain.
 - Note: test for both lock / unlock and mint / burn tokens
 
 ```bash
-ts-node sui/its link-coin [coin-symbol] [coin-description] [coin-decimals] [destination-chain] [destination-token-address]
+ts-node sui/its link-coin [coin-symbol] [coin-description] [coin-decimals] [destination-chain] [destination-token-address] --tokenManagerMode ['lock_unlock' | 'mint_burn'] --destinationDeployer [address]
 # Example
-# ts-node sui/its link-coin LINK "Custom link coin" 10 ethereum-sepolia 0x3fc29836e84e471a053d2d9e80494a867d670ead
+# ts-node sui/its link-coin LINK "Custom link coin" 10 ethereum-sepolia 0x3fc29836e84e471a053d2d9e80494a867d670ead --tokenManagerMode mint_burn --destinationDeployer 0x13f8C723AeB8CA762c652c553a11a11483846d8B
 ```

--- a/releases/sui/2025-09-ITS-v1.2.0.md
+++ b/releases/sui/2025-09-ITS-v1.2.0.md
@@ -202,5 +202,5 @@ Deploy a custom token and link it to the token on the origin chain.
 ```bash
 ts-node sui/its link-coin [coin-symbol] [coin-description] [coin-decimals] [destination-chain] [destination-token-address] --tokenManagerMode ['lock_unlock' | 'mint_burn'] --destinationDeployer [address]
 # Example
-# ts-node sui/its link-coin LINK "Custom link coin" 10 ethereum-sepolia 0x3fc29836e84e471a053d2d9e80494a867d670ead --tokenManagerMode mint_burn --destinationDeployer 0x13f8C723AeB8CA762c652c553a11a11483846d8B
+# ts-node sui/its link-coin LINK "Custom link coin" 10 ethereum-sepolia 0x3fc29836e84e471a053d2d9e80494a867d670ead --tokenManagerMode mint_burn --destinationDeployer 0x13f8C723AeB8CA762c652c553a11a11483846d8B --mintAmount 1000
 ```

--- a/releases/sui/2025-09-ITS-v1.2.0.md
+++ b/releases/sui/2025-09-ITS-v1.2.0.md
@@ -130,7 +130,15 @@ ts-node sui/its check-version-control 0
 
 ### Re-deploy Example contract
 
-Re-deploy the Example contract:
+1. Update the move contracts locally
+
+```bash
+ts-node sui/deploy-contract sync
+```
+
+- Note: this will ensure the `Move.toml` and `Move.lock` don't need to be manually edited
+
+2. Now, you can re-deploy the Example contract:
 
 - Note: use PRIVATE_KEY of deployer 
 
@@ -156,7 +164,10 @@ Test Sui Token Deployment using either lock / unlock or mint / burn token manage
 
 ```bash
 # Register token with manager type: lock / unlock
-ts-node sui/its-example deploy-token --origin TST "Test Token" 6
+ts-node sui/its-example deploy-token --origin LOCK "Test Token" 9
+
+# Register token with manager type: mint / burn
+ts-node sui/its-example deploy-token --tokenManagerMode "mint_burn" --origin MINT "Test Token" 9
 ```
 
 Testing Sui <-> EVM transfers
@@ -165,14 +176,14 @@ Testing Sui <-> EVM transfers
 ```bash
 ts-node sui/its-example send-deployment [coin-symbol] [chain] [gas-value]
 # Example:
-# ts-node sui/its-example send-deployment TST avalanche-fuji 0.5
+# ts-node sui/its-example send-deployment LOCK avalanche-fuji 0.5
 ```
 
 2. Send Tokens to an EVM Chain
 ```bash
 ts-node sui/its-example send-token [coin-symbol] [chain] [recepient-address] [gas-value] [amount-to-send]
 # Example:
-# ts-node sui/its-example send-token TST avalanche-fuji 0xba76c6980428A0b10CFC5d8ccb61949677A61233 0.5 1000
+# ts-node sui/its-example send-token LOCK avalanche-fuji 0xba76c6980428A0b10CFC5d8ccb61949677A61233 0.5 1000
 ```
 
 3. Send Tokens Back to Sui, from an EVM Chain
@@ -184,7 +195,9 @@ ts-node evm/its interchain-transfer sui [token-id] [recipient] [amount-to-send] 
 
 ### Test custom token linking
 
-Deploy a custom token and link it to the token on the origin chain.
+Deploy a custom token and link it to the token on the origin chain. 
+
+- Note: test for both lock / unlock and mint / burn tokens
 
 ```bash
 ts-node sui/its link-coin [coin-symbol] [coin-description] [coin-decimals] [destination-chain] [destination-token-address]

--- a/releases/sui/2025-09-ITS-v1.2.0.md
+++ b/releases/sui/2025-09-ITS-v1.2.0.md
@@ -201,6 +201,10 @@ Deploy a custom token and link it to the token on the origin chain.
 
 ```bash
 ts-node sui/its link-coin [coin-symbol] [coin-description] [coin-decimals] [destination-chain] [destination-token-address] --tokenManagerMode ['lock_unlock' | 'mint_burn'] --destinationOperator [address]
-# Example
-# ts-node sui/its link-coin LINK "Custom link coin" 10 ethereum-sepolia 0x3fc29836e84e471a053d2d9e80494a867d670ead --tokenManagerMode mint_burn --destinationOperator 0x13f8C723AeB8CA762c652c553a11a11483846d8B
+
+# Example (lock / unlock)
+# ts-node sui/its link-coin LNKL "Custom link coin" 10 ethereum-sepolia 0x3fc29836e84e471a053d2d9e80494a867d670ead
+
+# Example (mint / burn)
+# ts-node sui/its link-coin LNKM "Custom link coin" 10 ethereum-sepolia 0x3fc29836e84e471a053d2d9e80494a867d670ead --tokenManagerMode mint_burn --destinationOperator 0x13f8C723AeB8CA762c652c553a11a11483846d8B
 ```

--- a/sui/its-example.js
+++ b/sui/its-example.js
@@ -184,7 +184,7 @@ async function deployToken(keypair, client, contracts, args, options) {
     const [TreasuryCap, Metadata] = getObjectIdsByObjectTypes(publishTxn, [`TreasuryCap<${tokenType}>`, `Metadata<${tokenType}>`]);
 
     // Mint tokens before registration (while user still holds the TreasuryCap)
-    const amount = isNaN(options.mintAmount) ? parseInt(options.mintAmount) : 0;
+    const amount = !isNaN(options.mintAmount) ? parseInt(options.mintAmount) : 0;
     if (amount) {
         const unitAmount = getUnitAmount(options.mintAmount, decimals);
 

--- a/sui/its-example.js
+++ b/sui/its-example.js
@@ -387,10 +387,7 @@ if (require.main === module) {
                 .default('lock_unlock')
                 .choices(['lock_unlock', 'mint_burn']),
         )
-        .addOption(
-            new Option('--mintAmount <amount>', 'Amount of tokens to mint to the deployer')
-                .default('0')
-        )
+        .addOption(new Option('--mintAmount <amount>', 'Amount of tokens to mint to the deployer').default('0'))
         .addOption(new Option('--origin', 'Deploy as a origin token or receive deployment from another chain', false))
         .action((symbol, name, decimals, options) => {
             mainProcessor(deployToken, options, [symbol, name, decimals], processCommand);

--- a/sui/its-example.js
+++ b/sui/its-example.js
@@ -387,7 +387,7 @@ if (require.main === module) {
                 .default('lock_unlock')
                 .choices(['lock_unlock', 'mint_burn']),
         )
-        .addOption(new Option('--mintAmount <amount>', 'Amount of tokens to mint to the deployer').default('0'))
+        .addOption(new Option('--mintAmount <amount>', 'Amount of tokens to mint to the deployer').default('1000000'))
         .addOption(new Option('--origin', 'Deploy as a origin token or receive deployment from another chain', false))
         .action((symbol, name, decimals, options) => {
             mainProcessor(deployToken, options, [symbol, name, decimals], processCommand);

--- a/sui/its-example.js
+++ b/sui/its-example.js
@@ -387,7 +387,7 @@ if (require.main === module) {
                 .default('lock_unlock')
                 .choices(['lock_unlock', 'mint_burn']),
         )
-        .addOption(new Option('--mintAmount <amount>', 'Amount of tokens to mint to the deployer').default('1000000'))
+        .addOption(new Option('--mintAmount <amount>', 'Amount of tokens to mint to the deployer').default('1000'))
         .addOption(new Option('--origin', 'Deploy as a origin token or receive deployment from another chain', false))
         .action((symbol, name, decimals, options) => {
             mainProcessor(deployToken, options, [symbol, name, decimals], processCommand);

--- a/sui/its-example.js
+++ b/sui/its-example.js
@@ -196,7 +196,7 @@ async function deployToken(keypair, client, contracts, args, options) {
             typeArguments: [tokenType],
         });
 
-        mintTxBuilder.tx.transferObjects([coin], recipient);
+        mintTxBuilder.tx.transferObjects([coin], walletAddress);
 
         await broadcastFromTxBuilder(mintTxBuilder, keypair, `Minted ${amount} ${symbol}`, options);
     }

--- a/sui/its-example.js
+++ b/sui/its-example.js
@@ -183,24 +183,6 @@ async function deployToken(keypair, client, contracts, args, options) {
 
     const [TreasuryCap, Metadata] = getObjectIdsByObjectTypes(publishTxn, [`TreasuryCap<${tokenType}>`, `Metadata<${tokenType}>`]);
 
-    // Mint tokens before registration (while user still holds the TreasuryCap)
-    const amount = !isNaN(options.mintAmount) ? parseInt(options.mintAmount) : 0;
-    if (amount) {
-        const unitAmount = getUnitAmount(options.mintAmount, decimals);
-
-        const mintTxBuilder = new TxBuilder(client);
-
-        const coin = await mintTxBuilder.moveCall({
-            target: `${SUI_PACKAGE_ID}::coin::mint`,
-            arguments: [TreasuryCap, unitAmount],
-            typeArguments: [tokenType],
-        });
-
-        mintTxBuilder.tx.transferObjects([coin], walletAddress);
-
-        await broadcastFromTxBuilder(mintTxBuilder, keypair, `Minted ${amount} ${symbol}`, options);
-    }
-
     // Register Token in InterchainTokenService
     const { Example, InterchainTokenService } = contracts;
     let tokenId;
@@ -208,6 +190,24 @@ async function deployToken(keypair, client, contracts, args, options) {
     const postDeployTxBuilder = new TxBuilder(client);
 
     if (options.origin) {
+        // Mint tokens before registration (while user still holds the TreasuryCap)
+        const amount = !isNaN(options.mintAmount) ? parseInt(options.mintAmount) : 0;
+        if (amount) {
+            const unitAmount = getUnitAmount(options.mintAmount, decimals);
+
+            const mintTxBuilder = new TxBuilder(client);
+
+            const coin = await mintTxBuilder.moveCall({
+                target: `${SUI_PACKAGE_ID}::coin::mint`,
+                arguments: [TreasuryCap, unitAmount],
+                typeArguments: [tokenType],
+            });
+
+            mintTxBuilder.tx.transferObjects([coin], walletAddress);
+
+            await broadcastFromTxBuilder(mintTxBuilder, keypair, `Minted ${amount} ${symbol}`, options);
+        }
+
         if (options.tokenManagerMode === 'lock_unlock') {
             await postDeployTxBuilder.moveCall({
                 target: `${Example.address}::its::register_coin`,
@@ -387,7 +387,7 @@ if (require.main === module) {
                 .default('lock_unlock')
                 .choices(['lock_unlock', 'mint_burn']),
         )
-        .addOption(new Option('--mintAmount <amount>', 'Amount of tokens to mint to the deployer').default('1000'))
+        .addOption(new Option('--mintAmount <amount>', 'Amount of tokens to mint to the deployer (must be origin).').default('1000'))
         .addOption(new Option('--origin', 'Deploy as a origin token or receive deployment from another chain', false))
         .action((symbol, name, decimals, options) => {
             mainProcessor(deployToken, options, [symbol, name, decimals], processCommand);

--- a/sui/its.js
+++ b/sui/its.js
@@ -538,7 +538,7 @@ async function linkCoin(keypair, client, config, contracts, args, options) {
     });
 
     // Link params (only outbound chain supported for now)
-    const linkParams = options.destinationDeployer ? options.destinationDeployer : '';
+    const linkParams = options.destinationOperator ? options.destinationOperator : '';
 
     messageTicket = await txBuilder.moveCall({
         target: `${itsConfig.address}::interchain_token_service::link_coin`,
@@ -960,7 +960,7 @@ if (require.main === module) {
         .addOption(
             new Option('--tokenManagerMode <mode>', 'Token Manager Mode').default('lock_unlock').choices(['lock_unlock', 'mint_burn']),
         )
-        .addOption(new Option('--destinationDeployer <address>', 'Address that deployed the token at the destination chain & address'))
+        .addOption(new Option('--destinationOperator <address>', 'Operator that can control flow limits on the destination chain'))
         .action((symbol, name, decimals, destinationChain, destinationAddress, options) => {
             mainProcessor(linkCoin, options, [symbol, name, decimals, destinationChain, destinationAddress], processCommand);
         });

--- a/sui/its.js
+++ b/sui/its.js
@@ -470,8 +470,8 @@ async function linkCoin(keypair, client, config, contracts, args, options) {
     const [symbol, name, decimals, destinationChain, destinationAddress] = args;
 
     // Token manager type
-    const tokenManagerTypes = ["lock_unlock", "mint_burn"];
-    const tokenManager = (options.tokenManagerMode) ? options.tokenManagerMode : tokenManagerTypes[0];
+    const tokenManagerTypes = ['lock_unlock', 'mint_burn'];
+    const tokenManager = options.tokenManagerMode ? options.tokenManagerMode : tokenManagerTypes[0];
 
     const walletAddress = keypair.toSuiAddress();
     const deployConfig = { client, keypair, options, walletAddress };
@@ -522,12 +522,14 @@ async function linkCoin(keypair, client, config, contracts, args, options) {
     txBuilder = new TxBuilder(client);
 
     // Token manager type
-    const tokenManagerType = tokenManager == tokenManagerTypes[1] 
-        ? await txBuilder.moveCall({
-            target: `${itsConfig.address}::token_manager_type::mint_burn`,
-        }) : await txBuilder.moveCall({
-            target: `${itsConfig.address}::token_manager_type::lock_unlock`,
-        });
+    const tokenManagerType =
+        tokenManager == tokenManagerTypes[1]
+            ? await txBuilder.moveCall({
+                  target: `${itsConfig.address}::token_manager_type::mint_burn`,
+              })
+            : await txBuilder.moveCall({
+                  target: `${itsConfig.address}::token_manager_type::lock_unlock`,
+              });
 
     // Salt
     const salt = await txBuilder.moveCall({
@@ -535,7 +537,7 @@ async function linkCoin(keypair, client, config, contracts, args, options) {
         arguments: [saltAddress],
     });
 
-    // Link params 
+    // Link params
     const linkParams = options.destinationDeployer ? options.destinationDeployer : '';
 
     messageTicket = await txBuilder.moveCall({

--- a/sui/its.js
+++ b/sui/its.js
@@ -957,7 +957,11 @@ if (require.main === module) {
             `Deploy a source coin on SUI and register it in ITS using custom registration, then link it with the destination using the destination chain name and address.`,
         )
         .addOption(new Option('--channel <channel>', 'Existing channel ID to initiate a cross-chain message over'))
-        .addOption(new Option('--tokenManagerMode <mode>', 'Either "lock_unlock" or "mint_burn", default: "lock_unlock"'))
+        .addOption(
+            new Option('--tokenManagerMode <mode>', 'Token Manager Mode')
+                .default('lock_unlock')
+                .choices(['lock_unlock', 'mint_burn']),
+        )
         .addOption(new Option('--destinationDeployer <address>', 'Address that deployed the token at the destination chain & address'))
         .action((symbol, name, decimals, destinationChain, destinationAddress, options) => {
             mainProcessor(linkCoin, options, [symbol, name, decimals, destinationChain, destinationAddress], processCommand);

--- a/sui/its.js
+++ b/sui/its.js
@@ -958,9 +958,7 @@ if (require.main === module) {
         )
         .addOption(new Option('--channel <channel>', 'Existing channel ID to initiate a cross-chain message over'))
         .addOption(
-            new Option('--tokenManagerMode <mode>', 'Token Manager Mode')
-                .default('lock_unlock')
-                .choices(['lock_unlock', 'mint_burn']),
+            new Option('--tokenManagerMode <mode>', 'Token Manager Mode').default('lock_unlock').choices(['lock_unlock', 'mint_burn']),
         )
         .addOption(new Option('--destinationDeployer <address>', 'Address that deployed the token at the destination chain & address'))
         .action((symbol, name, decimals, destinationChain, destinationAddress, options) => {

--- a/sui/its.js
+++ b/sui/its.js
@@ -952,10 +952,7 @@ if (require.main === module) {
         )
         .addOption(new Option('--channel <channel>', 'Existing channel ID to initiate a cross-chain message over'))
         .addOption(
-            new Option('--tokenManagerMode <mode>', 'Token Manager Mode')
-                .default('lock_unlock')
-                .choices(['lock_unlock', 'mint_burn'])
-                .makeOptionMandatory(true),
+            new Option('--tokenManagerMode <mode>', 'Token Manager Mode').choices(['lock_unlock', 'mint_burn']).makeOptionMandatory(true),
         )
         .addOption(new Option('--destinationOperator <address>', 'Operator that can control flow limits on the destination chain'))
         .action((symbol, name, decimals, destinationChain, destinationAddress, options) => {

--- a/sui/its.js
+++ b/sui/its.js
@@ -537,7 +537,7 @@ async function linkCoin(keypair, client, config, contracts, args, options) {
         arguments: [saltAddress],
     });
 
-    // Link params
+    // Link params (only outbound chain supported for now)
     const linkParams = options.destinationDeployer ? options.destinationDeployer : '';
 
     messageTicket = await txBuilder.moveCall({

--- a/sui/its.js
+++ b/sui/its.js
@@ -952,7 +952,10 @@ if (require.main === module) {
         )
         .addOption(new Option('--channel <channel>', 'Existing channel ID to initiate a cross-chain message over'))
         .addOption(
-            new Option('--tokenManagerMode <mode>', 'Token Manager Mode').default('lock_unlock').choices(['lock_unlock', 'mint_burn']).makeOptionMandatory(true),
+            new Option('--tokenManagerMode <mode>', 'Token Manager Mode')
+                .default('lock_unlock')
+                .choices(['lock_unlock', 'mint_burn'])
+                .makeOptionMandatory(true),
         )
         .addOption(new Option('--destinationOperator <address>', 'Operator that can control flow limits on the destination chain'))
         .action((symbol, name, decimals, destinationChain, destinationAddress, options) => {

--- a/sui/utils/its-utils.js
+++ b/sui/utils/its-utils.js
@@ -41,7 +41,7 @@ async function registerCustomCoinUtil(config, itsConfig, AxelarGateway, coinSymb
 
     // TreasuryCapReclaimer<T>
     const treasuryCapReclaimerType = [itsConfig.structs.TreasuryCapReclaimer, '<', coinType, '>'].join('');
-    if (config.options.treasuryCap) {
+    if (treasuryCap) {
         const treasuryCapReclaimer = await txBuilder.moveCall({
             target: `${STD_PACKAGE_ID}::option::extract`,
             arguments: [treasuryCapReclaimerOption],


### PR DESCRIPTION
This PR adds support for custom token linking for tokens with mint / burn as token manager type in the ITS scripts. Additionally, it applies a temp fix to the Example contract scripts that makes the `send-token` script work for tokens with mint / burn token manager type. More work will need to be done to make the `mint-token` work for the Example contract scripts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enable mint/burn token support across Sui ITS scripts with pre-mint on deploy and updated link-coin options/flow, plus doc updates.
> 
> - **Scripts**:
>   - `sui/its-example.js`
>     - Pre-mint on origin deployment via `--mintAmount` before registration.
>     - Register with `register_coin_with_cap` when `--tokenManagerMode mint_burn`; default remains `lock_unlock`.
>   - `sui/its.js`
>     - `link-coin`: dynamic token manager type (`--tokenManagerMode`), optional `--destinationOperator` passed as link params, improved errors.
>     - Pass `treasuryCap` to custom registration when using mint/burn.
>   - `sui/utils/its-utils.js`
>     - Use provided `treasuryCap` flag/arg to extract and transfer `TreasuryCapReclaimer` (instead of config flag).
> - **Docs** (`releases/sui/2025-09-ITS-v1.2.0.md`):
>   - Update examples to cover both `lock_unlock` and `mint_burn` flows; clarify steps and sample commands.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea5bc838a797eab8d43519ad241f7602c87aa948. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-09-29 21:46:23 UTC

<h3>Summary</h3>

This PR adds comprehensive support for mint/burn tokens in Sui ITS scripts. The changes enable custom token linking for both lock/unlock and mint/burn token manager types, with enhanced script functionality for the Example contract.

Key changes include:
- Added `--mintAmount` option to `deploy-token` command for pre-minting tokens before registration
- Enhanced `link-coin` functionality with `--tokenManagerMode` and `--destinationOperator` parameters
- Updated documentation with clear examples for both token manager types
- Proper handling of TreasuryCap for mint/burn tokens during registration

The implementation correctly handles the different registration paths based on token manager type and maintains backward compatibility with existing lock/unlock functionality.

<h3>Confidence Score: 4/5</h3>

- This PR is mostly safe to merge with one minor logical issue that should be addressed
- Score reflects solid implementation of new functionality with comprehensive documentation updates, but reduced by one point due to a type coercion inconsistency in the minting logic that could cause unexpected behavior
- sui/its-example.js requires attention for the type coercion issue in the mint amount handling

<h3>Important Files Changed</h3>



File Analysis



| Filename | &nbsp;&nbsp;&nbsp;&nbsp; &nbsp;  Score &nbsp;&nbsp;&nbsp;&nbsp; &nbsp; | Overview |
|----------|-------|----------|
| sui/its-example.js | 4/5 | Added mint functionality for tokens before registration and support for mint_burn token manager mode with --mintAmount option |
| sui/its.js | 4/5 | Enhanced link-coin functionality with mint_burn token manager support and destinationOperator parameter |
| releases/sui/2025-09-ITS-v1.2.0.md | 5/5 | Updated documentation to support both lock/unlock and mint/burn token manager types with new examples and clarifications |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Script as its-example.js
    participant ITS as InterchainTokenService
    participant TM as TokenManager
    
    User->>Script: deploy-token --tokenManagerMode mint_burn --mintAmount 100
    Script->>Script: Deploy coin package
    Script->>Script: Mint tokens (if mintAmount > 0)
    
    alt Token Manager Type: mint_burn
        Script->>ITS: register_coin_with_cap(metadata, treasuryCap)
        ITS->>TM: Create mint/burn token manager
    else Token Manager Type: lock_unlock  
        Script->>ITS: register_coin(metadata)
        ITS->>TM: Create lock/unlock token manager
    end
    
    Script->>User: Token deployed with appropriate manager type
    
    User->>Script: link-coin --tokenManagerMode mint_burn --destinationOperator 0x123
    Script->>ITS: register_coin_metadata(metadata)
    Script->>ITS: register_custom_coin(treasuryCap if mint_burn)
    Script->>ITS: link_coin(destinationChain, destinationAddress, tokenManagerType, linkParams)
    ITS->>User: Token linked with destination
```

<!-- /greptile_comment -->