### PR TITLE
feat: update stellar's set-flow-limit command

### DIFF
--- a/stellar/its.js
+++ b/stellar/its.js
@@ -267,7 +267,19 @@ async function flowLimit(wallet, _config, chain, contract, args, options) {
     const response = await broadcast(operation, wallet, chain, 'Get Flow Limit', options);
     const flowLimit = response.value();
 
-    printInfo('Flow Limit', flowLimit || 'No limit set');
+    let display;
+    if (flowLimit === undefined || flowLimit === null) {
+        display = 'No limit set';
+    } else if (flowLimit._attributes) {
+        // i128 returned as XDR Int128Parts { hi, lo }; recombine as BigInt
+        const hi = BigInt(flowLimit._attributes.hi._value);
+        const lo = BigInt(flowLimit._attributes.lo._value);
+        display = ((hi << 64n) | lo).toString();
+    } else {
+        display = String(flowLimit);
+    }
+
+    printInfo('Flow Limit', display);
 }
 
 async function setFlowLimit(wallet, _config, chain, contract, args, options) {
@@ -352,7 +364,7 @@ async function isFlowLimiter(wallet, _config, chain, contract, args, options) {
     const operation = contract.call('is_flow_limiter', hexToScVal(tokenId), addressToScVal(flowLimiter));
     const response = await broadcast(operation, wallet, chain, 'Is Flow Limiter', options);
 
-    printInfo('Is Flow Limiter', response.value());
+    printInfo('Is Flow Limiter', String(response.value()));
 }
 
 async function interchainTokenAddress(wallet, _config, chain, contract, args, options) {

--- a/stellar/its.js
+++ b/stellar/its.js
@@ -336,12 +336,7 @@ async function transferFlowLimiter(wallet, _config, chain, contract, args, optio
         isNonEmptyString: { tokenId, from, to },
     });
 
-    const operation = contract.call(
-        'transfer_flow_limiter',
-        hexToScVal(tokenId),
-        addressToScVal(from),
-        addressToScVal(to),
-    );
+    const operation = contract.call('transfer_flow_limiter', hexToScVal(tokenId), addressToScVal(from), addressToScVal(to));
 
     await broadcast(operation, wallet, chain, 'Transfer Flow Limiter', options);
     printInfo('Successfully transferred flow limiter', `${from} -> ${to}`);

--- a/stellar/its.js
+++ b/stellar/its.js
@@ -278,9 +278,10 @@ async function setFlowLimit(wallet, _config, chain, contract, args, options) {
         isValidNumber: { flowLimit },
     });
 
+    const caller = addressToScVal(wallet.publicKey());
     const flowLimitScVal = nativeToScVal(flowLimit, { type: 'i128' });
 
-    const operation = contract.call('set_flow_limit', hexToScVal(tokenId), flowLimitScVal);
+    const operation = contract.call('set_flow_limit', caller, hexToScVal(tokenId), flowLimitScVal);
 
     await broadcast(operation, wallet, chain, 'Set Flow Limit', options);
     printInfo('Successfully set flow limit', flowLimit);
@@ -293,12 +294,70 @@ async function removeFlowLimit(wallet, _config, chain, contract, args, options) 
         isNonEmptyString: { tokenId },
     });
 
+    const caller = addressToScVal(wallet.publicKey());
     const flowLimitScVal = nativeToScVal(null, { type: 'void' });
 
-    const operation = contract.call('set_flow_limit', hexToScVal(tokenId), flowLimitScVal);
+    const operation = contract.call('set_flow_limit', caller, hexToScVal(tokenId), flowLimitScVal);
 
     await broadcast(operation, wallet, chain, 'Remove Flow Limit', options);
     printInfo('Successfully removed flow limit');
+}
+
+async function addFlowLimiter(wallet, _config, chain, contract, args, options) {
+    const [tokenId, flowLimiter] = args;
+
+    validateParameters({
+        isNonEmptyString: { tokenId, flowLimiter },
+    });
+
+    const operation = contract.call('add_flow_limiter', hexToScVal(tokenId), addressToScVal(flowLimiter));
+
+    await broadcast(operation, wallet, chain, 'Add Flow Limiter', options);
+    printInfo('Successfully added flow limiter', flowLimiter);
+}
+
+async function removeFlowLimiter(wallet, _config, chain, contract, args, options) {
+    const [tokenId, flowLimiter] = args;
+
+    validateParameters({
+        isNonEmptyString: { tokenId, flowLimiter },
+    });
+
+    const operation = contract.call('remove_flow_limiter', hexToScVal(tokenId), addressToScVal(flowLimiter));
+
+    await broadcast(operation, wallet, chain, 'Remove Flow Limiter', options);
+    printInfo('Successfully removed flow limiter', flowLimiter);
+}
+
+async function transferFlowLimiter(wallet, _config, chain, contract, args, options) {
+    const [tokenId, from, to] = args;
+
+    validateParameters({
+        isNonEmptyString: { tokenId, from, to },
+    });
+
+    const operation = contract.call(
+        'transfer_flow_limiter',
+        hexToScVal(tokenId),
+        addressToScVal(from),
+        addressToScVal(to),
+    );
+
+    await broadcast(operation, wallet, chain, 'Transfer Flow Limiter', options);
+    printInfo('Successfully transferred flow limiter', `${from} -> ${to}`);
+}
+
+async function isFlowLimiter(wallet, _config, chain, contract, args, options) {
+    const [tokenId, flowLimiter] = args;
+
+    validateParameters({
+        isNonEmptyString: { tokenId, flowLimiter },
+    });
+
+    const operation = contract.call('is_flow_limiter', hexToScVal(tokenId), addressToScVal(flowLimiter));
+    const response = await broadcast(operation, wallet, chain, 'Is Flow Limiter', options);
+
+    printInfo('Is Flow Limiter', response.value());
 }
 
 async function interchainTokenAddress(wallet, _config, chain, contract, args, options) {
@@ -640,6 +699,34 @@ if (require.main === module) {
         .description('Remove the flow limit for a token')
         .action((tokenId, options) => {
             return mainProcessor(removeFlowLimit, [tokenId], options);
+        });
+
+    program
+        .command('add-flow-limiter <tokenId> <flowLimiter>')
+        .description('Approve an address as a flow limiter for a token')
+        .action((tokenId, flowLimiter, options) => {
+            return mainProcessor(addFlowLimiter, [tokenId, flowLimiter], options);
+        });
+
+    program
+        .command('remove-flow-limiter <tokenId> <flowLimiter>')
+        .description('Revoke an address as a flow limiter for a token')
+        .action((tokenId, flowLimiter, options) => {
+            return mainProcessor(removeFlowLimiter, [tokenId, flowLimiter], options);
+        });
+
+    program
+        .command('transfer-flow-limiter <tokenId> <from> <to>')
+        .description('Transfer the flow limiter role for a token from one address to another')
+        .action((tokenId, from, to, options) => {
+            return mainProcessor(transferFlowLimiter, [tokenId, from, to], options);
+        });
+
+    program
+        .command('is-flow-limiter <tokenId> <flowLimiter>')
+        .description('Check if an address is an approved flow limiter for a token')
+        .action((tokenId, flowLimiter, options) => {
+            return mainProcessor(isFlowLimiter, [tokenId, flowLimiter], options);
         });
 
     program


### PR DESCRIPTION
### why

Following https://github.com/axelarnetwork/axelar-amplifier-stellar/pull/381

Part of CPI-293

### how
<!-- An agent will fill this out -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes on-chain ITS admin/limiter calls and argument encoding; misconfiguration could block or mis-set token flow limits.
> 
> **Overview**
> Updates the Stellar ITS CLI to match the revised **Interchain Token Service** contract API for flow limits and flow-limiter roles.
> 
> **`set_flow_limit` / remove flow limit** now pass the wallet as the first `caller` argument (along with token id and limit or void). **`flow-limit`** readout decodes Soroban **i128** XDR (`hi`/`lo`) into a decimal string instead of printing raw objects.
> 
> New commands wire **`add_flow_limiter`**, **`remove_flow_limiter`**, **`transfer_flow_limiter`**, and **`is_flow_limiter`** for managing which addresses may configure limits per token.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15c11b068943c61e089b647d9a24ad53bd0d2277. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->