### PR TITLE
docs(xrpl): add local token link flow

### DIFF
--- a/xrpl/README.md
+++ b/xrpl/README.md
@@ -53,7 +53,7 @@ ts-node xrpl/rotate-signers.js -e testnet -n xrpl --signerPublicKeys 028E425D6F7
 
 ### Token Deployments
 
-Refer to the XRPL ITS [Local Token Deployment](./docs/deploy-local-token.md), [Remote Token Deployment](./docs/deploy-remote-token.md),  and [Link Token](./docs/link-token.md) guides to enable transferring new tokens between XRPL and remote chains.
+Refer to the XRPL ITS [Local Token Deployment](./docs/deploy-local-token.md), [Remote Token Deployment](./docs/deploy-remote-token.md), [EVM-Origin Link Token](./docs/link-token.md), [XRPL Local Token Link](./docs/link-local-token.md), and [XRPL Local Token Interchain Transfer](./docs/interchain-transfer-local-token.md) guides to enable transferring tokens between XRPL and remote chains.
 
 ## Contract Interactions
 

--- a/xrpl/docs/interchain-transfer-local-token.md
+++ b/xrpl/docs/interchain-transfer-local-token.md
@@ -1,0 +1,242 @@
+# XRPL Local Token Interchain Transfer Guide
+
+## Background
+
+This guide validates transfers after an XRPL-local IOU has been linked to an existing EVM token with [link-local-token.md](./link-local-token.md).
+
+It covers both directions:
+
+```text
+XRPL IOU -> EVM token
+EVM token -> XRPL IOU
+```
+
+For `LockUnlock` TokenManagers, transfers require liquidity on both sides:
+
+- XRPL -> EVM releases tokens from the EVM TokenManager.
+- EVM -> XRPL releases IOUs from the Axelar XRPL multisig.
+
+## Environment
+
+Use the same variables from the link flow:
+
+```bash
+export ENV=testnet
+export XRPL_CHAIN=xrpl
+export DESTINATION_CHAIN=<evm-amplifier-chain>
+
+export TOKEN_ID=
+export TOKEN_ISSUER=
+export TOKEN_CURRENCY=
+export DESTINATION_TOKEN_ADDRESS=
+export TOKEN_MANAGER_ADDRESS=
+
+export XRPL_PRIVATE_KEY=        # XRPL sender/issuer seed for XRPL-origin transfer
+export XRPL_RECIPIENT_PRIVATE_KEY=
+export XRPL_RECIPIENT=
+export EVM_PRIVATE_KEY=
+export EVM_RECIPIENT=
+
+export ADMIN_KEY=
+export KEYRING_BACKEND=${KEYRING_BACKEND:-test}
+export RPC_URL=${RPC_URL:-$(node -e "const c=require('./axelar-chains-config/info/' + process.env.ENV + '.json'); console.log(c.axelar.rpc)")}
+export AXELAR_CHAIN_ID=${AXELAR_CHAIN_ID:-$(node -e "const c=require('./axelar-chains-config/info/' + process.env.ENV + '.json'); console.log(c.axelar.chainId)")}
+export GAS_PRICES=${GAS_PRICES:-$(node -e "const c=require('./axelar-chains-config/info/' + process.env.ENV + '.json'); console.log(c.axelar.gasPrice)")}
+export ARGS=(--from "$ADMIN_KEY" --keyring-backend "$KEYRING_BACKEND" --chain-id "$AXELAR_CHAIN_ID" --gas auto --gas-adjustment 1.5 --gas-prices "$GAS_PRICES" --node "$RPC_URL" -y)
+```
+
+## 1. Prepare XRPL Trustlines
+
+The XRPL recipient must trust the IOU issuer.
+
+```bash
+npx ts-node xrpl/trust-set.js \
+  -e "$ENV" \
+  -n "$XRPL_CHAIN" \
+  -p "$XRPL_RECIPIENT_PRIVATE_KEY" \
+  -y \
+  "$TOKEN_CURRENCY" \
+  "$TOKEN_ISSUER" \
+  --limit 1000000000
+```
+
+For EVM -> XRPL transfers where the Axelar multisig pays a recipient, the issuer must allow holder-to-holder IOU movement. For new test issuers, set DefaultRipple before creating trustlines:
+
+```bash
+npx ts-node xrpl/account-set.js \
+  -e "$ENV" \
+  -n "$XRPL_CHAIN" \
+  -p "$XRPL_PRIVATE_KEY" \
+  -y \
+  --flag 8
+```
+
+If trustlines already exist and the issuer side has `NoRipple`, clear it with XRPL tooling before testing EVM -> XRPL. Otherwise the destination XRPL payment can fail with `tecPATH_DRY`.
+
+## 2. Prepare Lock/Unlock Liquidity
+
+For `LockUnlock`, seed the EVM TokenManager with enough destination tokens for XRPL -> EVM transfers.
+
+Use any standard ERC-20 transfer tool. For example, with `cast`:
+
+```bash
+export DESTINATION_RPC_URL=$(node -e "const c=require('./axelar-chains-config/info/' + process.env.ENV + '.json'); console.log(c.chains[process.env.DESTINATION_CHAIN].rpc)")
+
+cast send "$DESTINATION_TOKEN_ADDRESS" \
+  "transfer(address,uint256)" \
+  "$TOKEN_MANAGER_ADDRESS" \
+  "<amount-in-base-units>" \
+  --rpc-url "$DESTINATION_RPC_URL" \
+  --private-key "$EVM_PRIVATE_KEY"
+```
+
+The XRPL multisig also needs IOU balance for EVM -> XRPL transfers. The usual way to seed it is to perform an XRPL -> EVM transfer first.
+
+## 3. XRPL to EVM Transfer
+
+Initiate the transfer with an XRPL `Payment` to the Axelar XRPL multisig.
+
+```bash
+npx ts-node xrpl/interchain-transfer.js \
+  -e "$ENV" \
+  -n "$XRPL_CHAIN" \
+  -p "$XRPL_PRIVATE_KEY" \
+  -y \
+  "$TOKEN_CURRENCY.$TOKEN_ISSUER" \
+  "<amount>" \
+  "$DESTINATION_CHAIN" \
+  "$EVM_RECIPIENT" \
+  --gasFeeAmount "<drops>"
+```
+
+Notes:
+
+- `--gasFeeAmount` is in drops, not XRP.
+- For an EVM destination address, pass the normal `0x...` address.
+
+Relay path:
+
+```text
+XRPL Payment
+-> XrplGateway verify_messages
+-> verifier voting / end poll
+-> XrplGateway route_incoming_messages
+-> AxelarnetGateway execute
+-> ITS Hub emits Axelar-to-EVM child message
+-> destination MultisigProver construct_proof
+-> evm/gateway.js submitProof
+-> evm/gateway.js execute
+```
+
+If relayers do not complete the destination leg, use the same destination proof and execute pattern from [link-local-token.md](./link-local-token.md).
+
+Verify balances:
+
+```bash
+npx ts-node xrpl/balances.js \
+  -e "$ENV" \
+  -n "$XRPL_CHAIN" \
+  -p "$XRPL_PRIVATE_KEY"
+```
+
+Check the EVM ERC-20 recipient and TokenManager balances with `cast call`, a block explorer, or a small ethers script.
+
+## 4. EVM to XRPL Transfer
+
+Initiate the EVM source transfer. Pass the classic XRPL destination address; `evm/its.js` encodes XRPL destination addresses as ASCII bytes internally.
+
+```bash
+npx ts-node evm/its.js interchain-transfer \
+  -e "$ENV" \
+  -n "$DESTINATION_CHAIN" \
+  -p "$EVM_PRIVATE_KEY" \
+  -y \
+  --destinationChain "$XRPL_CHAIN" \
+  --tokenId "0x$TOKEN_ID" \
+  --destinationAddress "$XRPL_RECIPIENT" \
+  --amount "<amount>"
+```
+
+The source EVM transaction emits a message to the ITS Hub. Once the Hub executes it, the Hub emits an Axelar-to-XRPL child message.
+
+If the XRPL destination proof is not handled by relayers, construct it manually on `XrplMultisigProver`. The XRPL prover requires both the child message ID and the child payload.
+
+```bash
+export XRPL_MULTISIG_PROVER=$(node -e "const c=require('./axelar-chains-config/info/' + process.env.ENV + '.json'); console.log(c.axelar.contracts.XrplMultisigProver[process.env.XRPL_CHAIN].address)")
+export HUB_TO_XRPL_MESSAGE_ID=
+export HUB_TO_XRPL_PAYLOAD= # without 0x
+
+MSG=$(jq -nc \
+  --arg id "$HUB_TO_XRPL_MESSAGE_ID" \
+  --arg payload "$HUB_TO_XRPL_PAYLOAD" \
+  '{construct_proof:{cc_id:{source_chain:"axelar",message_id:$id},payload:$payload}}')
+
+axelard tx wasm execute "$XRPL_MULTISIG_PROVER" "$MSG" "${ARGS[@]}"
+
+export XRPL_PROOF_SESSION_ID=
+```
+
+When the session is complete, broadcast the signed XRPL `Payment`.
+
+```bash
+npx ts-node xrpl/submit-proof.js \
+  -e "$ENV" \
+  -n "$XRPL_CHAIN" \
+  -p "$XRPL_PRIVATE_KEY" \
+  -y \
+  "$XRPL_PROOF_SESSION_ID"
+```
+
+Relayers may broadcast the XRPL payment before the manual command. If `submit-proof` returns `tefNO_TICKET`, query the XRPL multisig `account_tx`; the proof may already have succeeded and consumed the ticket.
+
+Verify the XRPL recipient balance:
+
+```bash
+npx ts-node xrpl/balances.js \
+  -e "$ENV" \
+  -n "$XRPL_CHAIN" \
+  -p "$XRPL_RECIPIENT_PRIVATE_KEY"
+```
+
+## 5. Expected Balance Movement
+
+For `LockUnlock`:
+
+```text
+XRPL -> EVM:
+  XRPL multisig IOU balance increases.
+  EVM TokenManager token balance decreases.
+  EVM recipient token balance increases.
+
+EVM -> XRPL:
+  EVM TokenManager token balance increases.
+  XRPL multisig IOU balance decreases.
+  XRPL recipient IOU balance increases.
+```
+
+## Troubleshooting
+
+`tecPATH_DRY` on XRPL destination payment:
+
+- Recipient may not have a trustline to `{ issuer, currency }`.
+- The issuer side of the trustlines may have `NoRipple` set.
+- The XRPL multisig may not hold enough IOU balance.
+
+`tefNO_TICKET` on `xrpl/submit-proof.js`:
+
+- The XRPL multisig ticket was already consumed.
+- Check whether a relayer already broadcast the same signed transaction successfully.
+- Query XRPL `account_tx` for the multisig before retrying.
+
+No EVM tokens released on XRPL -> EVM:
+
+- The destination TokenManager may not have enough token liquidity for `LockUnlock`.
+- The EVM destination proof may be approved but not executed. `submitProof` does not call the destination app; run `evm/gateway.js --action execute` with the Hub-emitted destination payload.
+
+Wrong XRPL destination address encoding:
+
+- For `evm/its.js interchain-transfer` to XRPL, pass the classic XRPL address. Do not pass decoded account bytes.
+
+Wrong XRPL token identity:
+
+- The token is `{ issuer, currency }`, not currency alone.

--- a/xrpl/docs/link-local-token.md
+++ b/xrpl/docs/link-local-token.md
@@ -1,0 +1,297 @@
+# XRPL Local Token Link Guide
+
+## Background
+
+This guide links an XRPL-local IOU to an already deployed token on a remote chain through Axelar ITS.
+
+Use this flow when the XRPL token identity is the source of truth and should determine the ITS token ID:
+
+```text
+XRPL token = { issuer: $TOKEN_ISSUER, currency: $TOKEN_CURRENCY }
+```
+
+The XRPL currency code alone is not a token. The IOU identity is the issuer plus currency pair.
+
+This flow differs from [link-token.md](./link-token.md), where an EVM token is the source of truth and the XRPL token is a remote representation issued by the Axelar XRPL multisig.
+
+## Prerequisites
+
+- Existing XRPL IOU issuer/currency pair, or a planned issuer/currency pair controlled by the project.
+- Existing remote token address on the destination chain.
+- Destination chain registered with the ITS Hub.
+- Metadata registered for both the XRPL token and the destination token before linking.
+- Sufficient permissions for the chosen TokenManager type.
+
+Recommended TokenManager types:
+
+```text
+1 = MintBurnFrom
+2 = LockUnlock
+4 = MintBurn
+```
+
+Use `2` (`LockUnlock`) when both sides are existing fixed-supply assets and bridge liquidity is held by the destination TokenManager and XRPL multisig. Use a mint/burn type only when the token permissions support it.
+
+For post-link transfer testing, see [interchain-transfer-local-token.md](./interchain-transfer-local-token.md).
+
+## Environment
+
+Set the working variables:
+
+```bash
+export ENV=testnet
+export XRPL_CHAIN=xrpl
+export DESTINATION_CHAIN=<evm-amplifier-chain>
+
+# Elevated Axelar account for XrplGateway / XrplMultisigProver operations.
+export MNEMONIC=
+
+# Optional alternative when using an axelard keyring for manual wasm executes.
+export ADMIN_KEY=
+export KEYRING_BACKEND=${KEYRING_BACKEND:-test}
+export RPC_URL=${RPC_URL:-$(node -e "const c=require('./axelar-chains-config/info/' + process.env.ENV + '.json'); console.log(c.axelar.rpc)")}
+export AXELAR_CHAIN_ID=${AXELAR_CHAIN_ID:-$(node -e "const c=require('./axelar-chains-config/info/' + process.env.ENV + '.json'); console.log(c.axelar.chainId)")}
+export GAS_PRICES=${GAS_PRICES:-$(node -e "const c=require('./axelar-chains-config/info/' + process.env.ENV + '.json'); console.log(c.axelar.gasPrice)")}
+export ARGS=(--from "$ADMIN_KEY" --keyring-backend "$KEYRING_BACKEND" --chain-id "$AXELAR_CHAIN_ID" --gas auto --gas-adjustment 1.5 --gas-prices "$GAS_PRICES" --node "$RPC_URL" -y)
+
+# XRPL seed used only to broadcast XRPL transactions such as the completed multisig TrustSet proof.
+export XRPL_PRIVATE_KEY=
+
+# EVM key funded on the destination chain for metadata registration, proof submission, and execute.
+export PRIVATE_KEY=
+
+export TOKEN_ISSUER=
+export TOKEN_SYMBOL=
+export TOKEN_CURRENCY=
+export DESTINATION_TOKEN_ADDRESS=
+export TOKEN_MANAGER_TYPE=2
+
+# Optional EVM TokenManager operator. Leave empty for no custom operator.
+export OPERATOR=
+```
+
+Generate a 160-bit XRPL currency code from a symbol:
+
+```bash
+npx ts-node xrpl/token.ts token-symbol-to-currency-code "$TOKEN_SYMBOL"
+```
+
+If the destination chain should exercise the full Amplifier proof path on testnet, choose a chain with `axelar.contracts.MultisigProver[$DESTINATION_CHAIN]` in the current config.
+
+## 1. Register the XRPL Local Token
+
+Register the issuer/currency pair on `XrplGateway`.
+
+```bash
+npx ts-node xrpl/register-local-token.js \
+  -e "$ENV" \
+  -n "$XRPL_CHAIN" \
+  -m "$MNEMONIC" \
+  -y \
+  --issuer "$TOKEN_ISSUER" \
+  --currency "$TOKEN_CURRENCY"
+```
+
+Query the XRPL-derived token ID.
+
+```bash
+npx ts-node xrpl/xrpl-token-id.js \
+  -e "$ENV" \
+  -n "$XRPL_CHAIN" \
+  --issuer "$TOKEN_ISSUER" \
+  --currency "$TOKEN_CURRENCY"
+
+export TOKEN_ID=
+```
+
+## 2. Create the XRPL Multisig Trustline
+
+Create a trustline from the Axelar XRPL multisig account to the local IOU. This is an `XrplMultisigProver` operation that constructs a signed XRPL `TrustSet`.
+
+```bash
+npx ts-node xrpl/trust-set-multisig.js \
+  -e "$ENV" \
+  -n "$XRPL_CHAIN" \
+  -m "$MNEMONIC" \
+  -y \
+  --tokenId "$TOKEN_ID"
+
+export MULTISIG_SESSION_ID=
+```
+
+When the multisig session is complete, broadcast the signed XRPL transaction.
+
+```bash
+npx ts-node xrpl/submit-proof.js \
+  -e "$ENV" \
+  -n "$XRPL_CHAIN" \
+  -p "$XRPL_PRIVATE_KEY" \
+  -y \
+  "$MULTISIG_SESSION_ID"
+```
+
+## 3. Register XRPL Token Metadata
+
+Register XRPL token metadata through `XrplGateway`. This emits a message to the ITS Hub.
+
+```bash
+npx ts-node xrpl/register-token-metadata.js \
+  -e "$ENV" \
+  -n "$XRPL_CHAIN" \
+  -m "$MNEMONIC" \
+  -y \
+  --issuer "$TOKEN_ISSUER" \
+  --currency "$TOKEN_CURRENCY"
+
+export XRPL_METADATA_MESSAGE_ID=
+export XRPL_METADATA_PAYLOAD=
+```
+
+Route the metadata message through `AxelarnetGateway`.
+
+```bash
+export AXELARNET_GATEWAY=$(node -e "const c=require('./axelar-chains-config/info/' + process.env.ENV + '.json'); console.log(c.axelar.contracts.AxelarnetGateway.address)")
+
+axelard tx wasm execute "$AXELARNET_GATEWAY" \
+  '{"execute":{"cc_id":{"source_chain":"'"$XRPL_CHAIN"'","message_id":"'"$XRPL_METADATA_MESSAGE_ID"'"},"payload":"'"$XRPL_METADATA_PAYLOAD"'"}}' \
+  "${ARGS[@]}"
+```
+
+Wait until the ITS Hub stores metadata for the XRPL token address before linking.
+
+## 4. Register Destination Token Metadata
+
+Register the existing destination token metadata from the destination EVM chain.
+
+```bash
+npx ts-node evm/its.js register-token-metadata "$DESTINATION_TOKEN_ADDRESS" \
+  -e "$ENV" \
+  -n "$DESTINATION_CHAIN" \
+  -p "$PRIVATE_KEY" \
+  -y
+```
+
+Wait until this message executes on the ITS Hub.
+
+## 5. Link the XRPL Token ID to the Existing Destination Token
+
+Call `LinkToken` on `XrplGateway`. This sends an ITS Hub `LinkToken` message using the XRPL-derived `TOKEN_ID`.
+
+Without a custom EVM operator:
+
+```bash
+npx ts-node xrpl/link-token.js \
+  -e "$ENV" \
+  -n "$XRPL_CHAIN" \
+  -m "$MNEMONIC" \
+  -y \
+  --tokenId "$TOKEN_ID" \
+  --destinationChain "$DESTINATION_CHAIN" \
+  --destinationTokenAddress "$DESTINATION_TOKEN_ADDRESS" \
+  --tokenManagerType "$TOKEN_MANAGER_TYPE"
+```
+
+With a custom EVM operator:
+
+```bash
+npx ts-node xrpl/link-token.js \
+  -e "$ENV" \
+  -n "$XRPL_CHAIN" \
+  -m "$MNEMONIC" \
+  -y \
+  --tokenId "$TOKEN_ID" \
+  --destinationChain "$DESTINATION_CHAIN" \
+  --destinationTokenAddress "$DESTINATION_TOKEN_ADDRESS" \
+  --tokenManagerType "$TOKEN_MANAGER_TYPE" \
+  --operator "$OPERATOR"
+```
+
+Export the emitted values:
+
+```bash
+export LINK_MESSAGE_ID=
+export LINK_PAYLOAD=
+```
+
+Route the link message through the ITS Hub.
+
+```bash
+axelard tx wasm execute "$AXELARNET_GATEWAY" \
+  '{"execute":{"cc_id":{"source_chain":"'"$XRPL_CHAIN"'","message_id":"'"$LINK_MESSAGE_ID"'"},"payload":"'"$LINK_PAYLOAD"'"}}' \
+  "${ARGS[@]}"
+```
+
+From the route transaction events, record the Axelar-to-destination message values from the `wasm-contract_called` event:
+
+```bash
+export DESTINATION_MESSAGE_ID=
+export DESTINATION_PAYLOAD=
+export DESTINATION_SOURCE_ADDRESS=
+```
+
+## 6. Execute on the Destination EVM Chain
+
+Construct the destination proof on the destination chain's `MultisigProver`.
+
+```bash
+export DESTINATION_MULTISIG_PROVER=$(node -e "const c=require('./axelar-chains-config/info/' + process.env.ENV + '.json'); console.log(c.axelar.contracts.MultisigProver[process.env.DESTINATION_CHAIN].address)")
+
+axelard tx wasm execute "$DESTINATION_MULTISIG_PROVER" \
+  '{"construct_proof":[{"source_chain":"axelar","message_id":"'"$DESTINATION_MESSAGE_ID"'"}]}' \
+  "${ARGS[@]}"
+
+export DESTINATION_SESSION_ID=
+```
+
+Submit the proof to the destination EVM Gateway.
+
+```bash
+npx ts-node evm/gateway.js \
+  -e "$ENV" \
+  -n "$DESTINATION_CHAIN" \
+  -p "$PRIVATE_KEY" \
+  -y \
+  --action submitProof \
+  --multisigSessionId "$DESTINATION_SESSION_ID"
+```
+
+This approves the command in the destination Gateway. Execute the destination ITS call with the payload emitted by the ITS Hub route transaction.
+
+```bash
+export DESTINATION_ITS=$(node -e "const c=require('./axelar-chains-config/info/' + process.env.ENV + '.json'); console.log(c.chains[process.env.DESTINATION_CHAIN].contracts.InterchainTokenService.address)")
+
+npx ts-node evm/gateway.js \
+  -e "$ENV" \
+  -n "$DESTINATION_CHAIN" \
+  -p "$PRIVATE_KEY" \
+  -y \
+  --action execute \
+  --messageId "$DESTINATION_MESSAGE_ID" \
+  --sourceChain axelar \
+  --sourceAddress "$DESTINATION_SOURCE_ADDRESS" \
+  --destination "$DESTINATION_ITS" \
+  --payload "$DESTINATION_PAYLOAD"
+```
+
+## 7. Verify the Link
+
+Query the destination TokenManager address for `TOKEN_ID`.
+
+```bash
+npx ts-node evm/its.js token-manager-address "0x$TOKEN_ID" \
+  -e "$ENV" \
+  -n "$DESTINATION_CHAIN" \
+  -p "$PRIVATE_KEY" \
+  -y
+```
+
+The destination ITS should now have a TokenManager for `TOKEN_ID` whose registered token is the existing ERC-20 at `DESTINATION_TOKEN_ADDRESS`.
+
+## Notes
+
+- `RegisterLocalToken`, `RegisterTokenMetadata`, and `LinkToken` are privileged `XrplGateway` messages.
+- `trust-set-multisig` calls `XrplMultisigProver`, which constructs a signed XRPL `TrustSet`; `submit-proof` broadcasts the transaction to XRPL.
+- `LinkToken` requires metadata to be registered for both the XRPL source token address and the destination token address.
+- `DeployRemoteToken` deploys a new destination token. `LinkToken` links to an existing destination token.
+- `submitProof` on the destination EVM Gateway only approves the command. The destination app call is completed by the following `execute` call into the destination ITS contract.
+- This XRPL-origin flow does not use an EVM deployment salt to choose the token ID. The token ID is derived from the XRPL issuer/currency registration and then used as the ID for the remote TokenManager.

--- a/xrpl/link-token.js
+++ b/xrpl/link-token.js
@@ -1,0 +1,120 @@
+'use strict';
+
+const { Command, Option } = require('commander');
+const { addAmplifierOptions, addChainNameOption } = require('../cosmwasm/cli-utils');
+const { executeTransaction } = require('../cosmwasm/utils');
+const { printInfo, printError } = require('../common');
+const { getEvent, getEventAttr } = require('./utils');
+const { mainProcessor } = require('../cosmwasm/processor');
+
+const CONTRACT_CALLED_EVENT_TYPE = 'wasm-contract_called';
+const LINK_TOKEN_STARTED_EVENT_TYPE = 'wasm-link_token_started';
+
+function strip0x(value) {
+    return value?.startsWith('0x') ? value.slice(2) : value;
+}
+
+function normalizeHex(value, name) {
+    const hex = strip0x(value);
+
+    if (!hex || hex.length % 2 !== 0 || !/^[0-9a-fA-F]+$/.test(hex)) {
+        throw new Error(`${name} must be a non-empty hex string`);
+    }
+
+    return hex;
+}
+
+function normalizeOptionalBytes(value, name) {
+    if (!value || value === '0x') {
+        return null;
+    }
+
+    return normalizeHex(value, name);
+}
+
+const linkToken = async (client, config, options, _args, fee) => {
+    const { chainName, tokenId, destinationChain, destinationTokenAddress, tokenManagerType, params, operator } = options;
+
+    if (params && operator) {
+        throw new Error('Use either --params or --operator, not both');
+    }
+
+    const xrplGateway = config.axelar.contracts.XrplGateway[chainName];
+    if (!xrplGateway) {
+        printError(`No XRPLGateway contract found on chain ${chainName}`);
+        process.exit(1);
+    }
+
+    const linkParams = operator ? normalizeHex(operator, 'operator') : normalizeOptionalBytes(params, 'params');
+
+    const execMsg = {
+        link_token: {
+            token_id: normalizeHex(tokenId, 'tokenId'),
+            destination_chain: destinationChain,
+            link_token: {
+                token_manager_type: tokenManagerType,
+                destination_token_address: normalizeHex(destinationTokenAddress, 'destinationTokenAddress'),
+                params: linkParams,
+            },
+        },
+    };
+
+    const { transactionHash, events } = await executeTransaction(client, xrplGateway.address, execMsg, fee);
+
+    printInfo('Initiated token link', transactionHash);
+
+    try {
+        const contractCalledEvent = getEvent(events, CONTRACT_CALLED_EVENT_TYPE);
+        const messageId = getEventAttr(contractCalledEvent, 'message_id');
+        const payload = getEventAttr(contractCalledEvent, 'payload');
+
+        printInfo('Message ID', messageId);
+        printInfo('Payload', payload);
+
+        const linkTokenStartedEvent = getEvent(events, LINK_TOKEN_STARTED_EVENT_TYPE);
+        printInfo('Token ID', getEventAttr(linkTokenStartedEvent, 'token_id'));
+        printInfo('Destination chain', getEventAttr(linkTokenStartedEvent, 'destination_chain'));
+        printInfo('Destination token address', getEventAttr(linkTokenStartedEvent, 'destination_token_address'));
+    } catch (err) {
+        printError(err.message);
+        process.exit(1);
+    }
+};
+
+const programHandler = () => {
+    const program = new Command();
+
+    program
+        .name('link-token')
+        .description('Link an XRPL-origin token ID to an existing token on a remote destination chain.')
+        .addOption(new Option('--tokenId <tokenId>', 'XRPL-origin token ID').makeOptionMandatory(true))
+        .addOption(new Option('--destinationChain <destinationChain>', 'Destination chain to link to').makeOptionMandatory(true))
+        .addOption(
+            new Option('--destinationTokenAddress <destinationTokenAddress>', 'Token address on the destination chain').makeOptionMandatory(
+                true,
+            ),
+        )
+        .addOption(
+            new Option(
+                '--tokenManagerType <tokenManagerType>',
+                'Token manager type to deploy on the destination chain',
+            ).makeOptionMandatory(true),
+        )
+        .addOption(new Option('--params <params>', 'Raw token manager params bytes. Empty by default.'))
+        .addOption(new Option('--operator <operator>', 'EVM operator address encoded as link params. Mutually exclusive with --params.'));
+
+    addChainNameOption(program);
+    addAmplifierOptions(program, {
+        contractOptions: false,
+    });
+
+    program.action((options) => {
+        mainProcessor(linkToken, options);
+    });
+
+    program.parse();
+};
+
+if (require.main === module) {
+    programHandler();
+}


### PR DESCRIPTION
### why
- <!-- Explain the reason for this change -->

### how
<!-- An agent will fill this out -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are documentation and a thin CLI wrapper around existing privileged gateway messages; no core auth or contract logic is modified.
> 
> **Overview**
> Documents and operationalizes **XRPL-origin** ITS linking: an existing XRPL IOU (issuer + currency) drives the token ID and is linked to an already-deployed remote token, distinct from the existing **EVM-origin** `link-token.md` flow.
> 
> Adds **`xrpl/link-token.js`**, a CLI that executes `XrplGateway` `link_token` (hex-normalized token ID, destination token address, token manager type, optional `--params` or `--operator`), and prints `wasm-contract_called` / `wasm-link_token_started` event fields for Hub routing.
> 
> Adds **`docs/link-local-token.md`** (register local token, multisig trustline, metadata on both sides, link, destination proof/execute) and **`docs/interchain-transfer-local-token.md`** (bidirectional transfers, liquidity, manual XRPL/EVM proof steps, troubleshooting). **`xrpl/README.md`** now indexes these guides and labels the prior link doc as EVM-origin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89c67a402955258ce683fc52b1e68c662359b6de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->