### PR TITLE
fix: give unlinked coin

### DIFF
--- a/sui/tokens.js
+++ b/sui/tokens.js
@@ -184,15 +184,13 @@ async function processListCommand(keypair, client, args, options) {
 async function publishCoinCommand(keypair, client, args, options, contracts) {
     const [symbol, name, decimals] = args;
 
-    validateParameters({ 
-        isNonEmptyString: { 
+    validateParameters({
+        isNonEmptyString: {
             symbol: symbol,
             name: name,
             decimals: decimals,
-        } 
+        },
     });
-
-    console.log({symbol, name, decimals});
 
     const walletAddress = keypair.toSuiAddress();
 
@@ -214,12 +212,12 @@ async function legacyCoinsCommand(keypair, client, args, options, contracts) {
     const { InterchainTokenService, InterchainTokenServicev0 } = itsConfig.objects;
 
     if (options.createCoin) {
-        validateParameters({ 
-            isNonEmptyString: { 
+        validateParameters({
+            isNonEmptyString: {
                 symbol: options.createCoin,
                 decimals: options.decimals,
-                name: options.name
-            } 
+                name: options.name,
+            },
         });
 
         const config = loadConfig(options.env);


### PR DESCRIPTION
## why?

- ...
- _Task_: ?

## how?

- ...

### testing

- ...

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors `give_unlinked_coin` to take `<symbol> <tokenId>`, use existing coin config instead of deploying/registering, removes salt handling, and updates the CLI accordingly.
> 
> - **ITS Sui scripts (`sui/its.js`)**:
>   - **give_unlinked_coin**:
>     - Changes signature to `(keypair, client, _, contracts, [symbol, tokenId], options)` and removes `AxelarGateway`.
>     - Replaces deploy/register flow with loading existing coin from `contracts[symbol.toUpperCase()]` and validating `tokenId`.
>     - Builds `TokenId` from provided `tokenId`; uses existing `metadata`, `packageId`, `tokenType`, `TreasuryCap`.
>     - Calls `saveTokenDeployment(...)` with empty `saltAddress`.
>   - **CLI**:
>     - Updates command to `give-unlinked-coin <symbol> <tokenId>` with new description.
>     - Removes `--salt` option; retains `--treasuryCapReclaimer`.
>     - Adjusts action to pass `[symbol, tokenId]`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e79a72e076e0f35f96e33646887269334552accf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->