### PR TITLE
chore(testnet.json): add tokens

### DIFF
--- a/axelar-chains-config/info/mainnet.json
+++ b/axelar-chains-config/info/mainnet.json
@@ -2842,7 +2842,7 @@
         "AXE": {
           "address": "0x2e894c867a1a81aaae7a3498ecbe55c78e1e1a8345202e36e20df8bcf6e19b5d",
           "typeArgument": "0x2e894c867a1a81aaae7a3498ecbe55c78e1e1a8345202e36e20df8bcf6e19b5d::axe::AXE",
-          "decimals": "9",
+          "decimals": 9,
           "objects": {
             "TokenId": "0xdb55ccc3ccf0c5c03226602a6131007393079c59a0de0c97dd8bb97328b37d10",
             "TreasuryCap": "0xcab750c6f1a294674f8ea0752e0e59c1fa987c0fb2aa026c9d1add0aca8f0e84",

--- a/axelar-chains-config/info/mainnet.json
+++ b/axelar-chains-config/info/mainnet.json
@@ -2838,6 +2838,16 @@
             }
           ],
           "tokenManagerType": "mint_burn"
+        },
+        "AXE": {
+          "address": "0x2e894c867a1a81aaae7a3498ecbe55c78e1e1a8345202e36e20df8bcf6e19b5d",
+          "typeArgument": "0x2e894c867a1a81aaae7a3498ecbe55c78e1e1a8345202e36e20df8bcf6e19b5d::axe::AXE",
+          "decimals": "9",
+          "objects": {
+            "TokenId": "0xdb55ccc3ccf0c5c03226602a6131007393079c59a0de0c97dd8bb97328b37d10",
+            "TreasuryCap": "0xcab750c6f1a294674f8ea0752e0e59c1fa987c0fb2aa026c9d1add0aca8f0e84",
+            "Metadata": "0x41f1a7e83668d89b467e7ffcda46431acb20cd9af4b0b6a884c87799c8141f94"
+          }
         }
       }
     },
@@ -2953,6 +2963,12 @@
           "tokenManagerAddress": "CAFGB2Q3T2VKZQN2CWR6YHXCHWIUFMEUCVNTIOX7ZSQPLXC7M4H7PWI6",
           "tokenManagerType": "mint_burn",
           "decimals": 18
+        },
+        "AXE": {
+          "address": "CB2NGT4E4G4OAJJV2MPQPP52WGRJBCSVQZLQ2DFBRY5IJ4Z5YJPLJNJH",
+          "tokenId": "0x5b7e73124ba00a2628e5a092aea0b52e000f0be26990fc683ee1c45ff0054038",
+          "decimals": 7,
+          "notes": "AXE ITS test token deployed by axe load-test; remote registered on hyperliquid. Skip re-deploy via chains.stellar.contracts.AXE.tokenId."
         }
       },
       "approxFinalityWaitTime": 1,
@@ -3496,6 +3512,12 @@
           "tokenManagerAddress": "0xc55569d816c7734Bb88d23F242A69DA994Ab9566",
           "tokenManagerType": "mint_burn",
           "decimals": 18
+        },
+        "AXE": {
+          "address": "0xeF4f74566E58cB7ddf483e52d130Bd87b8EA1a38",
+          "tokenId": "0x2cbebbff605dfbef70dc73805124fdcbeb0c809f24f183fad78f5006fda4598f",
+          "decimals": 18,
+          "notes": "AXE ITS test token deployed by axe load-test; remote registered on stellar. Skip re-deploy via chains.hyperliquid.contracts.AXE.tokenId."
         }
       }
     },

--- a/axelar-chains-config/info/testnet.json
+++ b/axelar-chains-config/info/testnet.json
@@ -2453,6 +2453,16 @@
             "ItsSingleton": "0x9926aca1bc1fcaf38db6b5570dd16e7ad265c1d7f621dbb0efdc49d61b6471dd",
             "ItsChannelId": "0xeadff6a48792bdb8ca1216bab78c502244152fc3632abac5f67e150da5e09315"
           }
+        },
+        "AXE": {
+          "address": "0x57975b22832d94a45f21a156b033a70fc44e7917b99303298abd426c4c393b7f",
+          "typeArgument": "0x57975b22832d94a45f21a156b033a70fc44e7917b99303298abd426c4c393b7f::axe::AXE",
+          "decimals": "9",
+          "objects": {
+            "TokenId": "0xf6bf5d313802acf0d26313c5245a2ed9d873846240c8d835690573ee148df078",
+            "TreasuryCap": "0x9a621ad4ce8094eed0870facdb58759969920e69b4d5828a067f323c879c3339",
+            "Metadata": "0x3215dd06147b36cd4874afbe981950975558fd980b3b0ce82b7f4e260cf2ba7d"
+          }
         }
       }
     },
@@ -3067,6 +3077,12 @@
           "address": "0x83a93500d23Fbc3e82B410aD07A6a9F7A0670D66",
           "implementation": "0x6977477Bd4C053E1BfD0B6F287060c2A4E5E1aA1",
           "version": "2.2.0"
+        },
+        "AXE": {
+          "tokenId": "0xa9d0d0d3063287083ec0f14c015cd786b3ae96c681105913d27c2954a1c54546",
+          "tokenAddress": "0x7AC528458e73A11F0149c9234EC5f49cb1718a6e",
+          "decimals": 18,
+          "notes": "AXE ITS test token deployed by axe load-test; remote registered on stellar-2026-q1-2. Skip re-deploy via chains.hyperliquid.contracts.AXE.tokenId."
         }
       }
     },
@@ -3448,6 +3464,12 @@
           "wasmHash": "48d81492a15e4a77f4ba270dcee530910ff0470c14bfa446cee2ee42ae43d8cb",
           "version": "1.0.0",
           "initializeArgs": {}
+        },
+        "AXE": {
+          "tokenId": "0x1600ee6a7b3810f8a277226b0f3a54cc9f92eb2e0456fc64578a78762ab7f838",
+          "tokenAddress": "CD4E76AHF7UUBDMEUXCUXGRZENJMSKSFDCIVMBLJMQNJFCT3NQF4X4JT",
+          "decimals": 7,
+          "notes": "AXE ITS test token deployed by axe load-test; remote registered on hyperliquid. Skip re-deploy via chains.stellar-2026-q1-2.contracts.AXE.tokenId."
         }
       }
     },

--- a/axelar-chains-config/info/testnet.json
+++ b/axelar-chains-config/info/testnet.json
@@ -3079,8 +3079,8 @@
           "version": "2.2.0"
         },
         "AXE": {
+          "address": "0x7AC528458e73A11F0149c9234EC5f49cb1718a6e",
           "tokenId": "0xa9d0d0d3063287083ec0f14c015cd786b3ae96c681105913d27c2954a1c54546",
-          "tokenAddress": "0x7AC528458e73A11F0149c9234EC5f49cb1718a6e",
           "decimals": 18,
           "notes": "AXE ITS test token deployed by axe load-test; remote registered on stellar-2026-q1-2. Skip re-deploy via chains.hyperliquid.contracts.AXE.tokenId."
         }
@@ -3466,8 +3466,8 @@
           "initializeArgs": {}
         },
         "AXE": {
+          "address": "CD4E76AHF7UUBDMEUXCUXGRZENJMSKSFDCIVMBLJMQNJFCT3NQF4X4JT",
           "tokenId": "0x1600ee6a7b3810f8a277226b0f3a54cc9f92eb2e0456fc64578a78762ab7f838",
-          "tokenAddress": "CD4E76AHF7UUBDMEUXCUXGRZENJMSKSFDCIVMBLJMQNJFCT3NQF4X4JT",
           "decimals": 7,
           "notes": "AXE ITS test token deployed by axe load-test; remote registered on hyperliquid. Skip re-deploy via chains.stellar-2026-q1-2.contracts.AXE.tokenId."
         }

--- a/axelar-chains-config/info/testnet.json
+++ b/axelar-chains-config/info/testnet.json
@@ -2457,7 +2457,7 @@
         "AXE": {
           "address": "0x57975b22832d94a45f21a156b033a70fc44e7917b99303298abd426c4c393b7f",
           "typeArgument": "0x57975b22832d94a45f21a156b033a70fc44e7917b99303298abd426c4c393b7f::axe::AXE",
-          "decimals": "9",
+          "decimals": 9,
           "objects": {
             "TokenId": "0xf6bf5d313802acf0d26313c5245a2ed9d873846240c8d835690573ee148df078",
             "TreasuryCap": "0x9a621ad4ce8094eed0870facdb58759969920e69b4d5828a067f323c879c3339",


### PR DESCRIPTION
### why
- <!-- Explain the reason for this change -->

### how
<!-- An agent will fill this out -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates chain configuration for interchain token deployments; incorrect `tokenId`/addresses or decimals could break bridging or cause misrouting for the `AXE` asset across affected chains.
> 
> **Overview**
> Adds `AXE` token entries to the chains config for both `mainnet.json` and `testnet.json`.
> 
> This registers `AXE` across the relevant chain sections (including Sui and EVM/Stellar environments) with addresses/type arguments, decimals, and token object IDs/notes to support ITS-related deployments and to instruct operators to skip re-deploys where the token is already remotely registered.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 519007024f7f6682110846aba488211ba3036f4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->