### PR TITLE
feat: add token-id related queries for stellar its

### DIFF
--- a/stellar/its.js
+++ b/stellar/its.js
@@ -301,6 +301,64 @@ async function removeFlowLimit(wallet, _config, chain, contract, args, options) 
     printInfo('Successfully removed flow limit');
 }
 
+async function canonicalInterchainTokenId(wallet, _config, chain, contract, args, options) {
+    const [tokenAddress] = args;
+
+    validateParameters({
+        isValidStellarAddress: { tokenAddress },
+    });
+
+    const operation = contract.call('canonical_interchain_token_id', nativeToScVal(tokenAddress, { type: 'address' }));
+    const returnValue = await broadcast(operation, wallet, chain, 'Get canonical interchain token id', options);
+    const tokenId = serializeValue(returnValue.value());
+
+    printInfo('Canonical Interchain Token ID', tokenId);
+
+    return tokenId;
+}
+
+async function interchainTokenId(wallet, _config, chain, contract, args, options) {
+    const [deployer, salt] = args;
+    const saltBytes32 = saltToBytes32(salt);
+
+    validateParameters({
+        isValidStellarAddress: { deployer },
+        isNonEmptyString: { salt },
+    });
+
+    printInfo('Salt', salt);
+    printInfo('Deployment salt (bytes32)', saltBytes32);
+
+    const operation = contract.call('interchain_token_id', addressToScVal(deployer), hexToScVal(saltBytes32));
+    const returnValue = await broadcast(operation, wallet, chain, 'Get interchain token id', options);
+    const tokenId = serializeValue(returnValue.value());
+
+    printInfo('Interchain Token ID', tokenId);
+
+    return tokenId;
+}
+
+async function linkedTokenId(wallet, _config, chain, contract, args, options) {
+    const [deployer, salt] = args;
+    const saltBytes32 = saltToBytes32(salt);
+
+    validateParameters({
+        isValidStellarAddress: { deployer },
+        isNonEmptyString: { salt },
+    });
+
+    printInfo('Salt', salt);
+    printInfo('Deployment salt (bytes32)', saltBytes32);
+
+    const operation = contract.call('linked_token_id', addressToScVal(deployer), hexToScVal(saltBytes32));
+    const returnValue = await broadcast(operation, wallet, chain, 'Get linked token id', options);
+    const tokenId = serializeValue(returnValue.value());
+
+    printInfo('Linked Token ID', tokenId);
+
+    return tokenId;
+}
+
 async function interchainTokenAddress(wallet, _config, chain, contract, args, options) {
     const [tokenId] = args;
 
@@ -640,6 +698,27 @@ if (require.main === module) {
         .description('Remove the flow limit for a token')
         .action((tokenId, options) => {
             mainProcessor(removeFlowLimit, [tokenId], options);
+        });
+
+    program
+        .command('canonical-interchain-token-id <tokenAddress>')
+        .description('Get the canonical interchain token id for a token address')
+        .action((tokenAddress, options) => {
+            mainProcessor(canonicalInterchainTokenId, [tokenAddress], options);
+        });
+
+    program
+        .command('interchain-token-id <deployer> <salt>')
+        .description('Get the interchain token id for a deployer and salt')
+        .action((deployer, salt, options) => {
+            mainProcessor(interchainTokenId, [deployer, salt], options);
+        });
+
+    program
+        .command('linked-token-id <deployer> <salt>')
+        .description('Get the linked token id for a deployer and salt')
+        .action((deployer, salt, options) => {
+            mainProcessor(linkedTokenId, [deployer, salt], options);
         });
 
     program


### PR DESCRIPTION
### why

For easier inspection.

```sh
# Get the canonical interchain token id for a token address
node stellar/its.js canonical-interchain-token-id <TOKEN_ADDRESS> -p <PRIVATE_KEY> --env testnet

# Get the interchain token id for a deployer and salt
node stellar/its.js interchain-token-id <DEPLOYER_ADDRESS> <SALT> -p <PRIVATE_KEY> --env testnet

# Get the linked token id for a deployer and salt
node stellar/its.js linked-token-id <DEPLOYER_ADDRESS> <SALT> -p <PRIVATE_KEY> --env testnet
```

### how
<!-- An agent will fill this out -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds read-only CLI queries that call existing contract methods and print results, without changing stateful operations or core transaction flow.
> 
> **Overview**
> Adds three new read-only commands to `stellar/its.js` for easier token inspection: `canonical-interchain-token-id`, `interchain-token-id`, and `linked-token-id`.
> 
> Each command validates inputs, computes/prints the derived salt bytes where relevant, calls the corresponding ITS contract method, and prints/returns the serialized token ID.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77078381d6c4e238dbffe290a6eb4e3352d7f99d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->