### PR TITLE
Feat/coordinator migration check

### DIFF
--- a/cosmwasm/migrate/coordinator.ts
+++ b/cosmwasm/migrate/coordinator.ts
@@ -283,16 +283,16 @@ async function checkCoordinatorToVersion2_1_0(client: CosmWasmClient, config, co
 
             const prover_seen = multisig_map.get(chain);
             if (prover_seen != prover) {
-                console.log(`Multisig prover mismatch for chain ${chain}: expected ${prover}, saw ${prover_seen}`);
+                console.log(`Coordinator's prover does not match multisig's for chain ${chain}: expected ${prover_seen}, saw ${prover}`);
                 state_is_consistent = false;
                 continue;
             }
         }
 
         if (!state_is_consistent) {
-            console.error(`Error: state of coordinator v2 is not consistent with the rest of protocol`);
+            console.error(`❌ State of coordinator v2 is not consistent with the rest of protocol`);
         } else {
-            console.log(`Migration succeeded!`);
+            console.log(`✅ Migration succeeded!`);
         }
     } catch (e) {
         // These errors should never happen, as it would indicate a critical problem in the

--- a/cosmwasm/migrate/coordinator.ts
+++ b/cosmwasm/migrate/coordinator.ts
@@ -180,6 +180,18 @@ async function coordinatorToVersion2_1_0(
     }
 }
 
+async function checkCoordinatorToVersion2_1_0(
+    client: typeof SigningCosmWasmClient,
+    config,
+    coordinator_address?: string,
+    multisig_address?: string,
+) {
+    coordinator_address = coordinator_address ?? config.axelar.contracts.Coordinator.address;
+    multisig_address = multisig_address ?? config.axelar.contracts.Multisig.address;
+
+    console.log(`"Coordinator ${coordinator_address}, Multisig ${multisig_address}`);
+}
+
 export async function migrate(
     client: typeof SigningCosmWasmClient,
     options: MigrationOptions,
@@ -194,5 +206,20 @@ export async function migrate(
             return coordinatorToVersion2_1_0(client, options, config, sender_address, coordinator_address, code_id);
         default:
             console.error(`no migration script found for coordinator ${version}`);
+    }
+}
+
+export async function checkMigration(
+    client: typeof SigningCosmWasmClient,
+    config,
+    version: string,
+    coordinator_address?: string,
+    multisig_address?: string,
+) {
+    switch (version) {
+        case '2.1.0':
+            return checkCoordinatorToVersion2_1_0(client, config, coordinator_address, multisig_address);
+        default:
+            console.error(`no migration check script found for coordinator ${version}`);
     }
 }

--- a/cosmwasm/migrate/migrate.ts
+++ b/cosmwasm/migrate/migrate.ts
@@ -1,16 +1,16 @@
 'use strict';
 
+import { CosmWasmClient } from '@cosmjs/cosmwasm-stargate';
 import { StdFee } from '@cosmjs/stargate';
 import { Command, Option } from 'commander';
 
+import { addEnvOption } from '../../common/cli-utils';
 import { FullConfig } from '../../common/config';
 import { addAmplifierOptions, addAmplifierQueryContractOptions } from '../cli-utils';
 import { ClientManager, mainProcessor, mainQueryProcessor } from '../processor';
 import { getContractInfo } from '../query';
-import { migrate as migrateCoordinator, checkMigration as checkMigrationCoordinator} from './coordinator';
+import { checkMigration as checkMigrationCoordinator, migrate as migrateCoordinator } from './coordinator';
 import { MigrationCheckOptions, MigrationOptions } from './types';
-import { addEnvOption } from '../../common/cli-utils';
-import { CosmWasmClient } from '@cosmjs/cosmwasm-stargate';
 
 async function migrate(
     client: ClientManager,
@@ -86,7 +86,7 @@ const programHandler = () => {
             .action((options: MigrationCheckOptions) => {
                 mainQueryProcessor(checkMigration, options, []);
             }),
-    )
+    );
 
     program.parse();
 };

--- a/cosmwasm/migrate/types.ts
+++ b/cosmwasm/migrate/types.ts
@@ -11,6 +11,12 @@ export interface MigrationOptions extends Options {
 
 export interface MigrationCheckOptions extends Options {
     address?: string;
-    coordinator?: string,
-    multisig?: string,
+    coordinator?: string;
+    multisig?: string;
+}
+
+export interface ProtocolContracts {
+    service_registry: string;
+    router: string;
+    multisig: string;
 }

--- a/cosmwasm/migrate/types.ts
+++ b/cosmwasm/migrate/types.ts
@@ -8,3 +8,9 @@ export interface MigrationOptions extends Options {
     proposal?: boolean;
     ignoreChains?: string;
 }
+
+export interface MigrationCheckOptions extends Options {
+    address?: string;
+    coordinator?: string,
+    multisig?: string,
+}

--- a/releases/cosmwasm/2025-09-Coordinator-v2.1.0.md
+++ b/releases/cosmwasm/2025-09-Coordinator-v2.1.0.md
@@ -207,3 +207,11 @@ The coordinator can now deploy a gateway, voting verifier, and multisig prover c
    ```bash
    {contract: 'coordinator', version: '2.1.0'}
    ```
+
+1. Check that the coordinator uses the same provers that the multisig uses for each chain.
+   
+   ```
+   ts-node cosmwasm/migrate/migrate.ts check -e $ENV -c Coordinator 
+   ```
+
+   You may manually specify the address of the coordinator and multisig by using the `--coordinator` and `--multisig` flags respectively.


### PR DESCRIPTION
## Description

This is a script that checks whether or not the coordinator v2's migration succeeded with respect to the multisig contract. In particular, it checks that every prover/chain pair in the coordinator can be found in the multisig contract. For detailed description of the situation this checks for, please see [ARC-8](https://github.com/axelarnetwork/arcs/pull/18).

## how?

- ...

### testing

- ...
