### PR TITLE
fix: destructure its fee sui

### DIFF
--- a/sui/its.js
+++ b/sui/its.js
@@ -758,7 +758,7 @@ async function interchainTransfer(keypair, client, config, contracts, args, opti
         arguments: [itsConfig.objects.InterchainTokenService, prepareInterchainTransferTicket, suiClockAddress],
     });
 
-    const gasValue = await estimateITSFee(
+    const {gasValue} = await estimateITSFee(
         config.chains[options.chainName],
         destinationChain,
         options.env,

--- a/sui/its.js
+++ b/sui/its.js
@@ -758,7 +758,7 @@ async function interchainTransfer(keypair, client, config, contracts, args, opti
         arguments: [itsConfig.objects.InterchainTokenService, prepareInterchainTransferTicket, suiClockAddress],
     });
 
-    const {gasValue} = await estimateITSFee(
+    const { gasValue } = await estimateITSFee(
         config.chains[options.chainName],
         destinationChain,
         options.env,


### PR DESCRIPTION
## why?
bug exists on sui its transfer due to gas est call

- ...
- _Task_: ?

## how?
destructured `gasValue` from `estimateItsFee` to return correct value

- ...

### testing

- ...

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Properly destructures `gasValue` from `estimateITSFee` result for Sui ITS interchain transfer gas payment.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 355e8671e8f358852820e4047e42db577dfbf01c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-01 19:37:48 UTC

<h3>Summary</h3>
This PR fixes a bug in the Sui Interchain Token Service (ITS) transfer functionality related to gas estimation. The issue was that the `estimateITSFee` function returns an object containing a `gasValue` property, but the code was treating it as if it returned the gas value directly as a primitive.

The fix destructures the return value from `estimateITSFee()` to properly extract the `gasValue` property: `const {gasValue} = await estimateITSFee(...)` instead of assigning the entire returned object. This `gasValue` is then correctly used in the subsequent `tx.splitCoins(tx.gas, [gasValue])` call to allocate the proper gas amount for the interchain transfer transaction.

This change integrates seamlessly with the existing codebase as it maintains the same API and functionality while fixing the underlying data extraction issue. The `estimateITSFee` function is imported from `../common/utils` and is used specifically in the `interchainTransfer` function within the ITS operations workflow.

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| sui/its.js | 5/5 | Fixed gas estimation bug by properly destructuring `gasValue` from `estimateITSFee` return object |

</details>

## Confidence score: 5/5

- This PR is safe to merge with minimal risk as it's a straightforward bug fix addressing a clear data extraction issue
- Score reflects the simple nature of the change and clear problem-solution alignment with no side effects
- No files require special attention as this is a single-line fix with obvious intent and impact

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant ITSScript as "ITS Script"
    participant Utils as "Utils"
    participant TxBuilder
    participant Client as "Sui Client"
    participant Gateway as "Axelar Gateway"
    participant GasService

    User->>ITSScript: "interchainTransfer(...)"
    ITSScript->>Utils: "validateParameters(...)"
    ITSScript->>Utils: "validateDestinationChain(...)"
    ITSScript->>Utils: "checkIfCoinExists(...)"
    Utils->>Client: "getObject(...)"
    Client-->>Utils: "coin object data"
    ITSScript->>Utils: "checkIfSenderHasSufficientBalance(...)"
    Utils->>Client: "getBalance(...)"
    Client-->>Utils: "balance data"
    
    ITSScript->>TxBuilder: "new TxBuilder(client)"
    ITSScript->>TxBuilder: "moveCall(token_id::from_u256)"
    ITSScript->>TxBuilder: "moveCall(channel::new)"
    ITSScript->>TxBuilder: "splitCoins(coinObjectId, amount)"
    ITSScript->>TxBuilder: "moveCall(prepare_interchain_transfer)"
    ITSScript->>TxBuilder: "moveCall(send_interchain_transfer)"
    
    ITSScript->>Utils: "estimateITSFee(...)"
    Utils-->>ITSScript: "{gasValue}"
    
    ITSScript->>TxBuilder: "splitCoins(tx.gas, gasValue)"
    ITSScript->>TxBuilder: "moveCall(gas_service::pay_gas)"
    ITSScript->>TxBuilder: "moveCall(gateway::send_message)"
    ITSScript->>TxBuilder: "moveCall(channel::destroy)"
    
    alt offline mode
        ITSScript->>Utils: "saveGeneratedTx(...)"
    else online mode
        ITSScript->>Utils: "broadcastFromTxBuilder(...)"
        Utils->>Client: "signAndExecuteTransaction(...)"
        Client-->>Utils: "transaction result"
        Utils-->>ITSScript: "broadcast result"
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->