### PR TITLE
feat: migrate ITS hub to v1.3.2 on testnet and mainnet

### DIFF
--- a/axelar-chains-config/info/mainnet.json
+++ b/axelar-chains-config/info/mainnet.json
@@ -4098,10 +4098,10 @@
         }
       },
       "InterchainTokenService": {
-        "storeCodeProposalId": "364",
-        "storeCodeProposalCodeHash": "ba46bfa2daa4f5d8ac77f456aecafb63a2e13c7a7965fa5c3e2af05dbd865e97",
-        "lastUploadedCodeId": 38,
-        "codeId": 38,
+        "storeCodeProposalId": "467",
+        "storeCodeProposalCodeHash": "92904bc37ca2bca0dd909684ac3ddaa00e429b4c5ce8e47b755c3073fff03772",
+        "lastUploadedCodeId": 63,
+        "codeId": 63,
         "address": "axelar1aqcj54lzz0rk22gvqgcn8fr5tx4rzwdv5wv5j9dmnacgefvd7wzsy2j2mr",
         "stellar": {
           "maxUintBits": 127,

--- a/axelar-chains-config/info/mainnet.json
+++ b/axelar-chains-config/info/mainnet.json
@@ -4137,7 +4137,7 @@
           "maxUintBits": 64,
           "maxDecimalsWhenTruncating": 6
         },
-        "version": "1.3.0",
+        "version": "1.3.2",
         "solana": {
           "maxUintBits": 64,
           "maxDecimalsWhenTruncating": 6,

--- a/axelar-chains-config/info/testnet.json
+++ b/axelar-chains-config/info/testnet.json
@@ -4151,7 +4151,7 @@
           "maxUintBits": 64,
           "maxDecimalsWhenTruncating": 6
         },
-        "version": "1.3.0",
+        "version": "1.3.2",
         "solana": {
           "maxUintBits": 64,
           "maxDecimalsWhenTruncating": 6,

--- a/axelar-chains-config/info/testnet.json
+++ b/axelar-chains-config/info/testnet.json
@@ -4079,10 +4079,10 @@
         }
       },
       "InterchainTokenService": {
-        "storeCodeProposalId": "341",
-        "storeCodeProposalCodeHash": "ba46bfa2daa4f5d8ac77f456aecafb63a2e13c7a7965fa5c3e2af05dbd865e97",
-        "lastUploadedCodeId": 59,
-        "codeId": 59,
+        "storeCodeProposalId": "570",
+        "storeCodeProposalCodeHash": "92904bc37ca2bca0dd909684ac3ddaa00e429b4c5ce8e47b755c3073fff03772",
+        "lastUploadedCodeId": 86,
+        "codeId": 86,
         "address": "axelar1aqcj54lzz0rk22gvqgcn8fr5tx4rzwdv5wv5j9dmnacgefvd7wzsy2j2mr",
         "sui": {
           "maxUintBits": 64,

--- a/releases/cosmwasm/2026-05-ITS-v1.3.2.md
+++ b/releases/cosmwasm/2026-05-ITS-v1.3.2.md
@@ -91,6 +91,16 @@ npx ts-node cosmwasm/contract.ts migrate \
 
 The `migrate` subcommand does not accept `-t`/`-d`. The submitted proposal title defaults to `Migrate InterchainTokenService contract` and the description to `Migrate InterchainTokenService contract to code ID <codeId>`.
 
+6. Refresh the on-chain version in the config
+
+`contract.ts migrate` only writes `codeId` back to the config; it does not update `version`. After the migration proposal has executed, run:
+
+```bash
+npx ts-node cosmwasm/query.ts contract-versions -c InterchainTokenService
+```
+
+This queries `contract_info` on chain and writes `InterchainTokenService.version` in the env's JSON. Commit the resulting change.
+
 ## Checklist
 
 Set the ITS Hub contract address (`$ITS_HUB_ADDRESS`) and Axelar RPC node (`$NODE`) for the network you are verifying:

--- a/releases/cosmwasm/2026-05-ITS-v1.3.2.md
+++ b/releases/cosmwasm/2026-05-ITS-v1.3.2.md
@@ -1,0 +1,141 @@
+# Cosmwasm ITS v1.3.2
+
+|                | **Owner**                                       |
+| -------------- | ----------------------------------------------- |
+| **Created By** | @MakisChristou <makis@commonprefix.com>              |
+| **Deployment** | @MakisChristou <makis@commonprefix.com>         |
+
+| **Network**          | **Deployment Status** | **Date** |
+| -------------------- | --------------------- | -------- |
+| **Devnet Amplifier** | -                     | TBD      |
+| **Stagenet**         | -                     | TBD      |
+| **Testnet**          | Deployed              | 2026-05-12 |
+| **Mainnet**          | -                     | TBD      |
+
+[Release](https://github.com/axelarnetwork/axelar-amplifier/releases/tag/interchain-token-service-v1.3.2)
+
+## Background
+
+Changes in this release:
+
+1. Removes the erroneously linked XRP token instance on Stellar from ITS Hub state.
+
+The XRP token (origin chain `xrpl`, token id `0xba5a21ca88ef6bba2bfff5088994f90e1077e2a1cc3dcc38bd261f00fce2824f`) was registered on Stellar via a P2P registration against a third-party custom token rather than a freshly deployed Axelar interchain token. The XRPL origin uses `lockUnlock` against the XRPL multisig while the Stellar side uses `mintBurnFrom` against an externally controlled token. This asymmetry would allow the custom token owner to drain the XRPL multisig. The migration removes the `(stellar, 0xba5a21ca…2824f)` entry from `TOKEN_INSTANCE`. All other XRP instances (`xrpl`, `xrpl-evm`, `hedera`, …) are left untouched.
+
+## Prerequisites
+
+Build the deployments tool once:
+
+```bash
+npm ci && npm run build
+```
+
+Export the env vars for the network you are deploying to:
+
+```bash
+export ENV=<devnet-amplifier|stagenet|testnet|mainnet>
+export MNEMONIC="<any mnemonic with enough AXL to cover the proposal deposit>"
+export INIT_ADDRESSES="<comma-separated list from the table in step 4>"
+```
+
+`contract.ts` reads `ENV` (or `-e <env>`) and `MNEMONIC`. Because this rollout submits governance proposals (`--governance`), the proposer wallet does not need to be an admin — any account with the proposal deposit (3000 AXL expedited on mainnet, less on other networks) works. The deposit is refunded when the proposal passes or is rejected by vote.
+
+## Deployment
+
+- This rollout upgrades ITS Hub from `v1.3.1` to `v1.3.2`
+- The migration removes a single token instance from state and takes an empty `MigrateMsg`
+
+1. Download interchain token service wasm bytecode
+
+```bash
+mkdir wasm
+wget https://static.axelar.network/releases/cosmwasm/interchain-token-service/1.3.2/interchain_token_service.wasm --directory-prefix=wasm/
+```
+
+2. Download and verify Checksum
+
+```bash
+wget https://static.axelar.network/releases/cosmwasm/interchain-token-service/1.3.2/checksums.txt
+CHECKSUM=$(cat checksums.txt | grep interchain_token_service.wasm | awk '{print $1}')
+shasum -a 256 wasm/interchain_token_service.wasm | grep $CHECKSUM
+```
+
+3. Expected output, make sure this matches before proceeding
+
+```
+92904bc37ca2bca0dd909684ac3ddaa00e429b4c5ce8e47b755c3073fff03772  wasm/interchain_token_service.wasm
+```
+
+4. Upload new ITS Hub contract
+
+| Network          | `INIT_ADDRESSES`                                                                                                                            |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| devnet-amplifier | `axelar10d07y265gmmuvt4z0w9aw880jnsr700j7v9daj,axelar1zlr7e5qf3sz7yf890rkh9tcnu87234k6k7ytd9`                                               |
+| stagenet         | `axelar1pumrull7z8y5kc9q4azfrmcaxd8w0779kg6anm,axelar10d07y265gmmuvt4z0w9aw880jnsr700j7v9daj,axelar12qvsvse32cjyw60ztysd3v655aj5urqeup82ky` |
+| testnet          | `axelar1uk66drc8t9hwnddnejjp92t22plup0xd036uc2,axelar10d07y265gmmuvt4z0w9aw880jnsr700j7v9daj,axelar12f2qn005d4vl03ssjq07quz6cja72w5ukuchv7` |
+| mainnet          | `axelar1uk66drc8t9hwnddnejjp92t22plup0xd036uc2,axelar10d07y265gmmuvt4z0w9aw880jnsr700j7v9daj,axelar1nctnr9x0qexemeld5w7w752rmqdsqqv92dw9am` |
+
+```bash
+npx ts-node cosmwasm/contract.ts store-code -c InterchainTokenService -t "Upload InterchainTokenService contract v1.3.2" -d "Upload InterchainTokenService contract v1.3.2" --instantiateAddresses $INIT_ADDRESSES --version 1.3.2 -a ./wasm --governance
+```
+
+5. Migrate ITS Hub contract
+
+```bash
+npx ts-node cosmwasm/contract.ts migrate \
+  -c InterchainTokenService \
+  --msg '{}' \
+  --fetchCodeId \
+  --governance
+```
+
+The `migrate` subcommand does not accept `-t`/`-d`. The submitted proposal title defaults to `Migrate InterchainTokenService contract` and the description to `Migrate InterchainTokenService contract to code ID <codeId>`.
+
+## Checklist
+
+Set the ITS Hub contract address (`$ITS_HUB_ADDRESS`) and Axelar RPC node (`$NODE`) for the network you are verifying:
+
+| Network          | `$ITS_HUB_ADDRESS`                                                  | `$NODE`                                       |
+| ---------------- | ------------------------------------------------------------------- | --------------------------------------------- |
+| devnet-amplifier | `axelar157hl7gpuknjmhtac2qnphuazv2yerfagva7lsu9vuj2pgn32z22qa26dk4` | `http://devnet-amplifier.axelar.dev:26657`    |
+| stagenet         | `axelar1ph8qufmsh556e40uk0ceaufc06nwhnw0ksgdqqk6ldszxchh8llq8x52dk` | `https://axelar-rpc.stagenet.qubelabs.io:443` |
+| testnet          | `axelar1aqcj54lzz0rk22gvqgcn8fr5tx4rzwdv5wv5j9dmnacgefvd7wzsy2j2mr` | `https://axelar-testnet-rpc.qubelabs.io:443`  |
+| mainnet          | `axelar1aqcj54lzz0rk22gvqgcn8fr5tx4rzwdv5wv5j9dmnacgefvd7wzsy2j2mr` | `https://rpc-axelar.imperator.co:443`         |
+
+Verify ITS hub contract version
+
+```bash
+axelard query wasm contract-state raw $ITS_HUB_ADDRESS 636F6E74726163745F696E666F --node $NODE -o json | jq -r '.data' | base64 -d
+```
+
+Expected output
+
+```bash
+{"contract":"interchain-token-service","version":"1.3.2"}
+```
+
+Verify the erroneous stellar/XRP token instance has been removed
+
+```bash
+axelard query wasm contract-state smart $ITS_HUB_ADDRESS \
+  '{"token_instance":{"chain":"stellar","token_id":"ba5a21ca88ef6bba2bfff5088994f90e1077e2a1cc3dcc38bd261f00fce2824f"}}' \
+  --node $NODE
+```
+
+Expected output
+
+```bash
+data: null
+```
+
+Verify other XRP token instances are still present
+
+```bash
+for chain in xrpl xrpl-evm hedera; do
+  axelard query wasm contract-state smart $ITS_HUB_ADDRESS \
+    '{"token_instance":{"chain":"'$chain'","token_id":"ba5a21ca88ef6bba2bfff5088994f90e1077e2a1cc3dcc38bd261f00fce2824f"}}' \
+    --node $NODE
+done
+```
+
+Each query should return a non-null `data` field.

--- a/releases/cosmwasm/2026-05-ITS-v1.3.2.md
+++ b/releases/cosmwasm/2026-05-ITS-v1.3.2.md
@@ -1,16 +1,16 @@
 # Cosmwasm ITS v1.3.2
 
-|                | **Owner**                                       |
-| -------------- | ----------------------------------------------- |
-| **Created By** | @MakisChristou <makis@commonprefix.com>              |
-| **Deployment** | @MakisChristou <makis@commonprefix.com>         |
+|                | **Owner**                               |
+| -------------- | --------------------------------------- |
+| **Created By** | @MakisChristou <makis@commonprefix.com> |
+| **Deployment** | @MakisChristou <makis@commonprefix.com> |
 
-| **Network**          | **Deployment Status** | **Date** |
-| -------------------- | --------------------- | -------- |
-| **Devnet Amplifier** | -                     | TBD      |
-| **Stagenet**         | -                     | TBD      |
+| **Network**          | **Deployment Status** | **Date**   |
+| -------------------- | --------------------- | ---------- |
+| **Devnet Amplifier** | -                     | TBD        |
+| **Stagenet**         | -                     | TBD        |
 | **Testnet**          | Deployed              | 2026-05-12 |
-| **Mainnet**          | -                     | TBD      |
+| **Mainnet**          | Deployed              | 2026-05-15 |
 
 [Release](https://github.com/axelarnetwork/axelar-amplifier/releases/tag/interchain-token-service-v1.3.2)
 


### PR DESCRIPTION
### why
- to remove invalid wXRP route on stellar

### how
<!-- An agent will fill this out -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> On-chain ITS Hub migration alters live token routing state; incorrect config or migration could break interchain token paths or leave a dangerous route in place.
> 
> **Overview**
> Records **ITS Hub (CosmWasm `InterchainTokenService`) v1.3.2** on **testnet** and **mainnet** by updating `axelar-chains-config/info/testnet.json` and `mainnet.json`: new `storeCodeProposalId`, wasm `storeCodeProposalCodeHash` (`92904bc3…`), `codeId` / `lastUploadedCodeId`, and `version` **1.3.0 → 1.3.2** (testnet code id 86, mainnet 63).
> 
> Adds **`releases/cosmwasm/2026-05-ITS-v1.3.2.md`** with upload/migrate steps and post-deploy checks. The v1.3.2 migration removes the invalid **Stellar / wXRP** `TOKEN_INSTANCE` (asymmetric lock/mint setup that could drain XRPL multisig); other XRP instances are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed8f105a6da8b46f8a080939e56fffc10b9dd8aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->