### PR TITLE
chore: derive ata for solana its transfer

### DIFF
--- a/solana/src/its.rs
+++ b/solana/src/its.rs
@@ -521,9 +521,10 @@ pub(crate) struct LinkTokenArgs {
 
 #[derive(Parser, Debug)]
 pub(crate) struct InterchainTransferArgs {
-    /// The token account from which tokens should transferred
+    /// The token account from which tokens should be transferred. Defaults to the
+    /// authority's associated token account for the mint.
     #[clap(long)]
-    pub(crate) source_account: Pubkey,
+    pub(crate) source_account: Option<Pubkey>,
 
     /// The token id of the Interchain Token
     #[clap(long, value_parser = parse_hex_bytes32)]
@@ -1573,6 +1574,9 @@ fn interchain_transfer(
 
     let token_program = get_token_program_from_mint(&mint, config)?;
     let token_manager_ata = get_associated_token_address(&token_manager_pda, &mint, &token_program);
+    let source_account = args
+        .source_account
+        .unwrap_or_else(|| get_associated_token_address(&authority, &mint, &token_program));
 
     let gateway_program = solana_axelar_gateway::id();
     let (gateway_root_pda, _) = Pubkey::find_program_address(&[b"gateway"], &gateway_program);
@@ -1599,6 +1603,7 @@ fn interchain_transfer(
     println!("- Decimals: {decimals}");
     println!("- Destination Chain: {}", args.destination_chain);
     println!("- Destination Address: {}", args.destination_address);
+    println!("- Source Account: {source_account}");
     println!("------------------------------------------");
 
     let (event_authority, _) =
@@ -1618,7 +1623,7 @@ fn interchain_transfer(
         AccountMeta::new(token_manager_pda, false),
         AccountMeta::new_readonly(token_program, false),
         AccountMeta::new(mint, false),
-        AccountMeta::new(args.source_account, false),
+        AccountMeta::new(source_account, false),
         AccountMeta::new(token_manager_ata, false),
         AccountMeta::new_readonly(solana_sdk_ids::system_program::ID, false),
         AccountMeta::new_readonly(event_authority, false),

--- a/solana/src/load_test/test.rs
+++ b/solana/src/load_test/test.rs
@@ -317,7 +317,7 @@ async fn execute_transfer_with_metrics(
     let data = generate_payload(args.payload.as_ref(), args.vary_payload);
 
     let interchain_transfer_args = its::InterchainTransferArgs {
-        source_account,
+        source_account: Some(source_account),
         token_id: args.token_id,
         destination_chain: args.destination_chain.clone(),
         destination_address: args.destination_address.clone(),


### PR DESCRIPTION
### why

We can derive the ATA as a default to avoid user needing to provide it.

### how
<!-- An agent will fill this out -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small CLI/API ergonomics change that defaults `source_account` to the authority’s derived ATA; primary risk is unintended use of the default account if a caller forgets to specify a non-ATA source.
> 
> **Overview**
> Updates Solana ITS `InterchainTransfer` to make `--source-account` optional and, when omitted, **derive the authority’s associated token account (ATA)** for the token mint and use it as the transfer source.
> 
> Also updates logging to print the resolved source account and adjusts the load test harness to pass `source_account` as `Some(...)` to match the new optional argument type.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f565616b5e52c3b2a3cd20afe740dad7a81c42fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->