### PR TITLE
fix(testnet): repoint AXE entries to live seeded families

### DIFF
--- a/axelar-chains-config/info/testnet.json
+++ b/axelar-chains-config/info/testnet.json
@@ -3202,10 +3202,13 @@
           "version": "2.2.0"
         },
         "AXE": {
-          "address": "0x7AC528458e73A11F0149c9234EC5f49cb1718a6e",
-          "tokenId": "0xa9d0d0d3063287083ec0f14c015cd786b3ae96c681105913d27c2954a1c54546",
-          "decimals": 18,
-          "notes": "AXE ITS test token deployed by axe load-test; remote registered on stellar-2026-q1-2. Skip re-deploy via chains.hyperliquid.contracts.AXE.tokenId."
+          "tokenId": "0x63e3c40efbdcd1f1c3643df19b0682e5d5772f4b673cc65c9fcfda814ebd9108",
+          "name": "AXE",
+          "symbol": "AXE",
+          "decimals": 9,
+          "originChain": "solana",
+          "address": "0xb26a4f524824e3cb428e49cfbb2c1ed5d5279c14",
+          "notes": "Testnet AXE family (home solana) remote-registered on hyperliquid. Supply seeded by solana->hyperliquid interchainTransfer. Hyperliquid<->Solana cron pair."
         },
         "AxelarServiceGovernance": {
           "minimumTimeDelay": 300,
@@ -3685,17 +3688,15 @@
           "version": "1.1.0"
         },
         "AXE": {
-          "tokenId": "0xd6311e67bdb5fb90d722d71fde9e7c33aa703a0b6c66518cebff80f63bc64a4a",
+          "tokenId": "0x63e3c40efbdcd1f1c3643df19b0682e5d5772f4b673cc65c9fcfda814ebd9108",
           "tokenProgram": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb",
-          "mintAuthority": "CiPBNL4HkNLn46w7NkkFnRsqgHkY6KGsbtrTR7A24wWQ",
+          "mintAuthority": "81v2PCCR4tFrCC7x6mzJjMmLmGhvS5kjwCZAUQRSeMfJ",
           "name": "AXE",
           "symbol": "AXE",
-          "decimals": 6,
-          "originChain": "hedera",
-          "originSalt": "0x6178655f4158455f7465737470a16574f7631000000000000000000000000000",
-          "deployedViaTx": "0x4d254e34b46b53896094b913fca8f47ea87c92d06205687ea4666e0387e59e2a",
-          "executeTx": "3nskpZgNZFHYCPknwf4juQvzDSvfhZ8dpqwyMXL3S84ZvEAXzAmG23pimveJWkTBbuCQHBEb8sLf6tN3E5qprXHP",
-          "address": "AswjwVEcBXX6FxktUvnYwktM5eaXUg9WLya4d9ttQKhW"
+          "decimals": 9,
+          "originChain": "solana",
+          "address": "9RdSWTNrfAEnZ679CBFCBMhB33Qm7unjd9DkY4WNZArv",
+          "notes": "Testnet AXE family (home solana), Token-2022 mint. Reused for Hyperliquid<->Solana cron pair."
         }
       }
     },

--- a/axelar-chains-config/info/testnet.json
+++ b/axelar-chains-config/info/testnet.json
@@ -2241,15 +2241,13 @@
           "salt": "v6.1.0"
         },
         "AXE": {
-          "salt": "0x6178655f4158455f7465737470a16574f7631000000000000000000000000000",
-          "deployer": "0xba76c6980428A0b10CFC5d8ccb61949677A61233",
-          "tokenId": "0xd6311e67bdb5fb90d722d71fde9e7c33aa703a0b6c66518cebff80f63bc64a4a",
-          "minter": "0xba76c6980428A0b10CFC5d8ccb61949677A61233",
+          "tokenId": "0xbcbec67efab1cf2e7a6d301d4374d0da5a05330d6936314d2a707841596ace92",
           "name": "AXE",
           "symbol": "AXE",
-          "decimals": 18,
-          "deployTransactionHash": "0x493e6e3340eee70f50455224e68990148ca445bde6d1380339491d85620eba84",
-          "address": "0x00000000000000000000000000000000008B6eBd"
+          "decimals": 6,
+          "originChain": "monad-3",
+          "address": "0x00000000000000000000000000000000008c8e9c",
+          "notes": "Testnet AXE family (home monad-3, HTS-fork on hedera, 6 decimals). Supply seeded by monad-3->hedera interchainTransfer. Monad-3<->Hedera cron pair."
         }
       }
     },
@@ -3095,14 +3093,13 @@
           "salt": "v6.1.0"
         },
         "AXE": {
-          "tokenId": "0xd6311e67bdb5fb90d722d71fde9e7c33aa703a0b6c66518cebff80f63bc64a4a",
+          "tokenId": "0xbcbec67efab1cf2e7a6d301d4374d0da5a05330d6936314d2a707841596ace92",
           "name": "AXE",
           "symbol": "AXE",
           "decimals": 18,
-          "originChain": "hedera",
-          "originSalt": "0x6178655f4158455f7465737470a16574f7631000000000000000000000000000",
-          "deployedViaTx": "0x929717c3127cae130355167092a2ce39529383ed96e5b247af70570f8cc1061e",
-          "address": "0xf73d4d8a56a5478ed9b357115dc674d6ec4356bb"
+          "originChain": "monad-3",
+          "address": "0x18C8085e46Dc09DFBFc1acb1D544c0058C84e293",
+          "notes": "Testnet AXE family (home monad-3) auto-deployed + remote-registered on hedera by axe load-test; reused via this tokenId. Monad-3<->Hedera cron pair."
         }
       }
     },


### PR DESCRIPTION
### why
- <!-- Explain the reason for this change -->

### how
<!-- An agent will fill this out -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Testnet-only JSON contract metadata; wrong entries could break load-test cron pairs but does not affect mainnet or on-chain contracts by itself.
> 
> **Overview**
> Updates **testnet** `contracts.AXE` metadata in `info/testnet.json` so load tests and tooling reference **already-seeded ITS families** instead of stale deploy/register fields.
> 
> **Monad-3 ↔ Hedera family:** Hedera and the paired EVM chain entry now share tokenId `0xbcbec67e…`, with **home chain `monad-3`**, updated addresses/decimals (Hedera **6** decimals, HTS-style), and notes describing supply via `monad-3→hedera` interchain transfer and the cron pair. Old Hedera-local deploy fields (salt, deployer, minter, deploy tx) and Hedera-as-origin remote-deploy metadata are removed.
> 
> **Solana ↔ Hyperliquid family:** Solana and Hyperliquid AXE entries are repointed to a **Solana-home** family (shared tokenId `0x63e3c40e…`, **9** decimals, new mint/addresses). Hyperliquid’s AXE block is expanded with name/symbol/originChain and replaces the previous load-test token tied to Stellar registration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a05208c427be5996574a3a0816609aef62459255. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->