### PR TITLE
feat: migrate legacy evm connections to amplifier-governance on testnet

### DIFF
--- a/axelar-chains-config/info/stagenet.json
+++ b/axelar-chains-config/info/stagenet.json
@@ -2726,8 +2726,7 @@
             "deploymentName": "solana-stagenet-3-22-85-84-solana-stagenet-3",
             "salt": "solana-stagenet-3"
           }
-        },
-        "axelar": {}
+        }
       },
       "Multisig": {
         "blockExpiry": 50,

--- a/axelar-chains-config/info/testnet.json
+++ b/axelar-chains-config/info/testnet.json
@@ -1393,18 +1393,6 @@
           "address": "0xbE406F0189A0B4cf3A05C286473D23791Dd44Cc6",
           "implementation": "0xA72afaa3130fE7F25CfcA4A49ed48e377a35aB6C",
           "deployer": "0x5b593E7b1725dc6FcbbFe80b2415B19153F94A85"
-        },
-        "AxelarServiceGovernance": {
-          "governanceChain": "axelar",
-          "governanceAddress": "axelar10d07y265gmmuvt4z0w9aw880jnsr700j7v9daj",
-          "minimumTimeDelay": 300,
-          "operator": "0x6e079CD1c6bBb72680DeDF2687d711AE9427eE8e",
-          "deploymentMethod": "create3",
-          "salt": "v6.0.4-axelar",
-          "address": "0x7Acbae6CBa67d78AAf69e47000884aE00F9B2525",
-          "predeployCodehash": "0x4fc776e1bb827206e031bd9e0ea8afccda553c870451ef4f5bfe33cae022be13",
-          "deployer": "0xba76c6980428A0b10CFC5d8ccb61949677A61233",
-          "codehash": "0x0afcb3c43205f100e66dfb328cde7c518026acf060e1b2d287c9b412f9546823"
         }
       },
       "gasOptions": {

--- a/axelar-chains-config/info/testnet.json
+++ b/axelar-chains-config/info/testnet.json
@@ -3606,8 +3606,7 @@
             "deploymentName": "solana-24-78-77",
             "salt": "solana"
           }
-        },
-        "axelar": {}
+        }
       },
       "Multisig": {
         "blockExpiry": 50,

--- a/axelar-chains-config/info/testnet.json
+++ b/axelar-chains-config/info/testnet.json
@@ -237,7 +237,7 @@
           "predeployCodehash": "0x912095d5076ee40a9dd49c0f9d61d61334c47a78c7512852791652baef26c296",
           "salt": "Multisig v5.5"
         },
-        "AxelarServiceGovernance_____": {
+        "AxelarServiceGovernance": {
           "governanceChain": "axelar",
           "governanceAddress": "axelar10d07y265gmmuvt4z0w9aw880jnsr700j7v9daj",
           "minimumTimeDelay": 300,

--- a/axelar-chains-config/info/testnet.json
+++ b/axelar-chains-config/info/testnet.json
@@ -122,6 +122,18 @@
           "address": "0x50beAbe4883981624aEa01F737B040d1e3Fe83FB",
           "pauser": "0x6f24A47Fc8AE5441Eb47EFfC3665e70e69Ac3F05",
           "owner": "0x3d6CB9D16FD5ff33511d630FC1E98a8F5f93dD85"
+        },
+        "AxelarServiceGovernance": {
+          "governanceChain": "axelar",
+          "governanceAddress": "axelar10d07y265gmmuvt4z0w9aw880jnsr700j7v9daj",
+          "minimumTimeDelay": 300,
+          "operator": "0x6e079CD1c6bBb72680DeDF2687d711AE9427eE8e",
+          "deploymentMethod": "create3",
+          "salt": "v6.0.4-axelar",
+          "address": "0x7Acbae6CBa67d78AAf69e47000884aE00F9B2525",
+          "predeployCodehash": "0x4fc776e1bb827206e031bd9e0ea8afccda553c870451ef4f5bfe33cae022be13",
+          "deployer": "0xba76c6980428A0b10CFC5d8ccb61949677A61233",
+          "codehash": "0x0afcb3c43205f100e66dfb328cde7c518026acf060e1b2d287c9b412f9546823"
         }
       },
       "explorer": {
@@ -244,6 +256,18 @@
           "codehash": "0x912095d5076ee40a9dd49c0f9d61d61334c47a78c7512852791652baef26c296",
           "predeployCodehash": "0x912095d5076ee40a9dd49c0f9d61d61334c47a78c7512852791652baef26c296",
           "salt": "Multisig v5.5"
+        },
+        "AxelarServiceGovernance": {
+          "governanceChain": "axelar",
+          "governanceAddress": "axelar10d07y265gmmuvt4z0w9aw880jnsr700j7v9daj",
+          "minimumTimeDelay": 300,
+          "operator": "0x6e079CD1c6bBb72680DeDF2687d711AE9427eE8e",
+          "deploymentMethod": "create3",
+          "salt": "v6.0.4-axelar",
+          "address": "0x7Acbae6CBa67d78AAf69e47000884aE00F9B2525",
+          "predeployCodehash": "0x4fc776e1bb827206e031bd9e0ea8afccda553c870451ef4f5bfe33cae022be13",
+          "deployer": "0xba76c6980428A0b10CFC5d8ccb61949677A61233",
+          "codehash": "0x989947b1646890093db39a46aad056df049d599345771681e66f7ececbe9f4db"
         }
       },
       "explorer": {
@@ -485,6 +509,18 @@
           "implementation": "0xe833E9662cb0A811AA3b1746280AB43507B61946",
           "address": "0x83a93500d23Fbc3e82B410aD07A6a9F7A0670D66",
           "version": "2.1.1"
+        },
+        "AxelarServiceGovernance": {
+          "governanceChain": "axelar",
+          "governanceAddress": "axelar10d07y265gmmuvt4z0w9aw880jnsr700j7v9daj",
+          "minimumTimeDelay": 300,
+          "operator": "0x6e079CD1c6bBb72680DeDF2687d711AE9427eE8e",
+          "deploymentMethod": "create3",
+          "salt": "v6.0.4-axelar",
+          "address": "0x7Acbae6CBa67d78AAf69e47000884aE00F9B2525",
+          "predeployCodehash": "0x4fc776e1bb827206e031bd9e0ea8afccda553c870451ef4f5bfe33cae022be13",
+          "deployer": "0xba76c6980428A0b10CFC5d8ccb61949677A61233",
+          "codehash": "0x486c91290d369662d6b62a2148003df09b6b2540725034002c69be9ccec2b6f8"
         }
       },
       "explorer": {
@@ -616,6 +652,18 @@
           "wstETH token": "0x0B15635FCF5316EdFD2a9A0b0dC3700aeA4D09E6",
           "NttManager": "0x66Cb5a992570EF01b522Bc59A056a64A84Bd0aAa",
           "wormholeChainId": 4
+        },
+        "AxelarServiceGovernance": {
+          "governanceChain": "axelar",
+          "governanceAddress": "axelar10d07y265gmmuvt4z0w9aw880jnsr700j7v9daj",
+          "minimumTimeDelay": 300,
+          "operator": "0x6e079CD1c6bBb72680DeDF2687d711AE9427eE8e",
+          "deploymentMethod": "create3",
+          "salt": "v6.0.4-axelar",
+          "address": "0x7Acbae6CBa67d78AAf69e47000884aE00F9B2525",
+          "predeployCodehash": "0x4fc776e1bb827206e031bd9e0ea8afccda553c870451ef4f5bfe33cae022be13",
+          "deployer": "0xba76c6980428A0b10CFC5d8ccb61949677A61233",
+          "codehash": "0x16770a41dc7919d951bbb055e2140eb5edce10d1ecaa47194681b8daf9a65dda"
         }
       },
       "explorer": {
@@ -731,6 +779,18 @@
           "implementation": "0xBBE9a6b47464617Dc6FA44F31896e38DC68b4ab2",
           "address": "0x83a93500d23Fbc3e82B410aD07A6a9F7A0670D66",
           "version": "2.1.1"
+        },
+        "AxelarServiceGovernance": {
+          "governanceChain": "axelar",
+          "governanceAddress": "axelar10d07y265gmmuvt4z0w9aw880jnsr700j7v9daj",
+          "minimumTimeDelay": 300,
+          "operator": "0x6e079CD1c6bBb72680DeDF2687d711AE9427eE8e",
+          "deploymentMethod": "create3",
+          "salt": "v6.0.4-axelar",
+          "address": "0x7Acbae6CBa67d78AAf69e47000884aE00F9B2525",
+          "predeployCodehash": "0x4fc776e1bb827206e031bd9e0ea8afccda553c870451ef4f5bfe33cae022be13",
+          "deployer": "0xba76c6980428A0b10CFC5d8ccb61949677A61233",
+          "codehash": "0x77e86f75c0b5a37cd17705700d78c77456653b604f45247f8ea9f8ebfbf6b029"
         }
       },
       "explorer": {
@@ -844,6 +904,18 @@
           "implementation": "0xe833E9662cb0A811AA3b1746280AB43507B61946",
           "address": "0x83a93500d23Fbc3e82B410aD07A6a9F7A0670D66",
           "version": "2.1.1"
+        },
+        "AxelarServiceGovernance": {
+          "governanceChain": "axelar",
+          "governanceAddress": "axelar10d07y265gmmuvt4z0w9aw880jnsr700j7v9daj",
+          "minimumTimeDelay": 300,
+          "operator": "0x6e079CD1c6bBb72680DeDF2687d711AE9427eE8e",
+          "deploymentMethod": "create3",
+          "salt": "v6.0.4-axelar",
+          "address": "0x7Acbae6CBa67d78AAf69e47000884aE00F9B2525",
+          "predeployCodehash": "0x4fc776e1bb827206e031bd9e0ea8afccda553c870451ef4f5bfe33cae022be13",
+          "deployer": "0xba76c6980428A0b10CFC5d8ccb61949677A61233",
+          "codehash": "0x1f05ceab48052e86c780500ca6f2e84786ebd71537fcb6b8a6236d0c6ba6174e"
         }
       },
       "explorer": {
@@ -960,6 +1032,18 @@
           "implementation": "0xe833E9662cb0A811AA3b1746280AB43507B61946",
           "address": "0x83a93500d23Fbc3e82B410aD07A6a9F7A0670D66",
           "version": "2.1.1"
+        },
+        "AxelarServiceGovernance": {
+          "governanceChain": "axelar",
+          "governanceAddress": "axelar10d07y265gmmuvt4z0w9aw880jnsr700j7v9daj",
+          "minimumTimeDelay": 300,
+          "operator": "0x6e079CD1c6bBb72680DeDF2687d711AE9427eE8e",
+          "deploymentMethod": "create3",
+          "salt": "v6.0.4-axelar",
+          "address": "0x7Acbae6CBa67d78AAf69e47000884aE00F9B2525",
+          "predeployCodehash": "0x4fc776e1bb827206e031bd9e0ea8afccda553c870451ef4f5bfe33cae022be13",
+          "deployer": "0xba76c6980428A0b10CFC5d8ccb61949677A61233",
+          "codehash": "0x0afcb3c43205f100e66dfb328cde7c518026acf060e1b2d287c9b412f9546823"
         }
       },
       "explorer": {
@@ -1079,6 +1163,18 @@
           "implementation": "0xe833E9662cb0A811AA3b1746280AB43507B61946",
           "address": "0x83a93500d23Fbc3e82B410aD07A6a9F7A0670D66",
           "version": "2.1.1"
+        },
+        "AxelarServiceGovernance": {
+          "governanceChain": "axelar",
+          "governanceAddress": "axelar10d07y265gmmuvt4z0w9aw880jnsr700j7v9daj",
+          "minimumTimeDelay": 300,
+          "operator": "0x6e079CD1c6bBb72680DeDF2687d711AE9427eE8e",
+          "deploymentMethod": "create3",
+          "salt": "v6.0.4-axelar",
+          "address": "0x7Acbae6CBa67d78AAf69e47000884aE00F9B2525",
+          "predeployCodehash": "0x4fc776e1bb827206e031bd9e0ea8afccda553c870451ef4f5bfe33cae022be13",
+          "deployer": "0xba76c6980428A0b10CFC5d8ccb61949677A61233",
+          "codehash": "0x0afcb3c43205f100e66dfb328cde7c518026acf060e1b2d287c9b412f9546823"
         }
       },
       "gasOptions": {
@@ -1194,6 +1290,18 @@
           "implementation": "0xe833E9662cb0A811AA3b1746280AB43507B61946",
           "address": "0x83a93500d23Fbc3e82B410aD07A6a9F7A0670D66",
           "version": "2.1.1"
+        },
+        "AxelarServiceGovernance": {
+          "governanceChain": "axelar",
+          "governanceAddress": "axelar10d07y265gmmuvt4z0w9aw880jnsr700j7v9daj",
+          "minimumTimeDelay": 300,
+          "operator": "0x6e079CD1c6bBb72680DeDF2687d711AE9427eE8e",
+          "deploymentMethod": "create3",
+          "salt": "v6.0.4-axelar",
+          "address": "0x7Acbae6CBa67d78AAf69e47000884aE00F9B2525",
+          "predeployCodehash": "0x4fc776e1bb827206e031bd9e0ea8afccda553c870451ef4f5bfe33cae022be13",
+          "deployer": "0xba76c6980428A0b10CFC5d8ccb61949677A61233",
+          "codehash": "0xf8bcaec89c550bc2eac4d275ddc9dcbefa4f62e29374439fea644d6ce4483827"
         }
       },
       "explorer": {
@@ -1285,6 +1393,18 @@
           "address": "0xbE406F0189A0B4cf3A05C286473D23791Dd44Cc6",
           "implementation": "0xA72afaa3130fE7F25CfcA4A49ed48e377a35aB6C",
           "deployer": "0x5b593E7b1725dc6FcbbFe80b2415B19153F94A85"
+        },
+        "AxelarServiceGovernance": {
+          "governanceChain": "axelar",
+          "governanceAddress": "axelar10d07y265gmmuvt4z0w9aw880jnsr700j7v9daj",
+          "minimumTimeDelay": 300,
+          "operator": "0x6e079CD1c6bBb72680DeDF2687d711AE9427eE8e",
+          "deploymentMethod": "create3",
+          "salt": "v6.0.4-axelar",
+          "address": "0x7Acbae6CBa67d78AAf69e47000884aE00F9B2525",
+          "predeployCodehash": "0x4fc776e1bb827206e031bd9e0ea8afccda553c870451ef4f5bfe33cae022be13",
+          "deployer": "0xba76c6980428A0b10CFC5d8ccb61949677A61233",
+          "codehash": "0x0afcb3c43205f100e66dfb328cde7c518026acf060e1b2d287c9b412f9546823"
         }
       },
       "gasOptions": {
@@ -1410,6 +1530,18 @@
           "implementation": "0xBBE9a6b47464617Dc6FA44F31896e38DC68b4ab2",
           "address": "0x83a93500d23Fbc3e82B410aD07A6a9F7A0670D66",
           "version": "2.1.1"
+        },
+        "AxelarServiceGovernance": {
+          "governanceChain": "axelar",
+          "governanceAddress": "axelar10d07y265gmmuvt4z0w9aw880jnsr700j7v9daj",
+          "minimumTimeDelay": 300,
+          "operator": "0x6e079CD1c6bBb72680DeDF2687d711AE9427eE8e",
+          "deploymentMethod": "create3",
+          "salt": "v6.0.4-axelar",
+          "address": "0x7Acbae6CBa67d78AAf69e47000884aE00F9B2525",
+          "predeployCodehash": "0x4fc776e1bb827206e031bd9e0ea8afccda553c870451ef4f5bfe33cae022be13",
+          "deployer": "0xba76c6980428A0b10CFC5d8ccb61949677A61233",
+          "codehash": "0x0afcb3c43205f100e66dfb328cde7c518026acf060e1b2d287c9b412f9546823"
         }
       },
       "finality": "finalized",
@@ -1528,6 +1660,18 @@
           "implementation": "0xe833E9662cb0A811AA3b1746280AB43507B61946",
           "address": "0x83a93500d23Fbc3e82B410aD07A6a9F7A0670D66",
           "version": "2.1.1"
+        },
+        "AxelarServiceGovernance": {
+          "governanceChain": "axelar",
+          "governanceAddress": "axelar10d07y265gmmuvt4z0w9aw880jnsr700j7v9daj",
+          "minimumTimeDelay": 300,
+          "operator": "0x6e079CD1c6bBb72680DeDF2687d711AE9427eE8e",
+          "deploymentMethod": "create3",
+          "salt": "v6.0.4-axelar",
+          "address": "0x7Acbae6CBa67d78AAf69e47000884aE00F9B2525",
+          "predeployCodehash": "0x4fc776e1bb827206e031bd9e0ea8afccda553c870451ef4f5bfe33cae022be13",
+          "deployer": "0xba76c6980428A0b10CFC5d8ccb61949677A61233",
+          "codehash": "0x0afcb3c43205f100e66dfb328cde7c518026acf060e1b2d287c9b412f9546823"
         }
       },
       "finality": "finalized",
@@ -1761,6 +1905,18 @@
           "implementation": "0xe833E9662cb0A811AA3b1746280AB43507B61946",
           "address": "0x83a93500d23Fbc3e82B410aD07A6a9F7A0670D66",
           "version": "2.1.1"
+        },
+        "AxelarServiceGovernance": {
+          "governanceChain": "axelar",
+          "governanceAddress": "axelar10d07y265gmmuvt4z0w9aw880jnsr700j7v9daj",
+          "minimumTimeDelay": 300,
+          "operator": "0x6e079CD1c6bBb72680DeDF2687d711AE9427eE8e",
+          "deploymentMethod": "create3",
+          "salt": "v6.0.4-axelar",
+          "address": "0x7Acbae6CBa67d78AAf69e47000884aE00F9B2525",
+          "predeployCodehash": "0x4fc776e1bb827206e031bd9e0ea8afccda553c870451ef4f5bfe33cae022be13",
+          "deployer": "0xba76c6980428A0b10CFC5d8ccb61949677A61233",
+          "codehash": "0x77e86f75c0b5a37cd17705700d78c77456653b604f45247f8ea9f8ebfbf6b029"
         }
       },
       "finality": "finalized",
@@ -1866,6 +2022,18 @@
           "implementation": "0xe833E9662cb0A811AA3b1746280AB43507B61946",
           "address": "0x83a93500d23Fbc3e82B410aD07A6a9F7A0670D66",
           "version": "2.1.1"
+        },
+        "AxelarServiceGovernance": {
+          "governanceChain": "axelar",
+          "governanceAddress": "axelar10d07y265gmmuvt4z0w9aw880jnsr700j7v9daj",
+          "minimumTimeDelay": 300,
+          "operator": "0x6e079CD1c6bBb72680DeDF2687d711AE9427eE8e",
+          "deploymentMethod": "create3",
+          "salt": "v6.0.4-axelar",
+          "address": "0x7Acbae6CBa67d78AAf69e47000884aE00F9B2525",
+          "predeployCodehash": "0x4fc776e1bb827206e031bd9e0ea8afccda553c870451ef4f5bfe33cae022be13",
+          "deployer": "0xba76c6980428A0b10CFC5d8ccb61949677A61233",
+          "codehash": "0x0afcb3c43205f100e66dfb328cde7c518026acf060e1b2d287c9b412f9546823"
         }
       },
       "explorer": {
@@ -1978,6 +2146,18 @@
           "implementation": "0xe833E9662cb0A811AA3b1746280AB43507B61946",
           "address": "0x83a93500d23Fbc3e82B410aD07A6a9F7A0670D66",
           "version": "2.1.1"
+        },
+        "AxelarServiceGovernance": {
+          "governanceChain": "axelar",
+          "governanceAddress": "axelar10d07y265gmmuvt4z0w9aw880jnsr700j7v9daj",
+          "minimumTimeDelay": 300,
+          "operator": "0x6e079CD1c6bBb72680DeDF2687d711AE9427eE8e",
+          "deploymentMethod": "create3",
+          "salt": "v6.0.4-axelar",
+          "address": "0x7Acbae6CBa67d78AAf69e47000884aE00F9B2525",
+          "predeployCodehash": "0x4fc776e1bb827206e031bd9e0ea8afccda553c870451ef4f5bfe33cae022be13",
+          "deployer": "0xba76c6980428A0b10CFC5d8ccb61949677A61233",
+          "codehash": "0x0afcb3c43205f100e66dfb328cde7c518026acf060e1b2d287c9b412f9546823"
         }
       },
       "explorer": {

--- a/axelar-chains-config/info/testnet.json
+++ b/axelar-chains-config/info/testnet.json
@@ -39,16 +39,6 @@
           "salt": "AxelarGateway v6.2",
           "connectionType": "consensus"
         },
-        "InterchainGovernance": {
-          "address": "0xfDF36A30070ea0241d69052ea85ff44Ad0476a66",
-          "governanceChain": "Axelarnet",
-          "minimumTimeDelay": 300,
-          "deployer": "0x6f24A47Fc8AE5441Eb47EFfC3665e70e69Ac3F05",
-          "deploymentMethod": "create3",
-          "codehash": "0x4bc0efa16652748f5c3fbb77aedff01e0c1df4156a4f4c82d6d8748ee28cb9af",
-          "predeployCodehash": "0xe2de43b29f2387b6f3575a1b50d566908fc00e03a8d88ad6be74b674a70874d2",
-          "salt": "InterchainGovernance v5.5"
-        },
         "Multisig": {
           "threshold": 2,
           "signers": [
@@ -233,16 +223,6 @@
           "deploymentMethod": "create2",
           "salt": "Operators"
         },
-        "InterchainGovernance": {
-          "governanceChain": "Axelarnet",
-          "minimumTimeDelay": 300,
-          "address": "0xfDF36A30070ea0241d69052ea85ff44Ad0476a66",
-          "deployer": "0x6f24A47Fc8AE5441Eb47EFfC3665e70e69Ac3F05",
-          "deploymentMethod": "create3",
-          "codehash": "0xbd50e2a21f021fc46f36e559e06cd62aabd0e53bada80dd3b8356c53109ec9f8",
-          "predeployCodehash": "0xe2de43b29f2387b6f3575a1b50d566908fc00e03a8d88ad6be74b674a70874d2",
-          "salt": "InterchainGovernance v5.5"
-        },
         "Multisig": {
           "threshold": 2,
           "signers": [
@@ -257,7 +237,7 @@
           "predeployCodehash": "0x912095d5076ee40a9dd49c0f9d61d61334c47a78c7512852791652baef26c296",
           "salt": "Multisig v5.5"
         },
-        "AxelarServiceGovernance": {
+        "AxelarServiceGovernance_____": {
           "governanceChain": "axelar",
           "governanceAddress": "axelar10d07y265gmmuvt4z0w9aw880jnsr700j7v9daj",
           "minimumTimeDelay": 300,
@@ -464,16 +444,6 @@
           "deploymentMethod": "create2",
           "salt": "Operators"
         },
-        "InterchainGovernance": {
-          "governanceChain": "Axelarnet",
-          "minimumTimeDelay": 300,
-          "address": "0xfDF36A30070ea0241d69052ea85ff44Ad0476a66",
-          "deployer": "0x6f24A47Fc8AE5441Eb47EFfC3665e70e69Ac3F05",
-          "deploymentMethod": "create3",
-          "codehash": "0xcab695ee4d0af84e5268a9307b8f8d2b00b25c9348e934304cad2c64f3c1fb6a",
-          "predeployCodehash": "0xe2de43b29f2387b6f3575a1b50d566908fc00e03a8d88ad6be74b674a70874d2",
-          "salt": "InterchainGovernance v5.5"
-        },
         "Multisig": {
           "threshold": 2,
           "signers": [
@@ -596,16 +566,6 @@
           "deployer": "0xB8Cd93C83A974649D76B1c19f311f639e62272BC",
           "deploymentMethod": "create2",
           "salt": "Operators"
-        },
-        "InterchainGovernance": {
-          "governanceChain": "Axelarnet",
-          "minimumTimeDelay": 300,
-          "address": "0xfDF36A30070ea0241d69052ea85ff44Ad0476a66",
-          "deployer": "0x6f24A47Fc8AE5441Eb47EFfC3665e70e69Ac3F05",
-          "deploymentMethod": "create3",
-          "codehash": "0x8dadd4fda64c3eb87dff013945415d1ff25e13e14068e1e34c1b000bddc78e2b",
-          "predeployCodehash": "0xe2de43b29f2387b6f3575a1b50d566908fc00e03a8d88ad6be74b674a70874d2",
-          "salt": "InterchainGovernance v5.5"
         },
         "Multisig": {
           "threshold": 2,
@@ -734,16 +694,6 @@
           "deploymentMethod": "create2",
           "salt": "Operators"
         },
-        "InterchainGovernance": {
-          "governanceChain": "Axelarnet",
-          "minimumTimeDelay": 300,
-          "address": "0xfDF36A30070ea0241d69052ea85ff44Ad0476a66",
-          "deployer": "0x6f24A47Fc8AE5441Eb47EFfC3665e70e69Ac3F05",
-          "deploymentMethod": "create3",
-          "codehash": "0xf9e87dd846b7424c8451f31cdaeb553f2ace3c503af51bd647690d146dc009d1",
-          "predeployCodehash": "0xe2de43b29f2387b6f3575a1b50d566908fc00e03a8d88ad6be74b674a70874d2",
-          "salt": "InterchainGovernance v5.5"
-        },
         "Multisig": {
           "threshold": 2,
           "signers": [
@@ -858,16 +808,6 @@
           "deployer": "0xB8Cd93C83A974649D76B1c19f311f639e62272BC",
           "deploymentMethod": "create2",
           "salt": "Operators"
-        },
-        "InterchainGovernance": {
-          "governanceChain": "Axelarnet",
-          "minimumTimeDelay": 300,
-          "address": "0xfDF36A30070ea0241d69052ea85ff44Ad0476a66",
-          "deployer": "0x6f24A47Fc8AE5441Eb47EFfC3665e70e69Ac3F05",
-          "deploymentMethod": "create3",
-          "codehash": "0x0a188afb57c6c5caec589da3096f75f674e48a8a8abb5d747a251630dbf5b2ab",
-          "predeployCodehash": "0xe2de43b29f2387b6f3575a1b50d566908fc00e03a8d88ad6be74b674a70874d2",
-          "salt": "InterchainGovernance v5.5"
         },
         "Multisig": {
           "threshold": 2,
@@ -987,16 +927,6 @@
           "predeployCodehash": "0x73fc31262c4bad113c79439fd231281201c7c7d45b50328bd86bccf37684bf92",
           "salt": "Create3Deployer"
         },
-        "InterchainGovernance": {
-          "governanceChain": "Axelarnet",
-          "minimumTimeDelay": 300,
-          "address": "0xfDF36A30070ea0241d69052ea85ff44Ad0476a66",
-          "deployer": "0x6f24A47Fc8AE5441Eb47EFfC3665e70e69Ac3F05",
-          "deploymentMethod": "create3",
-          "codehash": "0x4bc0efa16652748f5c3fbb77aedff01e0c1df4156a4f4c82d6d8748ee28cb9af",
-          "predeployCodehash": "0xe2de43b29f2387b6f3575a1b50d566908fc00e03a8d88ad6be74b674a70874d2",
-          "salt": "InterchainGovernance v5.5"
-        },
         "Multisig": {
           "threshold": 2,
           "signers": [
@@ -1101,16 +1031,6 @@
           "deploymentMethod": "create3",
           "salt": "AxelarGateway v6.2",
           "connectionType": "consensus"
-        },
-        "InterchainGovernance": {
-          "address": "0xfDF36A30070ea0241d69052ea85ff44Ad0476a66",
-          "governanceChain": "Axelarnet",
-          "minimumTimeDelay": 300,
-          "deployer": "0x6f24A47Fc8AE5441Eb47EFfC3665e70e69Ac3F05",
-          "deploymentMethod": "create3",
-          "codehash": "0x4bc0efa16652748f5c3fbb77aedff01e0c1df4156a4f4c82d6d8748ee28cb9af",
-          "predeployCodehash": "0xe2de43b29f2387b6f3575a1b50d566908fc00e03a8d88ad6be74b674a70874d2",
-          "salt": "InterchainGovernance v5.5"
         },
         "Multisig": {
           "threshold": 2,
@@ -1228,16 +1148,6 @@
           "deploymentMethod": "create3",
           "salt": "AxelarGateway v6.2",
           "connectionType": "consensus"
-        },
-        "InterchainGovernance": {
-          "minimumTimeDelay": 300,
-          "address": "0xfDF36A30070ea0241d69052ea85ff44Ad0476a66",
-          "governanceChain": "Axelarnet",
-          "deployer": "0x6f24A47Fc8AE5441Eb47EFfC3665e70e69Ac3F05",
-          "deploymentMethod": "create3",
-          "codehash": "0x501dea3a0c7bf8ee998c8815a7b5c186d0160054f7b1e322611cdaf7c9de046a",
-          "predeployCodehash": "0xe2de43b29f2387b6f3575a1b50d566908fc00e03a8d88ad6be74b674a70874d2",
-          "salt": "InterchainGovernance v5.5"
         },
         "Multisig": {
           "threshold": 2,
@@ -1457,16 +1367,6 @@
           "salt": "AxelarGateway v6.2",
           "connectionType": "consensus"
         },
-        "InterchainGovernance": {
-          "minimumTimeDelay": 300,
-          "address": "0xfDF36A30070ea0241d69052ea85ff44Ad0476a66",
-          "governanceChain": "Axelarnet",
-          "deployer": "0x6f24A47Fc8AE5441Eb47EFfC3665e70e69Ac3F05",
-          "deploymentMethod": "create3",
-          "codehash": "0x4bc0efa16652748f5c3fbb77aedff01e0c1df4156a4f4c82d6d8748ee28cb9af",
-          "predeployCodehash": "0xe2de43b29f2387b6f3575a1b50d566908fc00e03a8d88ad6be74b674a70874d2",
-          "salt": "InterchainGovernance v5.5"
-        },
         "Multisig": {
           "threshold": 2,
           "signers": [
@@ -1586,16 +1486,6 @@
           "deploymentMethod": "create3",
           "salt": "AxelarGateway v6.2",
           "connectionType": "consensus"
-        },
-        "InterchainGovernance": {
-          "minimumTimeDelay": 300,
-          "address": "0xfDF36A30070ea0241d69052ea85ff44Ad0476a66",
-          "governanceChain": "Axelarnet",
-          "deployer": "0x6f24A47Fc8AE5441Eb47EFfC3665e70e69Ac3F05",
-          "deploymentMethod": "create3",
-          "codehash": "0x4bc0efa16652748f5c3fbb77aedff01e0c1df4156a4f4c82d6d8748ee28cb9af",
-          "predeployCodehash": "0xe2de43b29f2387b6f3575a1b50d566908fc00e03a8d88ad6be74b674a70874d2",
-          "salt": "InterchainGovernance v5.5"
         },
         "Multisig": {
           "threshold": 2,
@@ -1803,16 +1693,6 @@
         "api": "https://api-sepolia.mantlescan.xyz/api"
       },
       "contracts": {
-        "InterchainGovernance": {
-          "minimumTimeDelay": 300,
-          "address": "0xfDF36A30070ea0241d69052ea85ff44Ad0476a66",
-          "governanceChain": "Axelarnet",
-          "deployer": "0x6f24A47Fc8AE5441Eb47EFfC3665e70e69Ac3F05",
-          "deploymentMethod": "create3",
-          "codehash": "0xf9e87dd846b7424c8451f31cdaeb553f2ace3c503af51bd647690d146dc009d1",
-          "predeployCodehash": "0xe2de43b29f2387b6f3575a1b50d566908fc00e03a8d88ad6be74b674a70874d2",
-          "salt": "InterchainGovernance v5.5"
-        },
         "Multisig": {
           "threshold": 2,
           "signers": [
@@ -1949,16 +1829,6 @@
           "predeployCodehash": "0x73fc31262c4bad113c79439fd231281201c7c7d45b50328bd86bccf37684bf92",
           "salt": "Create3Deployer"
         },
-        "InterchainGovernance": {
-          "address": "0xfDF36A30070ea0241d69052ea85ff44Ad0476a66",
-          "minimumTimeDelay": 300,
-          "governanceChain": "Axelarnet",
-          "deployer": "0x6f24A47Fc8AE5441Eb47EFfC3665e70e69Ac3F05",
-          "deploymentMethod": "create3",
-          "codehash": "0x4bc0efa16652748f5c3fbb77aedff01e0c1df4156a4f4c82d6d8748ee28cb9af",
-          "predeployCodehash": "0xe2de43b29f2387b6f3575a1b50d566908fc00e03a8d88ad6be74b674a70874d2",
-          "salt": "InterchainGovernance v5.5"
-        },
         "Multisig": {
           "address": "0xCC940AE49C78F20E3F13F3cF37e996b98Ac3EC68",
           "threshold": 2,
@@ -2072,16 +1942,6 @@
           "codehash": "0xf0ad66defbe082df243d4d274e626f557f97579c5c9e19f33d8093d6160808b7",
           "predeployCodehash": "0x73fc31262c4bad113c79439fd231281201c7c7d45b50328bd86bccf37684bf92",
           "salt": "Create3Deployer"
-        },
-        "InterchainGovernance": {
-          "address": "0xfDF36A30070ea0241d69052ea85ff44Ad0476a66",
-          "minimumTimeDelay": 300,
-          "governanceChain": "Axelarnet",
-          "deployer": "0x6f24A47Fc8AE5441Eb47EFfC3665e70e69Ac3F05",
-          "deploymentMethod": "create3",
-          "codehash": "0x4bc0efa16652748f5c3fbb77aedff01e0c1df4156a4f4c82d6d8748ee28cb9af",
-          "predeployCodehash": "0xe2de43b29f2387b6f3575a1b50d566908fc00e03a8d88ad6be74b674a70874d2",
-          "salt": "InterchainGovernance v5.5"
         },
         "Multisig": {
           "threshold": 2,
@@ -3746,7 +3606,8 @@
             "deploymentName": "solana-24-78-77",
             "salt": "solana"
           }
-        }
+        },
+        "axelar": {}
       },
       "Multisig": {
         "blockExpiry": 50,

--- a/evm/governance.js
+++ b/evm/governance.js
@@ -649,10 +649,11 @@ async function main(action, args, options) {
             // amplifier-only path (AxelarnetGateway.call_contract). Envs migrated so far:
             // - devnet-amplifier (2026-04-23)
             // - stagenet (2026-05-06)
+            // - testnet (2026-05-13)
             // Still using the legacy path:
-            // - testnet, mainnet
+            // - mainnet
             // TODO: remove this branch once all envs have migrated.
-            const useLegacyConsensusPath = isConsensusChain(chain) && !['devnet-amplifier', 'stagenet'].includes(options.env);
+            const useLegacyConsensusPath = isConsensusChain(chain) && !['devnet-amplifier', 'stagenet', 'testnet'].includes(options.env);
 
             if (useLegacyConsensusPath) {
                 consensusProposals.push(proposal);

--- a/releases/evm/2026-04-Governance-Chain-Rename-v1.0.0.md
+++ b/releases/evm/2026-04-Governance-Chain-Rename-v1.0.0.md
@@ -20,23 +20,21 @@
 |                      | `base-sepolia`      | Completed             | 06/05/2026 |
 |                      | `mantle-sepolia`    | Completed             | 06/05/2026 |
 |                      | `optimism-sepolia`  | Completed             | 06/05/2026 |
-| **Testnet**          | `ethereum-sepolia`  | -                     | TBD      |
-|                      | `avalanche`         | -                     | TBD      |
-|                      | `fantom`            | -                     | TBD      |
-|                      | `moonbeam`          | -                     | TBD      |
-|                      | `binance`           | -                     | TBD      |
-|                      | `kava`              | -                     | TBD      |
-|                      | `filecoin-2`        | -                     | TBD      |
-|                      | `scroll`            | -                     | TBD      |
-|                      | `immutable`         | -                     | TBD      |
-|                      | `arbitrum-sepolia`  | -                     | TBD      |
-|                      | `centrifuge-2`      | -                     | TBD      |
-|                      | `optimism-sepolia`  | -                     | TBD      |
-|                      | `base-sepolia`      | -                     | TBD      |
-|                      | `blast-sepolia`     | -                     | TBD      |
-|                      | `mantle-sepolia`    | -                     | TBD      |
-|                      | `polygon-sepolia`   | -                     | TBD      |
-|                      | `linea-sepolia`     | -                     | TBD      |
+| **Testnet**          | `ethereum-sepolia`  | Completed             | 13/05/2026 |
+|                      | `avalanche`         | Completed             | 13/05/2026 |
+|                      | `moonbeam`          | Completed             | 13/05/2026 |
+|                      | `binance`           | Completed             | 13/05/2026 |
+|                      | `kava`              | Completed             | 13/05/2026 |
+|                      | `filecoin-2`        | Completed             | 13/05/2026 |
+|                      | `scroll`            | Completed             | 13/05/2026 |
+|                      | `immutable`         | Completed             | 13/05/2026 |
+|                      | `arbitrum-sepolia`  | Completed             | 13/05/2026 |
+|                      | `optimism-sepolia`  | Completed             | 13/05/2026 |
+|                      | `base-sepolia`      | Completed             | 13/05/2026 |
+|                      | `blast-sepolia`     | Skipped               | 13/05/2026 |
+|                      | `mantle-sepolia`    | Completed             | 13/05/2026 |
+|                      | `polygon-sepolia`   | Completed             | 13/05/2026 |
+|                      | `linea-sepolia`     | Completed             | 13/05/2026 |
 | **Mainnet**          | `celo`              | -                     | TBD      |
 |                      | `ethereum`          | -                     | TBD      |
 |                      | `avalanche`         | -                     | TBD      |
@@ -79,7 +77,7 @@ Per-chain scope is conditional: a role is migrated only when on-chain `governanc
 | -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Devnet Amplifier** | `core-avalanche,core-ethereum,core-optimism`                                                                                                                                      |
 | **Stagenet**         | `avalanche,kava,ethereum-sepolia,arbitrum-sepolia,linea-sepolia,polygon-sepolia,base-sepolia,mantle-sepolia,optimism-sepolia` (fantom skipped — see notes) |
-| **Testnet**          | `ethereum-sepolia,avalanche,fantom,moonbeam,binance,kava,filecoin-2,scroll,immutable,arbitrum-sepolia,centrifuge-2,optimism-sepolia,base-sepolia,blast-sepolia,mantle-sepolia,polygon-sepolia,linea-sepolia` |
+| **Testnet**          | `ethereum-sepolia,avalanche,moonbeam,binance,kava,filecoin-2,scroll,immutable,arbitrum-sepolia,optimism-sepolia,base-sepolia,mantle-sepolia,polygon-sepolia,linea-sepolia` (blast-sepolia skipped — see notes) |
 | **Mainnet**          | `celo,ethereum,avalanche,fantom,polygon,moonbeam,binance,arbitrum,kava,filecoin,optimism,linea,base,mantle,scroll,centrifuge,immutable,fraxtal,blast`                             |
 
 1. Update npm dependencies:
@@ -140,6 +138,31 @@ Salt used: `v6.0.4-axelar devnet-amplifier` (CREATE2).
 
 Salt used: `v6.0.4-axelar` (CREATE2). Same deployer + salt + bytecode across all chains, hence the same deployed address. Roles transferred (gateway governance, gas service owner, ITS owner) all verified on-chain per chain.
 
+#### Testnet (completed 2026-05-13)
+
+| Chain               | New AxelarServiceGovernance                  | Completed   |
+| ------------------- | -------------------------------------------- | ----------- |
+| `ethereum-sepolia`  | `0x7Acbae6CBa67d78AAf69e47000884aE00F9B2525` | 2026-05-13  |
+| `avalanche`         | `0x7Acbae6CBa67d78AAf69e47000884aE00F9B2525` | 2026-05-13  |
+| `moonbeam`          | `0x7Acbae6CBa67d78AAf69e47000884aE00F9B2525` | 2026-05-13  |
+| `binance`           | `0x7Acbae6CBa67d78AAf69e47000884aE00F9B2525` | 2026-05-13  |
+| `kava`              | `0x7Acbae6CBa67d78AAf69e47000884aE00F9B2525` | 2026-05-13  |
+| `filecoin-2`        | `0x7Acbae6CBa67d78AAf69e47000884aE00F9B2525` | 2026-05-13  |
+| `scroll`            | `0x7Acbae6CBa67d78AAf69e47000884aE00F9B2525` | 2026-05-13  |
+| `immutable`         | `0x7Acbae6CBa67d78AAf69e47000884aE00F9B2525` | 2026-05-13  |
+| `arbitrum-sepolia`  | `0x7Acbae6CBa67d78AAf69e47000884aE00F9B2525` | 2026-05-13  |
+| `optimism-sepolia`  | `0x7Acbae6CBa67d78AAf69e47000884aE00F9B2525` | 2026-05-13  |
+| `base-sepolia`      | `0x7Acbae6CBa67d78AAf69e47000884aE00F9B2525` | 2026-05-13  |
+| `mantle-sepolia`    | `0x7Acbae6CBa67d78AAf69e47000884aE00F9B2525` | 2026-05-13  |
+| `polygon-sepolia`   | `0x7Acbae6CBa67d78AAf69e47000884aE00F9B2525` | 2026-05-13  |
+| `linea-sepolia`     | `0x7Acbae6CBa67d78AAf69e47000884aE00F9B2525` | 2026-05-13  |
+
+Salt used: `v6.0.4-axelar` (CREATE3). Same deployer + salt across all chains → identical address everywhere. Operator EOA: `0x6e079CD1c6bBb72680DeDF2687d711AE9427eE8e`. All gateway governance transfers verified on-chain.
+
+The Step 2 transfers were submitted as a single batched Axelar proposal (id `568`) carrying 14 `contract_calls[]` entries, one deposit of 1M AXL (refunded on pass) covering the per-call min-deposit gate on the `axelarnet` module.
+
+**`blast-sepolia` skipped**: both the RPC endpoint (`sepolia.blast.io`, load-balanced) and the underlying chain were unstable during the migration window — the deploy tx repeatedly failed on a "nonce too low" mismatch between the RPC's view and the chain's accepted nonce, and block production was intermittent. Revisit when the network stabilizes.
+
 ### Step 2: Transfer roles held by the legacy governance contract
 
 For each row in the per-env tables below, submit an Axelar governance proposal that routes through the **legacy governance contract** (column `Legacy governance`) and calls `transferGovernance` / `transferOwnership` on the target contract, handing the role to the new `AxelarServiceGovernance` (from Step 1).
@@ -198,9 +221,11 @@ Targets per chain (queryable post-Step-1):
 
 #### Testnet
 
-All 17 chains share the legacy governance contract `0xfDF36A30070ea0241d69052ea85ff44Ad0476a66`. Only the gateway is migrated; gas service / operators / ITS are EOA-owned on testnet.
+All chains share the legacy governance contract `0xfDF36A30070ea0241d69052ea85ff44Ad0476a66`. Only the gateway is migrated; gas service / operators / ITS are EOA-owned on testnet.
 
-Chains: `ethereum-sepolia, avalanche, fantom, moonbeam, binance, kava, filecoin-2, scroll, immutable, arbitrum-sepolia, centrifuge-2, optimism-sepolia, base-sepolia, blast-sepolia, mantle-sepolia, polygon-sepolia, linea-sepolia`.
+Chains: `ethereum-sepolia, avalanche, moonbeam, binance, kava, filecoin-2, scroll, immutable, arbitrum-sepolia, optimism-sepolia, base-sepolia, mantle-sepolia, polygon-sepolia, linea-sepolia`.
+
+`blast-sepolia` skipped — RPC and chain were unstable during the migration window. See note under Step 1.
 
 Use `activationTime = 0` (testnet `minimumTimeDelay = 300s`).
 


### PR DESCRIPTION
### why

Continues on #1369 and #1371

Fixes CPI-245

### how
<!-- An agent will fill this out -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Updates on-chain governance contract metadata and switches testnet EVM governance proposal routing away from the legacy consensus path—security-critical operational changes.
> 
> **Overview**
> This PR records **testnet completion** of the governance chain rename / amplifier migration (2026-05-13): legacy `InterchainGovernance` entries are removed from `testnet.json` and replaced with **`AxelarServiceGovernance`** (`governanceChain`: `axelar`, shared address `0x7Acbae6CBa67d78AAf69e47000884aE00F9B2525`, salt `v6.0.4-axelar`) across 14 migrated EVM chains.
> 
> **`evm/governance.js`** adds **`testnet`** to the env list that routes consensus-chain governance through the **amplifier** `AxelarnetGateway.call_contract` path instead of the legacy consensus proposal path (mainnet still on legacy).
> 
> The **release runbook** (`2026-04-Governance-Chain-Rename-v1.0.0.md`) is updated with completed testnet chain tables, batched proposal **568**, narrowed prerequisites (drops fantom/centrifuge-2; **`blast-sepolia` skipped** due to RPC/chain instability). **`stagenet.json`** trims an empty `"axelar": {}` under Coordinator deployments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f106350c74f5d8bf5489d48648938a2865b2cdb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->