### PR TITLE
docs(ampd): update ampd 1.12 release with v1.12.2

### DIFF
--- a/releases/ampd/2025-10-03-ampd-v1.12.2.md
+++ b/releases/ampd/2025-10-03-ampd-v1.12.2.md
@@ -1,4 +1,4 @@
-# Ampd v1.12.1
+# Ampd v1.12.2
 
 |                | **Owner**                         |
 | -------------- | --------------------------------- |
@@ -12,11 +12,14 @@
 | **Testnet**          | -                     | TBD      |
 | **Mainnet**          | -                     | TBD      |
 
-[Release](https://github.com/axelarnetwork/axelar-amplifier/releases/tag/ampd-v1.12.1)
+[Release](https://github.com/axelarnetwork/axelar-amplifier/releases/tag/ampd-v1.12.2)
 
 ## Background
 
-This ampd release fixes an issue with the account sequence management during high concurrency. It also removes overhead by filtering out events before reaching each handler.
+This ampd release removes overhead by filtering out events before reaching each handler and adds these bugfixes:
+
+- Fixes account sequence getting out of sync during high concurrency
+- Fixes ampd hanging during shutdown process
 
 ## Config change
 
@@ -39,7 +42,7 @@ tx_confirmation_queue_cap="1000"
 
 ## Deployment
 
-Restart ampd with the new binary. Binaries can be found [here](https://github.com/axelarnetwork/axelar-amplifier/releases/tag/ampd-v1.12.1)
+Restart ampd with the new binary. Binaries can be found [here](https://github.com/axelarnetwork/axelar-amplifier/releases/tag/ampd-v1.12.2)
 
 ### Checklist
 
@@ -47,7 +50,7 @@ Run the below command to output the version:
 
 ```
 $ ampd --version
-ampd 1.12.1
+ampd 1.12.2
 ```
 
 Check `ampd` logs to ensure it restarts fine. Monitor voting and signing for your verifier on axelarscan to verify it's operating correctly.


### PR DESCRIPTION
I updated the same 1.12 file since that version hasn't been deployed by external verifiers yet
