### PR TITLE
fix(evm): reject set-flow-limit=0 and annotate zero limits as unlimited

### DIFF
--- a/evm/docs/rate-limits.md
+++ b/evm/docs/rate-limits.md
@@ -10,7 +10,7 @@ These limits are controlled by an address whitelisted with the ITS `operator` ro
 
 - **Epoch**: 6 hours (hardcoded). Flow counters reset at the start of each epoch.
 - **Net Flow**: `|flowOut - flowIn|` - bidirectional transfers offset each other
-- **Flow Limit**: Maximum allowed net flow per epoch. Setting `flowLimit = 0` disables rate limiting.
+- **Flow Limit**: Maximum allowed net flow per epoch. A `flowLimit` of `0` disables rate limiting.
 - **Per-chain, per-token**: Each TokenManager on each chain has independent flow limits
 - **NOT per-chain-pair**: destination chains or source chains interacting with a specific chain share same flow limit for a given token
 - Flow limits protect against exploits by capping potential losses per epoch
@@ -93,11 +93,11 @@ ts-node evm/its.js set-flow-limit <token-id> <flow-limit>
 ```
 
 - **`token-id`**: ITS token identifier.
-- **`flow-limit`**: New flow limit for this token on the current chain.
+- **`flow-limit`**: New flow limit for this token on the current chain. Must be greater than `0`.
 
 Notes:
 - Requires **ITS operator** privileges.
-- `flow-limit = 0` effectively **removes** the limit (no rate limiting for that token on this chain). Use minimum integer number according to  token decimals to disable flows.
+- `flow-limit = 0` is **not allowed** via this command: on-chain it would disable rate limiting (unlimited flow). To remove the limit intentionally, use `unfreeze-tokens`. To disable flows, pass the minimum integer value according to the token decimals.
 
 ---
 

--- a/evm/its.js
+++ b/evm/its.js
@@ -264,7 +264,12 @@ async function processCommand(_axelar, chain, chains, action, options) {
             const tokenManager = new Contract(tokenManagerAddress, ITokenManager.abi, wallet);
 
             const flowLimit = await tokenManager.flowLimit();
-            printInfo(`Flow limit for tokenId ${tokenId}`, flowLimit);
+
+            if (flowLimit.isZero()) {
+                printInfo(`Flow limit for tokenId ${tokenId} 0 (= unlimited)`, flowLimit);
+            } else {
+                printInfo(`Flow limit for tokenId ${tokenId}`, flowLimit);
+            }
 
             break;
         }
@@ -415,6 +420,10 @@ async function processCommand(_axelar, chain, chains, action, options) {
 
             validateTokenIds(interchainTokenService, [tokenId]);
             validateParameters({ isValidNumber: { flowLimit } });
+
+            if (Number(flowLimit) === 0) {
+                throw new Error('Flow limit of 0 is not allowed as it disables rate limiting. Use `unfreeze-tokens` instead.');
+            }
 
             const tx = await interchainTokenService.setFlowLimits([tokenId], [flowLimit], gasOptions);
             await handleTx(tx, chain, interchainTokenService, action);

--- a/evm/its.js
+++ b/evm/its.js
@@ -422,7 +422,7 @@ async function processCommand(_axelar, chain, chains, action, options) {
             validateParameters({ isValidNumber: { flowLimit } });
 
             if (Number(flowLimit) === 0) {
-                throw new Error('Flow limit of 0 is not allowed as it disables rate limiting. Use `unfreeze-tokens` instead.');
+                throw new Error('Flow limit of 0 is not allowed as it disables rate limiting. Use 1 to disable flow or use `unfreeze-tokens` to disable rate limiting.');
             }
 
             const tx = await interchainTokenService.setFlowLimits([tokenId], [flowLimit], gasOptions);

--- a/evm/its.js
+++ b/evm/its.js
@@ -422,7 +422,9 @@ async function processCommand(_axelar, chain, chains, action, options) {
             validateParameters({ isValidNumber: { flowLimit } });
 
             if (Number(flowLimit) === 0) {
-                throw new Error('Flow limit of 0 is not allowed as it disables rate limiting. Use 1 to disable flow or use `unfreeze-tokens` to disable rate limiting.');
+                throw new Error(
+                    'Flow limit of 0 is not allowed as it disables rate limiting. Use 1 to disable flow or use `unfreeze-tokens` to disable rate limiting.',
+                );
             }
 
             const tx = await interchainTokenService.setFlowLimits([tokenId], [flowLimit], gasOptions);


### PR DESCRIPTION
### why
A flow limit of zero on EVM is interpreted as "unlimited". While on other chains, like stellar/solana it is handled as no flow is allowed. This small change is Just to make sure we don't shoot ourselves in the foot later.
- Disable calling set-flow-limit with 0.
- Annotate that 0 means unlimited

Part of CPI-264

### how
<!-- An agent will fill this out -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes operational behavior of the `evm/its.js set-flow-limit` CLI by rejecting `0`, which could break existing scripts/workflows that relied on using `0` to remove limits.
> 
> **Overview**
> **Prevents accidentally disabling EVM rate limiting via the CLI.** The `evm/its.js` `set-flow-limit` command now throws if `flowLimit` is `0`, forcing operators to use other mechanisms (e.g. `unfreeze-tokens` or setting `1` to effectively freeze).
> 
> The `flow-limit` query output is updated to explicitly annotate a zero on-chain value as *unlimited*, and the rate-limit docs are clarified to state that `flowLimit=0` disables rate limiting and is not accepted by `set-flow-limit`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b09cc28beac93df26a1a886cc2018d2dbced9692. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->