### PR TITLE
fix: use config governance address as default for runAs

### DIFF
--- a/cosmwasm/processor.ts
+++ b/cosmwasm/processor.ts
@@ -38,12 +38,12 @@ function prepareProcessor(options: Options): { configManager: ConfigManager; fee
     const configManager = new ConfigManager(env);
     const fee = configManager.getFee();
 
+    configManager.initContractConfig(options.contractName, options.chainName);
+
     options.runAs =
         runAs || configManager.axelar?.contracts?.ServiceRegistry?.governanceAccount || 'axelar10d07y265gmmuvt4z0w9aw880jnsr700j7v9daj';
     options.deposit = deposit || configManager.getProposalDepositAmount();
     options.instantiateAddresses = instantiateAddresses || configManager.getProposalInstantiateAddresses();
-
-    configManager.initContractConfig(options.contractName, options.chainName);
 
     return { configManager, fee };
 }


### PR DESCRIPTION
## why?
Governance address is hardcoded in `runAs` option default, which creates issues for custom devnets. This PR changes the default to get the governance address from the chain config.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Derives `options.runAs` from `configManager.axelar.contracts.ServiceRegistry.governanceAccount` with a hardcoded fallback and initializes contract config before setting defaults.
> 
> - **Processor (`cosmwasm/processor.ts`)**:
>   - **Default `runAs`**: Use `configManager.axelar?.contracts?.ServiceRegistry?.governanceAccount` with fallback to `axelar10d07y265gmmuvt4z0w9aw880jnsr700j7v9daj`; remove env-specific hardcoded address logic.
>   - **Init order**: Call `configManager.initContractConfig(options.contractName, options.chainName)` before computing defaults.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ce9431074ad49dbc2c2eb492274a1cba22b111ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-03 17:34:02 UTC

<h3>Summary</h3>
This PR fixes a configuration management issue with the `runAs` option in the CosmWasm processor. Previously, the governance address was hardcoded using environment-specific logic that checked if the environment was 'devnet-amplifier' and assigned different hardcoded addresses accordingly. This approach created deployment issues for teams running custom devnet environments that didn't fit into the predefined categories.

The change replaces the hardcoded conditional logic with a dynamic lookup that sources the governance address from the chain configuration at `configManager.axelar?.contracts?.ServiceRegistry?.governanceAccount`. This follows the configuration-driven approach used throughout the codebase, where deployment parameters are specified in environment-specific config files rather than hardcoded in the source code.

The modification maintains full backward compatibility by keeping the same mainnet governance address (`axelar10d07y265gmmuvt4z0w9aw880jnsr700j7v9daj`) as the final fallback when the config property doesn't exist. This ensures existing deployments continue to work while enabling custom devnets to specify their own governance addresses in their configuration files.

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| cosmwasm/processor.ts | 4/5 | Replaces hardcoded governance address logic with config-based lookup for better devnet flexibility |

</details>
<h3>Confidence score: 4/5</h3>

- This PR is safe to merge with minimal risk as it addresses a legitimate configuration management issue
- Score reflects a straightforward configuration change that improves flexibility without breaking existing functionality
- No files require special attention as the change is simple and maintains backward compatibility

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant CLI as "CLI Command"
    participant Processor as "mainProcessor/mainQueryProcessor"
    participant ConfigManager as "ConfigManager"
    participant Client as "CosmWasm Client"
    participant Blockchain as "Axelar Network"
    
    User->>CLI: "Execute cosmwasm command with options"
    CLI->>Processor: "Call with processorFn and options"
    Processor->>ConfigManager: "new ConfigManager(env)"
    ConfigManager-->>Processor: "Return config instance"
    
    Processor->>ConfigManager: "getFee()"
    ConfigManager-->>Processor: "Return fee configuration"
    
    Processor->>ConfigManager: "axelar?.contracts?.ServiceRegistry?.governanceAccount"
    ConfigManager-->>Processor: "Return governance address or undefined"
    
    alt If governance address exists in config
        Processor->>Processor: "Set runAs to config governance address"
    else If no governance address in config
        Processor->>Processor: "Set runAs to hardcoded fallback address"
    end
    
    Processor->>ConfigManager: "getProposalDepositAmount()"
    ConfigManager-->>Processor: "Return deposit amount"
    
    Processor->>ConfigManager: "getProposalInstantiateAddresses()"
    ConfigManager-->>Processor: "Return instantiate addresses"
    
    Processor->>ConfigManager: "initContractConfig(contractName, chainName)"
    ConfigManager-->>Processor: "Initialize contract configuration"
    
    alt If mnemonic provided (mainProcessor)
        Processor->>Client: "DirectSecp256k1HdWallet.fromMnemonic()"
        Client-->>Processor: "Return wallet instance"
        
        Processor->>Client: "SigningCosmWasmClient.connectWithSigner()"
        Client-->>Processor: "Return signing client"
        
        Processor->>Client: "wallet.getAccounts()"
        Client-->>Processor: "Return account data"
        
        Processor->>CLI: "processorFn(client, configManager, options, args, fee)"
        CLI->>Blockchain: "Execute contract operations"
        Blockchain-->>CLI: "Return transaction results"
    else If query only (mainQueryProcessor)
        Processor->>Client: "CosmWasmClient.connect(rpc)"
        Client-->>Processor: "Return read-only client"
        
        Processor->>CLI: "processorQueryFn(client, configManager, options, args, fee)"
        CLI->>Blockchain: "Execute query operations"
        Blockchain-->>CLI: "Return query results"
    end
    
    CLI->>ConfigManager: "saveConfig()"
    ConfigManager-->>CLI: "Configuration saved"
    
    CLI-->>User: "Return command results"
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->