### PR TITLE
fix: break link-coin command

### DIFF
--- a/sui/README.md
+++ b/sui/README.md
@@ -518,6 +518,8 @@ Deploys a source coin and links it with a destination chain coin. If a `channel`
 
 ```bash
 ts-node sui/its link-coin <symbol> <name> <decimals> <destinationChain> <destinationAddress>
+
+node sui/its.js link-coin-with-channel <symbol> <destinationChain> <destinationAddress> --channel <channelId> --tokenManagerMode <lock_unlock|mint_burn> --gasValue <amount_in_SUI> --saltAddress <addr>
 ```
 
 ### Deploy Remote Interchain Coin

--- a/sui/README.md
+++ b/sui/README.md
@@ -519,7 +519,7 @@ Deploys a source coin and links it with a destination chain coin. If a `channel`
 ```bash
 ts-node sui/its link-coin <symbol> <name> <decimals> <destinationChain> <destinationAddress>
 
-node sui/its.js link-coin-with-channel <symbol> <destinationChain> <destinationAddress> --channel <channelId> --tokenManagerMode <lock_unlock|mint_burn> --gasValue <amount_in_SUI> --saltAddress <addr>
+ts-node sui/its.js link-coin-with-channel <symbol> <destinationChain> <destinationAddress> --channel <channelId> --tokenManagerMode <lock_unlock|mint_burn> --gasValue <amount_in_SUI> --saltAddress <addr>
 ```
 
 ### Deploy Remote Interchain Coin

--- a/sui/its.js
+++ b/sui/its.js
@@ -516,7 +516,7 @@ async function linkCoin(keypair, client, config, contracts, args, options) {
     }
 
     printInfo(`ChannelId : ${channelId}`);
-    
+
     const sourceToken = { metadata, packageId, tokenType, treasuryCap };
 
     // Save deployed tokens

--- a/sui/its.js
+++ b/sui/its.js
@@ -897,6 +897,28 @@ async function linkCoinWithChannel(keypair, client, config, contracts, args, opt
     });
 
     await broadcastFromTxBuilder(txBuilder, keypair, `Link Coin (channel=${options.channel})`, options);
+
+    // Save linked token info in config
+    const symbolKey = symbol.toUpperCase();
+    const coin = contracts[symbolKey];
+    if (!coin) {
+        throw new Error(`Token ${symbolKey} not found in contracts config. Run registration first.`);
+    }
+
+    const linkedToken = { destinationChain, destinationAddress };
+
+    saveTokenDeployment(
+        coin.address,
+        coin.typeArgument,
+        contracts,
+        symbol,
+        coin.decimals,
+        coin.objects.TokenId,
+        coin.objects.TreasuryCap,
+        coin.objects.Metadata,
+        [linkedToken],
+        saltAddress,
+    );
 }
 
 async function processCommand(command, config, chain, args, options) {


### PR DESCRIPTION
## why?

- ...
- _Task_: ?

## how?

- ...

### testing

- ...

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Splits linking flow by adding `link-coin-with-channel` (uses existing channel, pays gas, sends link message) and trimming `link-coin` to deploy/register only; updates docs and CLI.
> 
> - **ITS CLI (sui/its.js)**
>   - **New command**: `link-coin-with-channel <symbol> <destinationChain> <destinationAddress> --channel <channelId> --tokenManagerMode <lock_unlock|mint_burn> --gasValue <amount_in_SUI> [--saltAddress <addr>]`.
>     - Constructs salt, selects token manager type, pays gas via `GasService::pay_gas`, sends link message via `AxelarGateway::gateway::send_message`, and saves `[linkedToken]` to config.
>   - **Refactor `link-coin`**: Remove in-command linking and message send; now only deploys/registers coin and saves deployment with empty `linkedTokens`.
>     - Logs resolved `channelId`.
> - **Docs (sui/README.md)**
>   - Add usage example for `link-coin-with-channel` alongside `link-coin`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 40c287015425fd69af0cd39e9365955d84d9ed5b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-01 13:16:51 UTC

<h3>Summary</h3>
This PR refactors the `link-coin` command in the Sui ITS (Interchain Token Service) implementation by breaking it into two separate, more focused commands. The original `link-coin` command was performing both token deployment/registration AND cross-chain linking in a single operation, which has been split for better separation of concerns.

The refactored `link-coin` command now only handles:
- Token deployment and registration with the ITS
- Generation of a channelId for the token
- Saving token deployment information (but with an empty linked tokens array)

The new `link-coin-with-channel` command handles the actual cross-chain linking functionality:
- Requires an existing channelId (from a previous `link-coin` operation)
- Handles token manager type configuration
- Manages gas payments for cross-chain transactions
- Performs the actual linking via gateway message sending

This change aligns with the principle of single responsibility, allowing developers to deploy tokens first and then link them to destination chains in separate steps. The documentation in `sui/README.md` has been updated to reflect both command options, providing users with examples of the simpler `link-coin` command and the more advanced `link-coin-with-channel` command with its additional parameters.

## Important Files Changed

<details><summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| sui/its.js | 4/5 | Breaks link-coin command into two separate commands, removing 49 lines of linking logic from the original command and adding new linkCoinWithChannel function |
| sui/README.md | 5/5 | Documentation update adding example usage for the new link-coin-with-channel command alongside existing link-coin command |

</details>

## Confidence score: 4/5

- This PR appears safe to merge with the separation of concerns improving code maintainability and user experience
- Score reflects solid architectural improvement with clear separation between deployment and linking phases
- The documentation file requires no special attention, but the main logic changes in sui/its.js should be tested to ensure both commands work independently

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant CLI as "CLI (sui/its.js)"
    participant TxBuilder as "Transaction Builder"
    participant ITS as "InterchainTokenService"
    participant Gateway as "AxelarGateway"
    participant GasService as "Gas Service"
    participant Blockchain as "Sui Network"

    User->>CLI: "link-coin-with-channel <symbol> <destinationChain> <destinationAddress> --channel <channelId>"
    CLI->>CLI: "Validate parameters and options"
    CLI->>TxBuilder: "Create new TxBuilder instance"
    
    TxBuilder->>ITS: "Call token_manager_type with tokenManagerMode"
    ITS-->>TxBuilder: "Return tokenManagerType object"
    
    TxBuilder->>Gateway: "Create bytes32 salt from saltAddress"
    Gateway-->>TxBuilder: "Return salt object"
    
    TxBuilder->>ITS: "Call link_coin with parameters"
    Note over TxBuilder,ITS: "Parameters: InterchainTokenService, channel, salt, destinationChain, destinationAddress, tokenManagerType, linkParams"
    ITS-->>TxBuilder: "Return messageTicket"
    
    TxBuilder->>TxBuilder: "Split gas coins for payment"
    
    TxBuilder->>GasService: "Call pay_gas with messageTicket and gas"
    GasService-->>TxBuilder: "Gas payment processed"
    
    TxBuilder->>Gateway: "Call send_message with messageTicket"
    Gateway-->>TxBuilder: "Message queued for sending"
    
    CLI->>Blockchain: "Broadcast transaction"
    Blockchain-->>CLI: "Transaction result"
    
    CLI->>CLI: "Save linked token info to config"
    CLI-->>User: "Link Coin operation completed"
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->