### PR TITLE
fix(cosmwasm,coordinator): adjust coordinator query command to contract's API

### DIFF
--- a/cosmwasm/query.ts
+++ b/cosmwasm/query.ts
@@ -161,7 +161,7 @@ async function saveDeployedContracts(client, config, _options, args, _fee) {
     let result;
     try {
         result = await client.queryContractSmart(coordinatorAddress, {
-            deployed_contracts: {
+            deployment: {
                 deployment_name: deploymentName,
             },
         });
@@ -172,11 +172,11 @@ async function saveDeployedContracts(client, config, _options, args, _fee) {
     }
 
     if (
-        !result.verifier ||
+        !result.verifier_address ||
         !config.axelar.contracts.VotingVerifier?.[chainName] ||
-        !result.prover ||
+        !result.prover_address ||
         !config.axelar.contracts.MultisigProver?.[chainName] ||
-        !result.gateway
+        !result.gateway_address
     ) {
         return printWarn(
             `Missing config for ${chainName}.`,
@@ -184,29 +184,17 @@ async function saveDeployedContracts(client, config, _options, args, _fee) {
         );
     }
 
-    config.axelar.contracts.VotingVerifier[chainName] = {
-        ...config.axelar.contracts.VotingVerifier[chainName],
-        address: result.verifier,
-    };
-    printInfo(`Updated VotingVerifier[${chainName}].address`, result.verifier);
+    config.initContractConfig('VotingVerifier', chainName);
+    config.initContractConfig('MultisigProver', chainName);
+    config.initContractConfig('Gateway', chainName);
 
-    if (!config.axelar.contracts.Gateway) {
-        config.axelar.contracts.Gateway = {};
-    }
-    if (!config.axelar.contracts.Gateway[chainName]) {
-        config.axelar.contracts.Gateway[chainName] = {};
-    }
-    config.axelar.contracts.Gateway[chainName] = {
-        ...config.axelar.contracts.Gateway[chainName],
-        address: result.gateway,
-    };
-    printInfo(`Updated Gateway[${chainName}].address`, result.gateway);
+    config.axelar.contracts.VotingVerifier[chainName].address = result.verifier_address;
+    config.axelar.contracts.MultisigProver[chainName].address = result.prover_address;
+    config.axelar.contracts.Gateway[chainName].address = result.gateway_address;
 
-    config.axelar.contracts.MultisigProver[chainName] = {
-        ...config.axelar.contracts.MultisigProver[chainName],
-        address: result.prover,
-    };
-    printInfo(`Updated MultisigProver[${chainName}].address`, result.prover);
+    printInfo(`Updated VotingVerifier[${chainName}].address`, result.verifier_address);
+    printInfo(`Updated MultisigProver[${chainName}].address`, result.prover_address);
+    printInfo(`Updated Gateway[${chainName}].address`, result.gateway_address);
     printInfo(`Config updated successfully for ${chainName}`);
 }
 


### PR DESCRIPTION
## why?
There's mismatch between deployment's query script and the Coordinator contract API.

### testing
Manually tested on custom devnet

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates Coordinator query to use `deployment` and new `*_address` fields, and simplifies contract config initialization before saving addresses.
> 
> - **Coordinator query and config updates**:
>   - Switch query payload to `deployment` with `deployment_name`.
>   - Use response fields `verifier_address`, `prover_address`, `gateway_address` instead of `verifier`, `prover`, `gateway`.
>   - Initialize configs via `config.initContractConfig('VotingVerifier'|'MultisigProver'|'Gateway', chainName)` and then set `.address` fields.
>   - Update corresponding info logs to reflect new field names.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e5c8c0d1cf269928a5af27006205308f1bd4b82a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-03 14:37:51 UTC

<h3>Summary</h3>
This PR fixes a mismatch between the deployment query script and the Coordinator contract's API in the CosmWasm module. The changes update the query structure and field mappings to align with the actual contract interface.

The primary modifications include:
- Changing the query from `deployed_contracts` to `deployment` to match the contract's expected query structure
- Updating field name mappings from generic names (`verifier`, `prover`, `gateway`) to more specific address field names (`verifier_address`, `prover_address`, `gateway_address`)
- Refactoring the contract configuration update logic to use the `initContractConfig` method with direct assignment instead of spread operators

This fix ensures proper communication between the deployment tooling and the Coordinator contract, which is critical for querying deployed contract addresses in the CosmWasm ecosystem. The change improves maintainability by centralizing configuration initialization and eliminating redundant operations.

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| cosmwasm/query.ts | 4/5 | Updates query structure from `deployed_contracts` to `deployment` and adjusts field mappings to match Coordinator contract API |

</details>
<h3>Confidence score: 4/5</h3>

- This PR is safe to merge with minimal risk as it addresses a clear API mismatch issue
- Score reflects straightforward API alignment changes that improve contract communication
- No files require special attention beyond standard review of the query logic changes

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant CLI as "Query CLI"
    participant Client as "CosmWasmClient"
    participant Coordinator as "Coordinator Contract"
    participant Config as "Config System"
    participant ITS as "ITS Hub Contract"
    participant Other as "Other Contracts"

    User->>CLI: "Execute query command"
    CLI->>Client: "Initialize CosmWasm client"
    
    alt saveDeployedContracts command
        CLI->>Config: "Get coordinator address"
        CLI->>Config: "Get deployment name for chain"
        CLI->>Coordinator: "Query deployment with deployment_name"
        Coordinator-->>CLI: "Return verifier_address, prover_address, gateway_address"
        CLI->>Config: "Update VotingVerifier address"
        CLI->>Config: "Update MultisigProver address" 
        CLI->>Config: "Update Gateway address"
        CLI->>User: "Print success message"
    end
    
    alt tokenConfig command
        CLI->>Config: "Get ITS Hub address"
        CLI->>ITS: "Query token_config with token_id"
        ITS-->>CLI: "Return token configuration"
        CLI->>User: "Print token config"
    end
    
    alt rewards command
        CLI->>Config: "Get multisig and voting verifier addresses"
        CLI->>Other: "Query rewards_pool for multisig"
        Other-->>CLI: "Return rewards pool data"
        CLI->>Other: "Query rewards_pool for voting verifier"
        Other-->>CLI: "Return rewards pool data"
        CLI->>User: "Print rewards information"
    end
    
    alt contractInfo command
        CLI->>Config: "Get contract address"
        CLI->>Client: "Query contract raw data"
        Client-->>CLI: "Return contract info"
        CLI->>User: "Print contract information"
    end
    
    alt customTokenMetadata command
        CLI->>Config: "Get ITS Hub address and chain config"
        CLI->>ITS: "Query custom_token_metadata"
        ITS-->>CLI: "Return token metadata"
        CLI->>User: "Print token metadata"
    end
    
    alt tokenInstance command
        CLI->>Config: "Get ITS Hub address and chain config"
        CLI->>ITS: "Query token_instance"
        ITS-->>CLI: "Return token instance"
        CLI->>User: "Print token instance"
    end
    
    alt itsChainConfig command
        CLI->>Config: "Get chain config"
        CLI->>ITS: "Query its_chain"
        ITS-->>CLI: "Return chain configuration"
        CLI->>User: "Print chain config"
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->