### PR TITLE
chore: bump service registry to v1.2.2

### DIFF
--- a/axelar-chains-config/info/devnet-amplifier.json
+++ b/axelar-chains-config/info/devnet-amplifier.json
@@ -1524,11 +1524,11 @@
     "contracts": {
       "ServiceRegistry": {
         "governanceAccount": "axelar1zlr7e5qf3sz7yf890rkh9tcnu87234k6k7ytd9",
-        "codeId": 1595,
-        "lastUploadedCodeId": 1595,
+        "codeId": 1651,
+        "lastUploadedCodeId": 1651,
         "address": "axelar1c9fkszt5lq34vvvlat3fxj6yv7ejtqapz04e97vtc9m5z9cwnamq8zjlhz",
-        "storeCodeProposalId": "1460",
-        "storeCodeProposalCodeHash": "934bca95d4c9729f93a7dcc8241a4ffb33905eab8da3020298e44beed3b37b23",
+        "storeCodeProposalId": "1603",
+        "storeCodeProposalCodeHash": "9f861ce450a4b0ba07d7ea9d198351355ea0ca57d2af0bf4f7e51504fdfe779e",
         "version": "1.2.0"
       },
       "Router": {

--- a/axelar-chains-config/info/mainnet.json
+++ b/axelar-chains-config/info/mainnet.json
@@ -3811,8 +3811,8 @@
         "governanceAccount": "axelar10d07y265gmmuvt4z0w9aw880jnsr700j7v9daj",
         "storeCodeProposalId": "477",
         "storeCodeProposalCodeHash": "9f861ce450a4b0ba07d7ea9d198351355ea0ca57d2af0bf4f7e51504fdfe779e",
-        "codeId": 51,
-        "lastUploadedCodeId": 51,
+        "codeId": 65,
+        "lastUploadedCodeId": 65,
         "address": "axelar1rpj2jjrv3vpugx9ake9kgk3s2kgwt0y60wtkmcgfml5m3et0mrls6nct9m",
         "version": "1.2.1"
       },

--- a/axelar-chains-config/info/mainnet.json
+++ b/axelar-chains-config/info/mainnet.json
@@ -3809,8 +3809,8 @@
     "contracts": {
       "ServiceRegistry": {
         "governanceAccount": "axelar10d07y265gmmuvt4z0w9aw880jnsr700j7v9daj",
-        "storeCodeProposalId": "422",
-        "storeCodeProposalCodeHash": "934bca95d4c9729f93a7dcc8241a4ffb33905eab8da3020298e44beed3b37b23",
+        "storeCodeProposalId": "477",
+        "storeCodeProposalCodeHash": "9f861ce450a4b0ba07d7ea9d198351355ea0ca57d2af0bf4f7e51504fdfe779e",
         "codeId": 51,
         "lastUploadedCodeId": 51,
         "address": "axelar1rpj2jjrv3vpugx9ake9kgk3s2kgwt0y60wtkmcgfml5m3et0mrls6nct9m",

--- a/axelar-chains-config/info/stagenet.json
+++ b/axelar-chains-config/info/stagenet.json
@@ -2658,10 +2658,10 @@
     "contracts": {
       "ServiceRegistry": {
         "governanceAccount": "axelar10d07y265gmmuvt4z0w9aw880jnsr700j7v9daj",
-        "storeCodeProposalId": "362",
-        "storeCodeProposalCodeHash": "934bca95d4c9729f93a7dcc8241a4ffb33905eab8da3020298e44beed3b37b23",
-        "codeId": 80,
-        "lastUploadedCodeId": 80,
+        "storeCodeProposalId": "500",
+        "storeCodeProposalCodeHash": "9f861ce450a4b0ba07d7ea9d198351355ea0ca57d2af0bf4f7e51504fdfe779e",
+        "codeId": 99,
+        "lastUploadedCodeId": 99,
         "address": "axelar15454y4v8x2ennqq6k0t4cu4r0cpqsy3d6m2jw7d0p4tagaafs29qnlhljd",
         "executeProposalId": "14",
         "version": "1.2.1"

--- a/axelar-chains-config/info/testnet.json
+++ b/axelar-chains-config/info/testnet.json
@@ -3898,10 +3898,10 @@
     "contracts": {
       "ServiceRegistry": {
         "governanceAccount": "axelar10d07y265gmmuvt4z0w9aw880jnsr700j7v9daj",
-        "storeCodeProposalId": "437",
-        "storeCodeProposalCodeHash": "934bca95d4c9729f93a7dcc8241a4ffb33905eab8da3020298e44beed3b37b23",
-        "codeId": 72,
-        "lastUploadedCodeId": 72,
+        "storeCodeProposalId": "613",
+        "storeCodeProposalCodeHash": "9f861ce450a4b0ba07d7ea9d198351355ea0ca57d2af0bf4f7e51504fdfe779e",
+        "codeId": 88,
+        "lastUploadedCodeId": 88,
         "address": "axelar1rpj2jjrv3vpugx9ake9kgk3s2kgwt0y60wtkmcgfml5m3et0mrls6nct9m",
         "executeProposalId": "112",
         "flow": {

--- a/releases/cosmwasm/2026-06-ServiceRegistry-v1.2.2.md
+++ b/releases/cosmwasm/2026-06-ServiceRegistry-v1.2.2.md
@@ -10,7 +10,7 @@
 | **Devnet Amplifier** | Completed             | 2026-06-11 |
 | **Stagenet**         | Completed             | 2026-06-11 |
 | **Testnet**          | Completed             | 2026-06-11 |
-| **Mainnet**          | --                    | --         |
+| **Mainnet**          | Completed             | 2026-06-15 |
 
 [Release](https://github.com/axelarnetwork/axelar-amplifier/releases/tag/service-registry-v1.2.2)
 

--- a/releases/cosmwasm/2026-06-ServiceRegistry-v1.2.2.md
+++ b/releases/cosmwasm/2026-06-ServiceRegistry-v1.2.2.md
@@ -1,0 +1,56 @@
+# Cosmwasm Service Registry v1.2.2
+
+|                | **Owner**                            |
+| -------------- | ------------------------------------ |
+| **Created By** | @rista404 <ristic@commonprefix.com>  |
+| **Deployment** | @rista404 <ristic@commonprefix.com>  |
+
+| **Network**          | **Deployment Status** | **Date**   |
+| -------------------- | --------------------- | ---------- |
+| **Devnet Amplifier** | Completed             | 2026-06-11 |
+| **Stagenet**         | Completed             | 2026-06-11 |
+| **Testnet**          | Completed             | 2026-06-11 |
+| **Mainnet**          | --                    | --         |
+
+[Release](https://github.com/axelarnetwork/axelar-amplifier/releases/tag/service-registry-v1.2.2)
+
+## Background
+
+Changes in this release:
+
+1. Reject `bond_verifier` calls with multi-denom funds ([#1165](https://github.com/axelarnetwork/axelar-amplifier/pull/1165))
+2. Require verifier to be authorized before registering for chain support ([#1166](https://github.com/axelarnetwork/axelar-amplifier/pull/1166))
+
+## Deployment
+
+This rollout upgrades the amplifier service registry contract from `v1.2.x` to `v1.2.2`. The migration message is empty; the migrate entry point backfills the authorized verifier count for any services missing it (idempotent).
+
+1. Upload new Service Registry contract
+
+```bash
+ts-node cosmwasm/contract.ts store-code -c ServiceRegistry -t "Upload Service Registry contract v1.2.2" -d "Upload Service Registry contract v1.2.2" --version 1.2.2 --governance
+```
+
+2. Upgrade Service Registry contract
+
+```bash
+ts-node cosmwasm/contract.ts migrate \
+  -c ServiceRegistry \
+  --msg '{}' \
+  --fetchCodeId \
+  --governance
+```
+
+## Checklist
+
+Verify service registry contract version
+
+```bash
+axelard query wasm contract-state raw $SERVICE_REGISTRY_ADDRESS 636F6E74726163745F696E666F -o json | jq -r '.data' | base64 -d
+```
+
+Expected output
+
+```bash
+{"contract":"service-registry","version":"1.2.2"}
+```


### PR DESCRIPTION
### why

https://github.com/axelarnetwork/axelar-amplifier/commit/4e736df19d61626e4e0270d9b006440e395fec36

Closes CPI-316

### how
<!-- An agent will fill this out -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches mainnet amplifier verifier bonding/authorization rules via a live contract migration; config-only PR but reflects production infrastructure change.
> 
> **Overview**
> Records **on-chain Service Registry** upgrades to **v1.2.2** by refreshing `codeId`, `lastUploadedCodeId`, `storeCodeProposalId`, and `storeCodeProposalCodeHash` under `axelar.contracts.ServiceRegistry` in **devnet-amplifier**, **stagenet**, **testnet**, and **mainnet** chain config. Contract **addresses** are unchanged; all environments now point at the same new wasm hash (`9f861ce4…`).
> 
> Adds **`releases/cosmwasm/2026-06-ServiceRegistry-v1.2.2.md`** documenting completed rollouts, the empty migrate payload, and post-deploy version checks. The release tightens **bond_verifier** (single-denom funds only) and **chain support registration** (verifier must be authorized first), with migrate backfilling authorized verifier counts where missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e787640b4c17f5e94791cd4b67a8ce3a4f30dbca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->