### PR TITLE
feat: bump solana programs to v1.1.0 on devnet, stagenet and testnet

### DIFF
--- a/axelar-chains-config/info/devnet-amplifier.json
+++ b/axelar-chains-config/info/devnet-amplifier.json
@@ -1396,33 +1396,33 @@
           "operator": "gopEFNgirbVNK29RA5DK8mZTDhN2whzcbhCWXkVEc18",
           "previousSignersRetention": 15,
           "upgradeAuthority": "upa8CAJAvxU32TZfVT6mcHQawRLzx3N4c65GQjL8Vfx",
-          "version": "1.0.0"
+          "version": "1.1.0"
         },
         "AxelarOperators": {
           "address": "oprVNGMBsXzJJBTDQasNWqQ8nZqNhJP2ZXvrC7b5xXd",
           "configAccount": "DSaMLBWjwYwgeTq3K6EJwhev7jdFnmgBtDBs51rn6UzL",
           "owner": "upa8CAJAvxU32TZfVT6mcHQawRLzx3N4c65GQjL8Vfx",
           "upgradeAuthority": "upa8CAJAvxU32TZfVT6mcHQawRLzx3N4c65GQjL8Vfx",
-          "version": "1.0.0"
+          "version": "1.1.0"
         },
         "AxelarMemo": {
           "address": "memKnP9ex71TveNFpsFNVqAYGEe1v9uHVsHNdFPW6FY",
           "upgradeAuthority": "upa8CAJAvxU32TZfVT6mcHQawRLzx3N4c65GQjL8Vfx",
-          "version": "1.0.0"
+          "version": "1.1.0"
         },
         "AxelarGasService": {
           "address": "gasUBnVr9GZon2cp8X5gyFrUsQFhzrprjy734Ci6Bmn",
           "operator": "gopEFNgirbVNK29RA5DK8mZTDhN2whzcbhCWXkVEc18",
           "configAccount": "D4kaxAQXuyrcgjH11KYtAHnfkWPBpFUJS9s6kTYyfjS8",
           "upgradeAuthority": "upa8CAJAvxU32TZfVT6mcHQawRLzx3N4c65GQjL8Vfx",
-          "version": "1.0.0"
+          "version": "1.1.0"
         },
         "InterchainTokenService": {
           "address": "itsYxmqAxNKUL5zaj3fD1K1whuVhqpxKVoiLGie1reF",
           "configAccount": "2wvQUpTH9VDQPNBoCTVSgLpedxkd2Kshth4Jvgxo2jKR",
           "operator": "gopEFNgirbVNK29RA5DK8mZTDhN2whzcbhCWXkVEc18",
           "upgradeAuthority": "upa8CAJAvxU32TZfVT6mcHQawRLzx3N4c65GQjL8Vfx",
-          "version": "1.0.0"
+          "version": "1.1.0"
         }
       }
     },

--- a/axelar-chains-config/info/stagenet.json
+++ b/axelar-chains-config/info/stagenet.json
@@ -2624,33 +2624,33 @@
           "operator": "gopuMNntD2aFtuVnwskU7jYpmdBdLXJMBpZWZjYE1sj",
           "previousSignersRetention": 15,
           "upgradeAuthority": "upaYdfY8H5dKa3wCV2pnfxEVNP1yT6mJycoZo3BJFFK",
-          "version": "1.0.0"
+          "version": "1.1.0"
         },
         "AxelarGasService": {
           "address": "gasgy6jz24wrfZL98uMy8QFUFziVPZ3bNLGXqnyTstW",
           "operator": "gopuMNntD2aFtuVnwskU7jYpmdBdLXJMBpZWZjYE1sj",
           "configAccount": "F7D4uerW7MZYu8RRSMiKfzA7oA1b2wcAyQJaStqmmda8",
           "upgradeAuthority": "upaYdfY8H5dKa3wCV2pnfxEVNP1yT6mJycoZo3BJFFK",
-          "version": "1.0.0"
+          "version": "1.1.0"
         },
         "AxelarOperators": {
           "address": "oprNyqaxdvxs9s3Ngyi1gHqXeM2QLTv8skVPCcqmekx",
           "configAccount": "JoYjgayBfRX4aAz1gp9ULMC3tdyKBe1w6qNqXJRGivp",
           "owner": "upaYdfY8H5dKa3wCV2pnfxEVNP1yT6mJycoZo3BJFFK",
           "upgradeAuthority": "upaYdfY8H5dKa3wCV2pnfxEVNP1yT6mJycoZo3BJFFK",
-          "version": "1.0.0"
+          "version": "1.1.0"
         },
         "AxelarMemo": {
           "address": "mem4E22pPgkbHAvoUYHa7HybBgUKn6jFjvj1YnPdkaq",
           "upgradeAuthority": "upaYdfY8H5dKa3wCV2pnfxEVNP1yT6mJycoZo3BJFFK",
-          "version": "1.0.0"
+          "version": "1.1.0"
         },
         "InterchainTokenService": {
           "address": "itsm3zZhp2oGgEfq7XBu9ojRCYZJnhzecbAEPCrvx2B",
           "configAccount": "BUhMWrB72CHg3gizWgPFxCjj6cnm1MRT2Jc9jYH8AQTS",
           "operator": "gopuMNntD2aFtuVnwskU7jYpmdBdLXJMBpZWZjYE1sj",
           "upgradeAuthority": "upaYdfY8H5dKa3wCV2pnfxEVNP1yT6mJycoZo3BJFFK",
-          "version": "1.0.0"
+          "version": "1.1.0"
         }
       }
     }

--- a/axelar-chains-config/info/testnet.json
+++ b/axelar-chains-config/info/testnet.json
@@ -3473,33 +3473,33 @@
           "operator": "gopdSWQFLKvxPz1SiP2W8CumFBtd2FF1ddDgNVkLmdG",
           "previousSignersRetention": 15,
           "upgradeAuthority": "upaHiTygNXvZZzAb9ZZxn63LhJoma35BKgt6rxH5XdS",
-          "version": "1.0.0"
+          "version": "1.1.0"
         },
         "AxelarGasService": {
           "address": "gasq7KHHv9Rs8C82hu3dgoBD9wk5LTKpWqbdf5o5juu",
           "operator": "gopdSWQFLKvxPz1SiP2W8CumFBtd2FF1ddDgNVkLmdG",
           "configAccount": "FnMi7boHKiDLjubdoLtr2Nen5XBxT9HCVSabC2bQU9sf",
           "upgradeAuthority": "upaHiTygNXvZZzAb9ZZxn63LhJoma35BKgt6rxH5XdS",
-          "version": "1.0.0"
+          "version": "1.1.0"
         },
         "AxelarOperators": {
           "address": "opriTiaaV7Ew1kma71TjKbrwQ2RWKJ3wbiWEAp3hUZc",
           "configAccount": "CAbbFCJV9eVuF47UiuurbiJwNroSovhpTzusdmbLcxYN",
           "owner": "upaHiTygNXvZZzAb9ZZxn63LhJoma35BKgt6rxH5XdS",
           "upgradeAuthority": "upaHiTygNXvZZzAb9ZZxn63LhJoma35BKgt6rxH5XdS",
-          "version": "1.0.0"
+          "version": "1.1.0"
         },
         "AxelarMemo": {
           "address": "mem7UJouaeyTgySvXhQSxWtGFrWPQ89jywjc8YvQFRT",
           "upgradeAuthority": "upaHiTygNXvZZzAb9ZZxn63LhJoma35BKgt6rxH5XdS",
-          "version": "1.0.0"
+          "version": "1.1.0"
         },
         "InterchainTokenService": {
           "address": "itsJo4kNJ3mdh3requwbtTTt7vyYTudp1pxhn2KiHMc",
           "configAccount": "Ctehm9EVDZDYetXCxVrHgaJpLgw7gHNo184rKFpJMb7Y",
           "operator": "gopdSWQFLKvxPz1SiP2W8CumFBtd2FF1ddDgNVkLmdG",
           "upgradeAuthority": "upaHiTygNXvZZzAb9ZZxn63LhJoma35BKgt6rxH5XdS",
-          "version": "1.0.1"
+          "version": "1.1.0"
         }
       }
     }

--- a/solana/Cargo.lock
+++ b/solana/Cargo.lock
@@ -226,9 +226,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-access-control"
-version = "1.0.0-rc.5"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3db7f5f8a6b16fa2b6e1b0222e656249c3abedf052e3943babf248929571204"
+checksum = "b972f5fbd02524c92e4eb487c3c648904572702670f3d6fc81aef5f1751b1569"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -237,9 +237,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-account"
-version = "1.0.0-rc.5"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a12661acaba9866a5f2d8d8d46a1eed8b484f41dc9f94f808c3b07d35726816"
+checksum = "9acfcb07a92084bcfa9f6cc49a5c2e8e0e986f25f4b7caa184b7a2c9c9e561c2"
 dependencies = [
  "anchor-syn",
  "proc-macro2",
@@ -249,9 +249,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-constant"
-version = "1.0.0-rc.5"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dff08bc0187aafc559da8f63b5adeab0bcdf97128765c72dd9a4861f70627fc"
+checksum = "8f46cc38f819377f07663b8eb492a701427950065e79d2d7b622a782443deb7a"
 dependencies = [
  "anchor-syn",
  "quote",
@@ -260,9 +260,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-error"
-version = "1.0.0-rc.5"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2af8ce12fb8cf782a3e127d376698a4548a518e38b4686f9c439adce4730b48"
+checksum = "9c34748789107c9838329e058ca7b253e67f37b39ceae5a0a6c8d99f5d1bf1fe"
 dependencies = [
  "anchor-syn",
  "quote",
@@ -271,9 +271,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-event"
-version = "1.0.0-rc.5"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "338be5df076369b99585264aaa46c66229ead67568d61bd38c3ab0fa7a15e554"
+checksum = "1a28a3e5eefa03d9c5ef02b2139198f652547d38dddafc9c5545152dfba54556"
 dependencies = [
  "anchor-syn",
  "proc-macro2",
@@ -283,9 +283,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-program"
-version = "1.0.0-rc.5"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5c4ec70cef4ef7e2d87b4e9c550f727a43d691d3d7f3e4d6b2e3bd530ae098d"
+checksum = "dfaa03865053cb168bfc4debe5992be87f397aa027dd81b69a2e44f2e5bae1c5"
 dependencies = [
  "anchor-lang-idl",
  "anchor-syn",
@@ -298,9 +298,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-derive-accounts"
-version = "1.0.0-rc.5"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f610cb50e10e4c404cc774f20a4eb602b904f68ea04590f8b1eb22a1e28b33e5"
+checksum = "eef330db08f9ceee45c18ef96b15b869883d280c0ab5c6ff5d2e2f6481da7911"
 dependencies = [
  "anchor-syn",
  "quote",
@@ -309,9 +309,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-derive-serde"
-version = "1.0.0-rc.5"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be9ead49a9689493f8857a61dd1abf1d70eeeeb0683f8c1e09b015ab5bdd382d"
+checksum = "e0e80ff4e3ddb8c85aafd37926335c28f820516311e7106e5b7482b42e798aaa"
 dependencies = [
  "anchor-syn",
  "proc-macro-crate 3.4.0",
@@ -322,9 +322,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-derive-space"
-version = "1.0.0-rc.5"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea4d1372743444967347b60f9311d2ee54a630152fd1d6d805adebd7fcd72056"
+checksum = "2672af0ef4dfd5f5b6199355867b580cd8b4048093ef5208dd2b441305c15b8b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -333,9 +333,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-lang"
-version = "1.0.0-rc.5"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "254d0cb160ea5c4c6a8c2f847bbd0f384fef733ebc36ef8426ae95f1bfda5757"
+checksum = "8de9dce227fa0c08be20fef008c5b04681e1e0a15cb396e9619a9a1f800ff6cd"
 dependencies = [
  "anchor-attribute-access-control",
  "anchor-attribute-account",
@@ -401,9 +401,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-spl"
-version = "1.0.0-rc.5"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3f1da81d6a7486339833833db9285f3771c1c368db418d481b5584a901cd675"
+checksum = "300e2e8058e674e8d6ea7c72dfb8be4349609dd9c3760ce729fc6406199624fe"
 dependencies = [
  "anchor-lang",
  "spl-associated-token-account-interface",
@@ -416,9 +416,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-syn"
-version = "1.0.0-rc.5"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9a855d34b1b0488f37ccc759c8bd4a696cd3a7bba8cb0734c2a965109f707da"
+checksum = "6940253e80acf0f8e83b1ebd9c4772c496aedcce6ad19aa85ce75d0b6b188298"
 dependencies = [
  "anyhow",
  "bs58",
@@ -5952,9 +5952,9 @@ dependencies = [
 
 [[package]]
 name = "solana-axelar-gas-service"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d928f915b62a59b16893b6ba13f596c66d40e17c3e91e464d07bea81d05926eb"
+checksum = "17d0d3dbf952afaff2168fee280af6bbf8891b6c644f811ae4e0ba05dbbd649b"
 dependencies = [
  "anchor-lang",
  "bytemuck",
@@ -5964,9 +5964,9 @@ dependencies = [
 
 [[package]]
 name = "solana-axelar-gateway"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d99ca0054740903450969fb1e6f2116b7fa4226494157fb6ccac6bbe2a20ca9d"
+checksum = "5d0360377d14b777ec5c7d9e678fb6d7ac9c5fb1b56d4a31c825b4f32fa278ba"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -5984,9 +5984,9 @@ dependencies = [
 
 [[package]]
 name = "solana-axelar-governance"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fff41a0facb8108f69aa87dc8a6e197c0b94e0bee438804f99c6c4160561d7a2"
+checksum = "87ef58f4a02dababf6afe9a6bbc09e080430b2427d0baf9e75837237ba9486df"
 dependencies = [
  "alloy-sol-types",
  "anchor-lang",
@@ -5999,9 +5999,9 @@ dependencies = [
 
 [[package]]
 name = "solana-axelar-its"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2831a1f0e4e22f3c0edfe4632a19782215ca4f70d649715b004afbd7313a2fe"
+checksum = "d197a1c6e6150a03566c09db7812bbecc7676b002a7a792b3e36f2d9c785c0b9"
 dependencies = [
  "anchor-lang",
  "anchor-spl",
@@ -6018,9 +6018,9 @@ dependencies = [
 
 [[package]]
 name = "solana-axelar-memo"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d710fe46ba7cc4308ac18280c273130cf25e9ed63b70e3c70f70dfd777f080c9"
+checksum = "529ed6350f5442db56cad4989e0fa55df7cad64c51e0513e18836e9c1c1c9df0"
 dependencies = [
  "anchor-lang",
  "anchor-spl",
@@ -6031,9 +6031,9 @@ dependencies = [
 
 [[package]]
 name = "solana-axelar-operators"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba0e4164a6954870a615441c471c0d802cdcdf01c75a36fe7bd14b4a980327fb"
+checksum = "15a146fa57bfb1c7dd9ed0cf50eec1aa021a1310f1f50a0dea2d04f141b7d1fd"
 dependencies = [
  "anchor-lang",
  "solana-axelar-std",
@@ -6041,12 +6041,11 @@ dependencies = [
 
 [[package]]
 name = "solana-axelar-std"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40868dc81fd889a70532209cad62512ba8d2d2c171611a6c0b4d7413496bf377"
+checksum = "b68b1ed52c5aca3c640ec0955398bade43296be94a46eee3839e93adb82d94ac"
 dependencies = [
  "alloy-primitives",
- "anchor-lang",
  "arrayref",
  "bnum 0.10.0",
  "borsh 1.6.0",

--- a/solana/Cargo.toml
+++ b/solana/Cargo.toml
@@ -27,8 +27,8 @@ tokio = { version = "1", features = ["full"] }
 axelar-wasm-std = { git = "https://github.com/axelarnetwork/axelar-amplifier.git", rev = "voting-verifier-v2.0.0" }
 
 # solana dependencies
-anchor-lang = { version = "1.0.0-rc.5", features = ["event-cpi"] }
-anchor-spl = { version = "1.0.0-rc.5" }
+anchor-lang = { version = "=1.0.0", features = ["event-cpi"] }
+anchor-spl = { version = "=1.0.0" }
 borsh = { version = "1.6", features = ["derive"] }
 bincode = { version = "2.0.1", features = ["serde"] }
 solana-sdk = "~3.0.0"
@@ -45,25 +45,25 @@ solana-system-interface = { version = "~2.0.0", features = ["bincode"] }
 mpl-token-metadata = { version = "5.1.2-alpha.2" }
 
 # solana axelar dependencies
-solana-axelar-gas-service = { version = "1.0.0", features = [
+solana-axelar-gas-service = { version = "1.1.0", features = [
     "no-entrypoint",
 ], default-features = false }
-solana-axelar-gateway = { version = "1.0.0", features = [
+solana-axelar-gateway = { version = "1.1.0", features = [
     "no-entrypoint",
 ], default-features = false }
-solana-axelar-governance = { version = "1.0.0", features = [
+solana-axelar-governance = { version = "1.1.0", features = [
     "no-entrypoint",
 ], default-features = false }
-solana-axelar-its = { version = "1.0.0", features = [
+solana-axelar-its = { version = "1.1.0", features = [
     "no-entrypoint",
 ], default-features = false }
-solana-axelar-memo = { version = "1.0.0", features = [
+solana-axelar-memo = { version = "1.1.0", features = [
     "no-entrypoint",
 ], default-features = false }
-solana-axelar-operators = { version = "1.0.0", features = [
+solana-axelar-operators = { version = "1.1.0", features = [
     "no-entrypoint",
 ], default-features = false }
-solana-axelar-std = { version = "1.0.0" }
+solana-axelar-std = { version = "1.1.0" }
 
 [lints.clippy]
 cargo = { priority = -1, level = "deny" }

--- a/solana/scripts/verify.sh
+++ b/solana/scripts/verify.sh
@@ -1,0 +1,243 @@
+#!/bin/bash
+set -euo pipefail
+
+# =============================================================================
+# Solana Program Verification Script (Mainnet only)
+#
+# Reproduces deployed Solana program binaries from source and uploads the
+# verification PDA on-chain, signed by the program's upgrade authority.
+# Then queues an OtterSec remote build, which is what makes block explorers
+# (Solscan, SolanaFM, etc.) display the "verified" badge.
+#
+# Fetches the upgrade-authority keypair from 1Password on-demand and cleans
+# it up on exit.
+#
+# Prerequisites:
+#   - Programs already deployed to mainnet (see deploy.sh)
+#   - 1Password CLI (op) authenticated
+#   - Docker daemon running (image is amd64; on Apple Silicon Rosetta is used)
+#
+# Usage:
+#   ./solana/scripts/verify.sh --commit-hash <SHA>
+#   ./solana/scripts/verify.sh --commit-hash <SHA> --only gateway
+# =============================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SOLANA_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+DEPLOYMENTS_DIR="$(cd "${SOLANA_DIR}/.." && pwd)"
+
+log_step()  { echo -e "\n\033[1;34m==> $1\033[0m"; }
+log_info()  { echo "    $1"; }
+log_warn()  { echo -e "    \033[1;33mWARNING: $1\033[0m"; }
+log_error() { echo -e "\033[1;31mERROR: $1\033[0m"; }
+
+CHAIN="solana"
+FEATURE="mainnet"
+OP_VAULT="Mainnet - Axelar Externally Owned Accounts"
+CHAINS_INFO_FILE="${DEPLOYMENTS_DIR}/axelar-chains-config/info/mainnet.json"
+
+# Default RPC URL. Override with --rpc-url or SOLANA_MAINNET_RPC_URL env var.
+# Public mainnet-beta rate-limits aggressively; a paid RPC is recommended.
+DEFAULT_RPC_URL="${SOLANA_MAINNET_RPC_URL:-mainnet-beta}"
+
+# Pinned base image. Must contain platform-tools matching what built the
+# deployed binary. See docs/verifiable-builds.md in axelar-amplifier-solana.
+BASE_IMAGE="solanafoundation/solana-verifiable-build:3.1.12"
+
+REPO_URL="https://github.com/axelarnetwork/axelar-amplifier-solana"
+
+# Programs: "display_name|library_name|chains_config_key"
+VERIFY_PROGRAMS=(
+    "Gateway|solana_axelar_gateway|AxelarGateway"
+    "Gas Service|solana_axelar_gas_service|AxelarGasService"
+    "Operators|solana_axelar_operators|AxelarOperators"
+    "Memo|solana_axelar_memo|AxelarMemo"
+    "ITS|solana_axelar_its|InterchainTokenService"
+)
+
+TEMP_KEYPAIR_FILES=()
+
+cleanup() {
+    if [[ ${#TEMP_KEYPAIR_FILES[@]} -gt 0 ]]; then
+        log_info "Cleaning up temporary keypair files..."
+        for f in "${TEMP_KEYPAIR_FILES[@]}"; do
+            [[ -f "$f" ]] && rm -f "$f"
+        done
+    fi
+}
+trap cleanup EXIT
+
+# =============================================================================
+# Flag parsing
+# =============================================================================
+
+usage() {
+    echo "Usage: $0 --commit-hash <SHA> [--only <name>] [--rpc-url <url>]"
+    echo ""
+    echo "Required:"
+    echo "  --commit-hash <sha>   Full git SHA in axelarnetwork/axelar-amplifier-solana"
+    echo "                        corresponding to the deployed binaries"
+    echo ""
+    echo "Optional:"
+    echo "  --only <name>         Verify a single program by short name"
+    echo "                        (gateway, gas-service, operators, memo, its)"
+    echo "  --rpc-url <url>       Solana RPC URL or moniker (default: \$SOLANA_MAINNET_RPC_URL"
+    echo "                        or 'mainnet-beta'). Public mainnet-beta rate-limits"
+    echo "                        aggressively; a paid RPC is recommended."
+    echo "  --skip-build          Skip the local docker build (only upload PDA)"
+    echo "  -h, --help            Show this help"
+}
+
+COMMIT_HASH=""
+ONLY=""
+SKIP_BUILD_FLAG=""
+RPC_URL="$DEFAULT_RPC_URL"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --commit-hash)  COMMIT_HASH="$2"; shift 2 ;;
+        --only)         ONLY="$2"; shift 2 ;;
+        --rpc-url)      RPC_URL="$2"; shift 2 ;;
+        --skip-build)   SKIP_BUILD_FLAG="--skip-build"; shift ;;
+        -h|--help)      usage; exit 0 ;;
+        *)              log_error "Unknown flag: $1"; usage; exit 1 ;;
+    esac
+done
+
+if [[ -z "$COMMIT_HASH" ]]; then
+    log_error "--commit-hash is required"
+    usage
+    exit 1
+fi
+
+if [[ ! "$COMMIT_HASH" =~ ^[a-fA-F0-9]{40}$ ]]; then
+    log_error "Invalid commit hash: $COMMIT_HASH (must be a 40-character SHA)"
+    exit 1
+fi
+
+# =============================================================================
+# Step functions
+# =============================================================================
+
+check_prerequisites() {
+    log_step "Checking prerequisites"
+
+    local missing=()
+    command -v solana >/dev/null 2>&1 || missing+=("solana")
+    command -v solana-keygen >/dev/null 2>&1 || missing+=("solana-keygen")
+    command -v solana-verify >/dev/null 2>&1 || missing+=("solana-verify (cargo install solana-verify)")
+    command -v docker >/dev/null 2>&1 || missing+=("docker")
+    command -v jq >/dev/null 2>&1 || missing+=("jq")
+    command -v op >/dev/null 2>&1 || missing+=("op (1Password CLI)")
+
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        log_error "Missing required tools: ${missing[*]}"
+        exit 1
+    fi
+
+    if ! docker info >/dev/null 2>&1; then
+        log_error "Docker daemon is not running"
+        exit 1
+    fi
+
+    if [[ ! -f "$CHAINS_INFO_FILE" ]]; then
+        log_error "Chains info file not found: $CHAINS_INFO_FILE"
+        exit 1
+    fi
+
+    log_info "All tools available"
+}
+
+# Fetch a document from 1Password by title; track for cleanup.
+fetch_keypair_from_op() {
+    local title="$1"
+    mkdir -p "${SOLANA_DIR}/deployments"
+    local sanitized
+    sanitized=$(echo "$title" | tr '[:upper:]' '[:lower:]' | sed 's/[][]//g; s/://g; s/  */-/g; s/^-//; s/-$//')
+    local output_path="${SOLANA_DIR}/deployments/${sanitized}.json"
+
+    log_info "Fetching '${title}' from 1Password..." >&2
+    op document get "$title" --vault "$OP_VAULT" --out-file "$output_path" --force >/dev/null 2>&1 || {
+        log_error "Failed to fetch '${title}' from 1Password vault '${OP_VAULT}'"
+        exit 1
+    }
+
+    TEMP_KEYPAIR_FILES+=("$output_path")
+    echo "$output_path"
+}
+
+resolve_upgrade_authority() {
+    log_step "Fetching upgrade authority from 1Password"
+    UPGRADE_AUTHORITY_KEYPAIR_PATH=$(fetch_keypair_from_op "[Mainnet] Upgrade Authority: Solana")
+    UPGRADE_AUTHORITY_PUBKEY=$(solana-keygen pubkey "$UPGRADE_AUTHORITY_KEYPAIR_PATH")
+    log_info "Upgrade authority: $UPGRADE_AUTHORITY_PUBKEY"
+}
+
+verify_one() {
+    local display="$1"
+    local library="$2"
+    local config_key="$3"
+
+    log_step "Verify ${display}"
+
+    local program_id
+    program_id=$(jq -r ".chains[\"${CHAIN}\"].contracts[\"${config_key}\"].address // empty" "$CHAINS_INFO_FILE")
+
+    if [[ -z "$program_id" ]]; then
+        log_warn "${display} not found in mainnet.json — skipping"
+        return
+    fi
+
+    log_info "Program ID:        ${program_id}"
+    log_info "Library:           ${library}"
+    log_info "Commit:            ${COMMIT_HASH}"
+
+    DOCKER_DEFAULT_PLATFORM=linux/amd64 solana-verify verify-from-repo \
+        -u "$RPC_URL" \
+        -k "$UPGRADE_AUTHORITY_KEYPAIR_PATH" \
+        --program-id "$program_id" \
+        --library-name "$library" \
+        --commit-hash "$COMMIT_HASH" \
+        --base-image "$BASE_IMAGE" \
+        --skip-prompt \
+        $SKIP_BUILD_FLAG \
+        "$REPO_URL" \
+        -- --features "$FEATURE" --no-default-features
+
+    log_step "Submitting OtterSec remote build for ${display}"
+    solana-verify remote submit-job \
+        --program-id "$program_id" \
+        --uploader "$UPGRADE_AUTHORITY_PUBKEY" \
+        -u "$RPC_URL"
+}
+
+# =============================================================================
+# Main
+# =============================================================================
+
+main() {
+    log_step "Solana Mainnet Verification"
+    log_info "RPC URL:     ${RPC_URL}"
+    log_info "Commit:      ${COMMIT_HASH}"
+    [[ -n "$ONLY" ]] && log_info "Only:        ${ONLY}"
+    echo ""
+
+    check_prerequisites
+    resolve_upgrade_authority
+
+    for entry in "${VERIFY_PROGRAMS[@]}"; do
+        IFS='|' read -r display library config_key <<< "$entry"
+
+        if [[ -n "$ONLY" ]]; then
+            local short
+            short=$(echo "$display" | tr '[:upper:] ' '[:lower:]-')
+            [[ "$short" == "$ONLY" ]] || continue
+        fi
+
+        verify_one "$display" "$library" "$config_key"
+    done
+
+    log_step "Done!"
+}
+
+main "$@"

--- a/solana/src/gateway.rs
+++ b/solana/src/gateway.rs
@@ -9,7 +9,6 @@ use eyre::eyre;
 use k256::ecdsa::SigningKey;
 use k256::elliptic_curve::sec1::ToEncodedPoint;
 use serde_json::json;
-use solana_axelar_gateway::state::config::RotationDelaySecs;
 use solana_axelar_gateway::state::config::{InitialVerifierSet, InitializeConfigParams};
 use solana_axelar_std::PayloadType;
 use solana_axelar_std::U256;
@@ -147,7 +146,7 @@ pub(crate) struct InitArgs {
 
     /// Minimum delay between SignerSet rotations
     #[clap(long)]
-    minimum_rotation_delay: RotationDelaySecs,
+    minimum_rotation_delay: u64,
 
     /// Optional hex string with secp256k1 compressed public key used to create the initial SignerSet
     #[clap(long)]


### PR DESCRIPTION
### why

new version! also adds a helper script to verify the solana programs on-chain.

Closes CPI-279

### how
<!-- An agent will fill this out -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dependency bumps to Anchor and multiple `solana-axelar-*` crates may change build outputs/ABI expectations, and the new verification script interacts with mainnet upgrade authority keys and on-chain PDAs.
> 
> **Overview**
> Updates Solana SVM contract version metadata in `devnet-amplifier.json`, `stagenet.json`, and `testnet.json` from `1.0.x` to `1.1.0` for `AxelarGateway`, `AxelarGasService`, `AxelarOperators`, `AxelarMemo`, and `InterchainTokenService`.
> 
> Bumps the Solana CLI workspace dependencies to Anchor `1.0.0` and `solana-axelar-*` crates `1.1.0` (with corresponding `Cargo.lock` updates), and adjusts the gateway CLI init flag type for `minimum_rotation_delay` from `RotationDelaySecs` to a plain `u64`.
> 
> Adds `solana/scripts/verify.sh`, a *mainnet-only* automation script that fetches the Solana upgrade-authority keypair from 1Password, reproduces program builds via `solana-verify` in a pinned verifiable-build Docker image, uploads verification PDAs, and submits OtterSec remote build jobs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12836089e50dbc310f17f496daae5b8a5eba73c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->