### PR TITLE
feat: axe mainnet hedera solana monad

### DIFF
--- a/axelar-chains-config/info/mainnet.json
+++ b/axelar-chains-config/info/mainnet.json
@@ -2965,10 +2965,16 @@
           "decimals": 18
         },
         "AXE": {
-          "address": "CB2NGT4E4G4OAJJV2MPQPP52WGRJBCSVQZLQ2DFBRY5IJ4Z5YJPLJNJH",
-          "tokenId": "0x5b7e73124ba00a2628e5a092aea0b52e000f0be26990fc683ee1c45ff0054038",
-          "decimals": 7,
-          "notes": "AXE ITS test token deployed by axe load-test; remote registered on hyperliquid. Skip re-deploy via chains.stellar.contracts.AXE.tokenId."
+          "tokenId": "0xbe1d7843a1110e56b4e14d8b6c78becf8fc328e44144266c148fffcf2a9f140e",
+          "tokenAddress": "CCE2Q5EFPFACGX3LCQ7MCFVEJZYXDCDQ2EFFBT5D2QI47N6TRGA2EC6N",
+          "name": "AXE",
+          "symbol": "AXE",
+          "decimals": 18,
+          "originChain": "xrpl-evm",
+          "salt": "0x460e1d30e3ac65916d1044e75c5f78f8db9a6ccd2719b6163db9fe53e805d3ed",
+          "saltKey": "axe_AXE_mainnet_v2",
+          "deployedViaTx": "0x24329a92c58cc0cf6d8eff90df0a60aa83f3401905c41225e394058e312631f7",
+          "notes": "Canonical single AXE v2 (home xrpl-evm), 18 decimals on Stellar. Reused by load tests via chains.stellar.contracts.AXE.tokenId."
         }
       },
       "approxFinalityWaitTime": 1,
@@ -3072,6 +3078,18 @@
           "tokenManagerAddress": "0xdb0a778c57Bd31E401D52ba6cf936D06E1324aE8",
           "tokenManagerType": "mint_burn",
           "decimals": 18
+        },
+        "AXE": {
+          "tokenId": "0xbe1d7843a1110e56b4e14d8b6c78becf8fc328e44144266c148fffcf2a9f140e",
+          "tokenAddress": "0x54BEdCF8fc56faf4FbffF88DBb3efb9BDa0c655f",
+          "name": "AXE",
+          "symbol": "AXE",
+          "decimals": 18,
+          "originChain": "xrpl-evm",
+          "salt": "0x460e1d30e3ac65916d1044e75c5f78f8db9a6ccd2719b6163db9fe53e805d3ed",
+          "saltKey": "axe_AXE_mainnet_v2",
+          "deployTransactionHash": "0x5990e957d8e7dd362b6406c66ed9dfeff3a06ca410b0241794479fb65fe3bddd",
+          "notes": "Canonical single AXE v2, home chain. Deployed via interchainTokenFactory deploy-interchain-token (salt axe_AXE_mainnet_v2), 1e9 initial supply to deployer. Reused by load tests via chains.xrpl-evm.contracts.AXE.tokenId."
         }
       }
     },
@@ -3526,10 +3544,15 @@
           "decimals": 18
         },
         "AXE": {
-          "address": "0xeF4f74566E58cB7ddf483e52d130Bd87b8EA1a38",
-          "tokenId": "0x2cbebbff605dfbef70dc73805124fdcbeb0c809f24f183fad78f5006fda4598f",
+          "tokenId": "0xbe1d7843a1110e56b4e14d8b6c78becf8fc328e44144266c148fffcf2a9f140e",
+          "tokenAddress": "0x54BEdCF8fc56faf4FbffF88DBb3efb9BDa0c655f",
+          "name": "AXE",
+          "symbol": "AXE",
           "decimals": 18,
-          "notes": "AXE ITS test token deployed by axe load-test; remote registered on stellar. Skip re-deploy via chains.hyperliquid.contracts.AXE.tokenId."
+          "originChain": "xrpl-evm",
+          "salt": "0x460e1d30e3ac65916d1044e75c5f78f8db9a6ccd2719b6163db9fe53e805d3ed",
+          "saltKey": "axe_AXE_mainnet_v2",
+          "notes": "Canonical single AXE v2 (home xrpl-evm), remote-registered via deployRemoteInterchainToken. Reused by load tests via chains.hyperliquid.contracts.AXE.tokenId."
         }
       }
     },
@@ -3704,17 +3727,17 @@
           "version": "1.1.0"
         },
         "AXE": {
-          "tokenId": "0xd902254936e709777eda727385e43d9082916e0932034ed876b99d9f80f9a826",
-          "tokenAddress": "9tvofHTgnDTZ98WZq5Qw6CtRKPsBJmTDcuABuRyKzxNv",
+          "tokenId": "0xbe1d7843a1110e56b4e14d8b6c78becf8fc328e44144266c148fffcf2a9f140e",
+          "tokenAddress": "BmdKnsEhFC2oQ8KqL2XumXm2Xqjngbt8bgzkvBzXMSQ7",
           "tokenProgram": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb",
-          "mintAuthority": "9ddVJTcCGQ9bZkdwkvUi9hmixeAN6XJHJUG8iosL6xgJ",
           "name": "AXE",
           "symbol": "AXE",
-          "decimals": 18,
-          "originChain": "hedera",
-          "originSalt": "0x6178655f4158455f6d61696e6e65745f76310000000000000000000000000000",
-          "deployedViaTx": "0x9b3027fd3786fb6813ad4bdaae942f3f5fb809989a15baeda518c28cb011c356",
-          "executeTx": "4mBAzHxvr29su2yFXCdFMMoUZuzG52RzCF5awPKLii5YcEgKWVG6MEWTg4vPL4BLcX7SiyTFLP6u4Lg3unoNGreX"
+          "decimals": 6,
+          "originChain": "xrpl-evm",
+          "salt": "0x460e1d30e3ac65916d1044e75c5f78f8db9a6ccd2719b6163db9fe53e805d3ed",
+          "saltKey": "axe_AXE_mainnet_v2",
+          "deployedViaTx": "0x33f71a8cb101c9662326e24f4739a5eac36e24bc766a15732989f57666dac642",
+          "notes": "Canonical single AXE v2 (home xrpl-evm). Solana mint is 6 decimals (ITS-assigned). Reused by load tests via chains.solana.contracts.AXE.tokenId."
         }
       }
     }

--- a/axelar-chains-config/info/mainnet.json
+++ b/axelar-chains-config/info/mainnet.json
@@ -3307,6 +3307,18 @@
           "tokenManagerAddress": "0x9F0b6857009E73746DcBb4A0DBf0e0a46219e3c4",
           "tokenManagerType": "mint_burn",
           "decimals": 8
+        },
+        "AXE": {
+          "salt": "0x6178655f4158455f6d61696e6e65745f76310000000000000000000000000000",
+          "deployer": "0xba76c6980428A0b10CFC5d8ccb61949677A61233",
+          "tokenId": "0xd902254936e709777eda727385e43d9082916e0932034ed876b99d9f80f9a826",
+          "tokenAddress": "0x0000000000000000000000000000000000a081dD",
+          "minter": "0xba76c6980428A0b10CFC5d8ccb61949677A61233",
+          "name": "AXE",
+          "symbol": "AXE",
+          "decimals": 18,
+          "deployTransactionHash": "0xc04eb6c852d0cd295345074f18c0a759baf8203a4b2c1185b6a921cfb52eddbe",
+          "remoteDeployTransactionHash": "0x9b3027fd3786fb6813ad4bdaae942f3f5fb809989a15baeda518c28cb011c356"
         }
       }
     },
@@ -3627,6 +3639,17 @@
           "tokenManagerAddress": "0xfdA07e1b359e18484211aF722Dc81c3edb0Ec54C",
           "tokenManagerType": "mint_burn",
           "decimals": 18
+        },
+        "AXE": {
+          "tokenId": "0xd902254936e709777eda727385e43d9082916e0932034ed876b99d9f80f9a826",
+          "tokenAddress": "0xe9fd422eb644281854241a860361de833fc28b7a",
+          "name": "AXE",
+          "symbol": "AXE",
+          "decimals": 18,
+          "originChain": "hedera",
+          "originSalt": "0x6178655f4158455f6d61696e6e65745f76310000000000000000000000000000",
+          "deployedViaTx": "0x416f1fae1fff84dd4d70e5454d56b9885c401ee91f3bdfea43af2be32935222c",
+          "executeTx": "0xa5c77f7067e68e7b4abd28a55f683c64afac3cc36c6590b84c7285fa7f8cba32"
         }
       }
     },
@@ -3679,6 +3702,19 @@
           "operator": "gopXXoSxFC2DXi5fhQ9ojxwHj37t6AJwj9NfY2P4GBa",
           "upgradeAuthority": "upasKKwjeYapRCgP98S4zmUJmPRi9qcmRyr6ji8xHQd",
           "version": "1.1.0"
+        },
+        "AXE": {
+          "tokenId": "0xd902254936e709777eda727385e43d9082916e0932034ed876b99d9f80f9a826",
+          "tokenAddress": "9tvofHTgnDTZ98WZq5Qw6CtRKPsBJmTDcuABuRyKzxNv",
+          "tokenProgram": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb",
+          "mintAuthority": "9ddVJTcCGQ9bZkdwkvUi9hmixeAN6XJHJUG8iosL6xgJ",
+          "name": "AXE",
+          "symbol": "AXE",
+          "decimals": 18,
+          "originChain": "hedera",
+          "originSalt": "0x6178655f4158455f6d61696e6e65745f76310000000000000000000000000000",
+          "deployedViaTx": "0x9b3027fd3786fb6813ad4bdaae942f3f5fb809989a15baeda518c28cb011c356",
+          "executeTx": "4mBAzHxvr29su2yFXCdFMMoUZuzG52RzCF5awPKLii5YcEgKWVG6MEWTg4vPL4BLcX7SiyTFLP6u4Lg3unoNGreX"
         }
       }
     }

--- a/axelar-chains-config/info/mainnet.json
+++ b/axelar-chains-config/info/mainnet.json
@@ -2966,7 +2966,6 @@
         },
         "AXE": {
           "tokenId": "0xbe1d7843a1110e56b4e14d8b6c78becf8fc328e44144266c148fffcf2a9f140e",
-          "tokenAddress": "CCE2Q5EFPFACGX3LCQ7MCFVEJZYXDCDQ2EFFBT5D2QI47N6TRGA2EC6N",
           "name": "AXE",
           "symbol": "AXE",
           "decimals": 18,
@@ -2974,7 +2973,8 @@
           "salt": "0x460e1d30e3ac65916d1044e75c5f78f8db9a6ccd2719b6163db9fe53e805d3ed",
           "saltKey": "axe_AXE_mainnet_v2",
           "deployedViaTx": "0x24329a92c58cc0cf6d8eff90df0a60aa83f3401905c41225e394058e312631f7",
-          "notes": "Canonical single AXE v2 (home xrpl-evm), 18 decimals on Stellar. Reused by load tests via chains.stellar.contracts.AXE.tokenId."
+          "notes": "Canonical single AXE v2 (home xrpl-evm), 18 decimals on Stellar. Reused by load tests via chains.stellar.contracts.AXE.tokenId.",
+          "address": "CCE2Q5EFPFACGX3LCQ7MCFVEJZYXDCDQ2EFFBT5D2QI47N6TRGA2EC6N"
         }
       },
       "approxFinalityWaitTime": 1,
@@ -3081,7 +3081,6 @@
         },
         "AXE": {
           "tokenId": "0xbe1d7843a1110e56b4e14d8b6c78becf8fc328e44144266c148fffcf2a9f140e",
-          "tokenAddress": "0x54BEdCF8fc56faf4FbffF88DBb3efb9BDa0c655f",
           "name": "AXE",
           "symbol": "AXE",
           "decimals": 18,
@@ -3089,7 +3088,8 @@
           "salt": "0x460e1d30e3ac65916d1044e75c5f78f8db9a6ccd2719b6163db9fe53e805d3ed",
           "saltKey": "axe_AXE_mainnet_v2",
           "deployTransactionHash": "0x5990e957d8e7dd362b6406c66ed9dfeff3a06ca410b0241794479fb65fe3bddd",
-          "notes": "Canonical single AXE v2, home chain. Deployed via interchainTokenFactory deploy-interchain-token (salt axe_AXE_mainnet_v2), 1e9 initial supply to deployer. Reused by load tests via chains.xrpl-evm.contracts.AXE.tokenId."
+          "notes": "Canonical single AXE v2, home chain. Deployed via interchainTokenFactory deploy-interchain-token (salt axe_AXE_mainnet_v2), 1e9 initial supply to deployer. Reused by load tests via chains.xrpl-evm.contracts.AXE.tokenId.",
+          "address": "0x54BEdCF8fc56faf4FbffF88DBb3efb9BDa0c655f"
         }
       }
     },
@@ -3330,13 +3330,13 @@
           "salt": "0x6178655f4158455f6d61696e6e65745f76310000000000000000000000000000",
           "deployer": "0xba76c6980428A0b10CFC5d8ccb61949677A61233",
           "tokenId": "0xd902254936e709777eda727385e43d9082916e0932034ed876b99d9f80f9a826",
-          "tokenAddress": "0x0000000000000000000000000000000000a081dD",
           "minter": "0xba76c6980428A0b10CFC5d8ccb61949677A61233",
           "name": "AXE",
           "symbol": "AXE",
           "decimals": 18,
           "deployTransactionHash": "0xc04eb6c852d0cd295345074f18c0a759baf8203a4b2c1185b6a921cfb52eddbe",
-          "remoteDeployTransactionHash": "0x9b3027fd3786fb6813ad4bdaae942f3f5fb809989a15baeda518c28cb011c356"
+          "remoteDeployTransactionHash": "0x9b3027fd3786fb6813ad4bdaae942f3f5fb809989a15baeda518c28cb011c356",
+          "address": "0x0000000000000000000000000000000000a081dD"
         }
       }
     },
@@ -3545,14 +3545,14 @@
         },
         "AXE": {
           "tokenId": "0xbe1d7843a1110e56b4e14d8b6c78becf8fc328e44144266c148fffcf2a9f140e",
-          "tokenAddress": "0x54BEdCF8fc56faf4FbffF88DBb3efb9BDa0c655f",
           "name": "AXE",
           "symbol": "AXE",
           "decimals": 18,
           "originChain": "xrpl-evm",
           "salt": "0x460e1d30e3ac65916d1044e75c5f78f8db9a6ccd2719b6163db9fe53e805d3ed",
           "saltKey": "axe_AXE_mainnet_v2",
-          "notes": "Canonical single AXE v2 (home xrpl-evm), remote-registered via deployRemoteInterchainToken. Reused by load tests via chains.hyperliquid.contracts.AXE.tokenId."
+          "notes": "Canonical single AXE v2 (home xrpl-evm), remote-registered via deployRemoteInterchainToken. Reused by load tests via chains.hyperliquid.contracts.AXE.tokenId.",
+          "address": "0x54BEdCF8fc56faf4FbffF88DBb3efb9BDa0c655f"
         }
       }
     },
@@ -3665,14 +3665,14 @@
         },
         "AXE": {
           "tokenId": "0xd902254936e709777eda727385e43d9082916e0932034ed876b99d9f80f9a826",
-          "tokenAddress": "0xe9fd422eb644281854241a860361de833fc28b7a",
           "name": "AXE",
           "symbol": "AXE",
           "decimals": 18,
           "originChain": "hedera",
           "originSalt": "0x6178655f4158455f6d61696e6e65745f76310000000000000000000000000000",
           "deployedViaTx": "0x416f1fae1fff84dd4d70e5454d56b9885c401ee91f3bdfea43af2be32935222c",
-          "executeTx": "0xa5c77f7067e68e7b4abd28a55f683c64afac3cc36c6590b84c7285fa7f8cba32"
+          "executeTx": "0xa5c77f7067e68e7b4abd28a55f683c64afac3cc36c6590b84c7285fa7f8cba32",
+          "address": "0xe9fd422eb644281854241a860361de833fc28b7a"
         }
       }
     },
@@ -3728,7 +3728,6 @@
         },
         "AXE": {
           "tokenId": "0xbe1d7843a1110e56b4e14d8b6c78becf8fc328e44144266c148fffcf2a9f140e",
-          "tokenAddress": "BmdKnsEhFC2oQ8KqL2XumXm2Xqjngbt8bgzkvBzXMSQ7",
           "tokenProgram": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb",
           "name": "AXE",
           "symbol": "AXE",
@@ -3737,7 +3736,8 @@
           "salt": "0x460e1d30e3ac65916d1044e75c5f78f8db9a6ccd2719b6163db9fe53e805d3ed",
           "saltKey": "axe_AXE_mainnet_v2",
           "deployedViaTx": "0x33f71a8cb101c9662326e24f4739a5eac36e24bc766a15732989f57666dac642",
-          "notes": "Canonical single AXE v2 (home xrpl-evm). Solana mint is 6 decimals (ITS-assigned). Reused by load tests via chains.solana.contracts.AXE.tokenId."
+          "notes": "Canonical single AXE v2 (home xrpl-evm). Solana mint is 6 decimals (ITS-assigned). Reused by load tests via chains.solana.contracts.AXE.tokenId.",
+          "address": "BmdKnsEhFC2oQ8KqL2XumXm2Xqjngbt8bgzkvBzXMSQ7"
         }
       }
     }

--- a/axelar-chains-config/info/testnet.json
+++ b/axelar-chains-config/info/testnet.json
@@ -2219,12 +2219,12 @@
           "salt": "0x6178655f4158455f7465737470a16574f7631000000000000000000000000000",
           "deployer": "0xba76c6980428A0b10CFC5d8ccb61949677A61233",
           "tokenId": "0xd6311e67bdb5fb90d722d71fde9e7c33aa703a0b6c66518cebff80f63bc64a4a",
-          "tokenAddress": "0x00000000000000000000000000000000008B6eBd",
           "minter": "0xba76c6980428A0b10CFC5d8ccb61949677A61233",
           "name": "AXE",
           "symbol": "AXE",
           "decimals": 18,
-          "deployTransactionHash": "0x493e6e3340eee70f50455224e68990148ca445bde6d1380339491d85620eba84"
+          "deployTransactionHash": "0x493e6e3340eee70f50455224e68990148ca445bde6d1380339491d85620eba84",
+          "address": "0x00000000000000000000000000000000008B6eBd"
         }
       }
     },
@@ -3020,13 +3020,13 @@
         },
         "AXE": {
           "tokenId": "0xd6311e67bdb5fb90d722d71fde9e7c33aa703a0b6c66518cebff80f63bc64a4a",
-          "tokenAddress": "0xf73d4d8a56a5478ed9b357115dc674d6ec4356bb",
           "name": "AXE",
           "symbol": "AXE",
           "decimals": 18,
           "originChain": "hedera",
           "originSalt": "0x6178655f4158455f7465737470a16574f7631000000000000000000000000000",
-          "deployedViaTx": "0x929717c3127cae130355167092a2ce39529383ed96e5b247af70570f8cc1061e"
+          "deployedViaTx": "0x929717c3127cae130355167092a2ce39529383ed96e5b247af70570f8cc1061e",
+          "address": "0xf73d4d8a56a5478ed9b357115dc674d6ec4356bb"
         }
       }
     },
@@ -3574,16 +3574,16 @@
         },
         "AXE": {
           "tokenId": "0xd6311e67bdb5fb90d722d71fde9e7c33aa703a0b6c66518cebff80f63bc64a4a",
-          "tokenAddress": "AswjwVEcBXX6FxktUvnYwktM5eaXUg9WLya4d9ttQKhW",
           "tokenProgram": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb",
           "mintAuthority": "CiPBNL4HkNLn46w7NkkFnRsqgHkY6KGsbtrTR7A24wWQ",
           "name": "AXE",
           "symbol": "AXE",
-          "decimals": 18,
+          "decimals": 6,
           "originChain": "hedera",
           "originSalt": "0x6178655f4158455f7465737470a16574f7631000000000000000000000000000",
           "deployedViaTx": "0x4d254e34b46b53896094b913fca8f47ea87c92d06205687ea4666e0387e59e2a",
-          "executeTx": "3nskpZgNZFHYCPknwf4juQvzDSvfhZ8dpqwyMXL3S84ZvEAXzAmG23pimveJWkTBbuCQHBEb8sLf6tN3E5qprXHP"
+          "executeTx": "3nskpZgNZFHYCPknwf4juQvzDSvfhZ8dpqwyMXL3S84ZvEAXzAmG23pimveJWkTBbuCQHBEb8sLf6tN3E5qprXHP",
+          "address": "AswjwVEcBXX6FxktUvnYwktM5eaXUg9WLya4d9ttQKhW"
         }
       }
     }

--- a/axelar-chains-config/info/testnet.json
+++ b/axelar-chains-config/info/testnet.json
@@ -2214,6 +2214,17 @@
           "address": "0x83a93500d23Fbc3e82B410aD07A6a9F7A0670D66",
           "version": "2.1.0",
           "implementation": "0x18e160AA6740bfa78091a6Aee08270d48CAf9944"
+        },
+        "AXE": {
+          "salt": "0x6178655f4158455f7465737470a16574f7631000000000000000000000000000",
+          "deployer": "0xba76c6980428A0b10CFC5d8ccb61949677A61233",
+          "tokenId": "0xd6311e67bdb5fb90d722d71fde9e7c33aa703a0b6c66518cebff80f63bc64a4a",
+          "tokenAddress": "0x00000000000000000000000000000000008B6eBd",
+          "minter": "0xba76c6980428A0b10CFC5d8ccb61949677A61233",
+          "name": "AXE",
+          "symbol": "AXE",
+          "decimals": 18,
+          "deployTransactionHash": "0x493e6e3340eee70f50455224e68990148ca445bde6d1380339491d85620eba84"
         }
       }
     },
@@ -3006,6 +3017,16 @@
           "address": "0x578d62784cd79de8cdEC994DF8f8844fC4cf90D8",
           "version": "2.2.0",
           "implementation": "0xFCd9E5C814A7A8F1681bEc38817A91A4DC452c2e"
+        },
+        "AXE": {
+          "tokenId": "0xd6311e67bdb5fb90d722d71fde9e7c33aa703a0b6c66518cebff80f63bc64a4a",
+          "tokenAddress": "0xf73d4d8a56a5478ed9b357115dc674d6ec4356bb",
+          "name": "AXE",
+          "symbol": "AXE",
+          "decimals": 18,
+          "originChain": "hedera",
+          "originSalt": "0x6178655f4158455f7465737470a16574f7631000000000000000000000000000",
+          "deployedViaTx": "0x929717c3127cae130355167092a2ce39529383ed96e5b247af70570f8cc1061e"
         }
       }
     },
@@ -3550,6 +3571,19 @@
           "operator": "gopdSWQFLKvxPz1SiP2W8CumFBtd2FF1ddDgNVkLmdG",
           "upgradeAuthority": "upaHiTygNXvZZzAb9ZZxn63LhJoma35BKgt6rxH5XdS",
           "version": "1.1.0"
+        },
+        "AXE": {
+          "tokenId": "0xd6311e67bdb5fb90d722d71fde9e7c33aa703a0b6c66518cebff80f63bc64a4a",
+          "tokenAddress": "AswjwVEcBXX6FxktUvnYwktM5eaXUg9WLya4d9ttQKhW",
+          "tokenProgram": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb",
+          "mintAuthority": "CiPBNL4HkNLn46w7NkkFnRsqgHkY6KGsbtrTR7A24wWQ",
+          "name": "AXE",
+          "symbol": "AXE",
+          "decimals": 18,
+          "originChain": "hedera",
+          "originSalt": "0x6178655f4158455f7465737470a16574f7631000000000000000000000000000",
+          "deployedViaTx": "0x4d254e34b46b53896094b913fca8f47ea87c92d06205687ea4666e0387e59e2a",
+          "executeTx": "3nskpZgNZFHYCPknwf4juQvzDSvfhZ8dpqwyMXL3S84ZvEAXzAmG23pimveJWkTBbuCQHBEb8sLf6tN3E5qprXHP"
         }
       }
     }


### PR DESCRIPTION
### why
- <!-- Explain the reason for this change -->

### how
<!-- An agent will fill this out -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Production chain config defines live interchain token IDs and addresses; mismatches would break ITS bridging, tooling, and load tests across multiple chains.
> 
> **Overview**
> Registers **canonical AXE v2** interchain token metadata across **mainnet** and **testnet** in `axelar-chains-config/info/mainnet.json` and `testnet.json`, replacing prior load-test **AXE** stubs on **Stellar** and **Hyperliquid** with shared `tokenId` `0xbe1d7843…`, home chain **xrpl-evm**, salt `axe_AXE_mainnet_v2`, and updated on-chain addresses.
> 
> **Mainnet** adds or refreshes `contracts.AXE` on **xrpl-evm** (home deploy), **Stellar**, **Hyperliquid**, and **Solana** (remote, including Solana 6-decimal mint), and introduces a separate **Hedera**-origin AXE (`tokenId` `0xd9022549…`, salt `axe_AXE_mainnet_v1`) on **hedera** and **monad**. **Testnet** adds **AXE** on **hedera**, **monad**, and **solana** with a common test `tokenId` and Hedera-origin salt.
> 
> No application code changes—only chain config JSON used for ITS deployment references and load tests (`chains.*.contracts.AXE.tokenId`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1eeaecc9da5f46c4a7981428c88a585ef76d215c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->