### PR TITLE
Fix/sui link coin encoding

### DIFF
--- a/sui/its.js
+++ b/sui/its.js
@@ -579,8 +579,6 @@ async function linkCoin(keypair, client, config, contracts, args, options) {
     const { Gateway } = AxelarGateway.objects;
     const [symbol, destinationChain, destinationAddress] = args;
 
-    const encoder = new TextEncoder();
-
     const unvalidatedParams = {
         isNonEmptyString: { symbol, destinationChain, destinationAddress },
         isNonArrayObject: { tokenEntry: contracts[symbol.toUpperCase()] },
@@ -657,9 +655,10 @@ async function linkCoin(keypair, client, config, contracts, args, options) {
             channel,
             salt,
             destinationChain, // This assumes the chain is already added as a trusted chain
-            encoder.encode(destinationAddress),
+            destinationAddress,
             tokenManagerType,
-            encoder.encode(linkParams),
+            // TODO: evaluate / test encoding of linkParams
+            bcs.string().serialize(linkParams).toBytes()
         ],
     });
 

--- a/sui/its.js
+++ b/sui/its.js
@@ -658,7 +658,7 @@ async function linkCoin(keypair, client, config, contracts, args, options) {
             destinationAddress,
             tokenManagerType,
             // TODO: evaluate / test encoding of linkParams
-            bcs.string().serialize(linkParams).toBytes()
+            bcs.string().serialize(linkParams).toBytes(),
         ],
     });
 


### PR DESCRIPTION
## why?

Currently, the code for the `link-coin` command fails with error saying the destination token is not registered. This happens due to incorrect encoding of the destination token cli argument, which is fixed in this PR.

This same fix will likely need to be applied to other areas of the source code. The other areas where this should be tested (and fixed if required) are:
- the `linkParams` parameter, which is the argument of the same function
- line 129 of gateway.js where destination token address is being encoded with BCS

### testing

- Deploy coins on Sui and another chain
- Register the token metadata for both 
- Register the Sui coin on ITS (e.g. with the `register-custom-coin` command
- Link the registered Sui coin to the destination token:

```bash
// Example:
ts-node sui/its link-coin $SYMBOL $EVM_CHAIN $EVM_TOKEN_ADDRESS --tokenManagerMode $TOKEN_MANAGER_MODE --salt $SALT --registered --channel $CHANNEL_ID
```
