### PR TITLE
chore: update amplifier multisig prover admins

### DIFF
--- a/releases/cosmwasm/2026-06-MultisigProver-Admin-Transfer.md
+++ b/releases/cosmwasm/2026-06-MultisigProver-Admin-Transfer.md
@@ -1,0 +1,127 @@
+# MultisigProver Admin Transfer
+
+|                | **Owner** |
+| -------------- | --------- |
+| **Created By** | rista404  |
+| **Deployment** | rista404  |
+
+| **Network** | **Deployment Status** | **Date** |
+| ----------- | --------------------- | -------- |
+| **Mainnet** | Pending               | TBD      |
+
+## Background
+
+Transfer the `adminAddress` for every chain-specific `MultisigProver` contract whose current admin is
+`axelar1pczf792wf3p3xssk4dmwfxrh6hcqnrjp70danj`.
+
+This transfer must be executed through Axelar governance. `MultisigProver` supports `update_admin`, but the message is
+guarded by the `Governance` permission, not the `Admin` permission. The current admin EOA cannot rotate this role
+directly.
+
+Each included governance message updates one `MultisigProver` instance:
+
+```json
+{
+  "update_admin": {
+    "new_admin_address": "axelar1w2ey0ek9e8q2dfmeznz6ah49zdywpdme0z0kly"
+  }
+}
+```
+
+## Scope
+
+- Environment: `mainnet`
+- Source admin: `axelar1pczf792wf3p3xssk4dmwfxrh6hcqnrjp70danj`
+- Target admin: `axelar1w2ey0ek9e8q2dfmeznz6ah49zdywpdme0z0kly`
+- Contract set: all configured chain-specific `MultisigProver` instances whose live admin matches the source admin
+
+## Preconditions
+
+- `.env` is configured for mainnet Axelar operations, including `ENV=mainnet`, `AXELAR_RPC`, and proposer signing
+  configuration.
+- Confirm each included `MultisigProver` has the Axelar governance module as its governance address.
+- Review the prepared proposal file before submission. It should contain only `MsgExecuteContract` messages for
+  `MultisigProver` contracts that currently have the source admin.
+
+## Prepare Proposal
+
+Prepare a reviewed contract list containing only chain-specific `MultisigProver` contracts whose live admin is
+`axelar1pczf792wf3p3xssk4dmwfxrh6hcqnrjp70danj`.
+
+The reviewed contract list should have this shape:
+
+```json
+[
+  {
+    "chain": "<chain-name>",
+    "address": "<multisig-prover-address>",
+    "current_admin": "axelar1pczf792wf3p3xssk4dmwfxrh6hcqnrjp70danj"
+  }
+]
+```
+
+Build `multisig-prover-admin-transfer.json` from that reviewed list. The proposal should be an expedited governance
+proposal with one `/cosmwasm.wasm.v1.MsgExecuteContract` message per reviewed contract. Each message must:
+
+- use the Axelar governance module as `sender`: `axelar10d07y265gmmuvt4z0w9aw880jnsr700j7v9daj`
+- use the reviewed `MultisigProver` address as `contract`
+- execute `update_admin` with `new_admin_address` set to `axelar1w2ey0ek9e8q2dfmeznz6ah49zdywpdme0z0kly`
+- include no funds
+
+Example proposal messages:
+
+```json
+[
+  {
+    "@type": "/cosmwasm.wasm.v1.MsgExecuteContract",
+    "sender": "axelar10d07y265gmmuvt4z0w9aw880jnsr700j7v9daj",
+    "contract": "axelar1rsuejfntt4rs2y8dn4dd3acszs00zyg9wpnsc6fmhevcp6plu5qspzn7e0",
+    "msg": {
+      "update_admin": {
+        "new_admin_address": "axelar1w2ey0ek9e8q2dfmeznz6ah49zdywpdme0z0kly"
+      }
+    },
+    "funds": []
+  },
+  {
+    "@type": "/cosmwasm.wasm.v1.MsgExecuteContract",
+    "sender": "axelar10d07y265gmmuvt4z0w9aw880jnsr700j7v9daj",
+    "contract": "axelar1v8jrupu2rqpskwgtr69max0ajul92q8z5mdxd505m2hu3xc5jzcqm8zyc6",
+    "msg": {
+      "update_admin": {
+        "new_admin_address": "axelar1w2ey0ek9e8q2dfmeznz6ah49zdywpdme0z0kly"
+      }
+    },
+    "funds": []
+  }
+]
+```
+
+Review the proposal artifact:
+
+```bash
+jq -r '.[] | [.chain, .address, .current_admin] | @tsv' multisig-prover-admin-transfer-contracts.json
+jq -r '.messages[] | [.contract, (.msg.update_admin.new_admin_address)] | @tsv' multisig-prover-admin-transfer.json
+jq '.messages | length' multisig-prover-admin-transfer.json
+```
+
+## Submit Proposal
+
+```bash
+axelard tx gov submit-proposal multisig-prover-admin-transfer.json \
+  --from <proposer-key> \
+  --chain-id axelar-dojo-1 \
+  --node "$AXELAR_RPC" \
+  --gas auto \
+  --gas-adjustment 1.4 \
+  -y
+```
+
+Vote and wait for the proposal to pass.
+
+## Verify
+
+After the proposal executes, verify every contract included in `multisig-prover-admin-transfer.json` has
+`axelar1w2ey0ek9e8q2dfmeznz6ah49zdywpdme0z0kly` as its admin.
+
+The release is complete when every included contract returns the new admin address.

--- a/releases/cosmwasm/2026-06-MultisigProver-Admin-Transfer.md
+++ b/releases/cosmwasm/2026-06-MultisigProver-Admin-Transfer.md
@@ -5,20 +5,39 @@
 | **Created By** | rista404  |
 | **Deployment** | rista404  |
 
-| **Network** | **Deployment Status** | **Date** |
-| ----------- | --------------------- | -------- |
-| **Mainnet** | Pending               | TBD      |
+| **Network** | **Deployment Status** | **Date**   |
+| ----------- | --------------------- | ---------- |
+| **Mainnet** | Deployed              | 2026-06-17 |
 
 ## Background
 
-Transfer the `adminAddress` for every chain-specific `MultisigProver` contract whose current admin is
+Transfer the `adminAddress` for every chain-specific `MultisigProver` contract whose current admin was
 `axelar1pczf792wf3p3xssk4dmwfxrh6hcqnrjp70danj`.
 
-This transfer must be executed through Axelar governance. `MultisigProver` supports `update_admin`, but the message is
-guarded by the `Governance` permission, not the `Admin` permission. The current admin EOA cannot rotate this role
-directly.
+This transfer had to be executed through Axelar governance. `MultisigProver` supports `update_admin`, but the message
+is guarded by the `Governance` permission, not the `Admin` permission. The previous admin EOA could not rotate this
+role directly.
 
-Each included governance message updates one `MultisigProver` instance:
+## Scope
+
+- Environment: `mainnet`
+- Source admin: `axelar1pczf792wf3p3xssk4dmwfxrh6hcqnrjp70danj`
+- Target admin: `axelar1w2ey0ek9e8q2dfmeznz6ah49zdywpdme0z0kly`
+- Contract set: all configured chain-specific `MultisigProver` instances whose live admin matched the source admin
+
+## Governance Proposal
+
+- Proposal: [481](https://axelarscan.io/proposals/481)
+- Status: `PROPOSAL_STATUS_PASSED`
+- Title: `Rotate MultisigProver Admin for flow, sui, stellar, xrpl-evm, plume, hedera, berachain, hyperliquid, monad.`
+- Submitted: `2026-06-16T12:44:32Z`
+- Voting ended: `2026-06-17T12:44:32Z`
+- Expedited: `true`
+
+Each proposal message was a `/cosmwasm.wasm.v1.MsgExecuteContract` sent by the Axelar governance module:
+`axelar10d07y265gmmuvt4z0w9aw880jnsr700j7v9daj`.
+
+Each message executed:
 
 ```json
 {
@@ -28,100 +47,29 @@ Each included governance message updates one `MultisigProver` instance:
 }
 ```
 
-## Scope
+## Updated Contracts
 
-- Environment: `mainnet`
-- Source admin: `axelar1pczf792wf3p3xssk4dmwfxrh6hcqnrjp70danj`
-- Target admin: `axelar1w2ey0ek9e8q2dfmeznz6ah49zdywpdme0z0kly`
-- Contract set: all configured chain-specific `MultisigProver` instances whose live admin matches the source admin
+| Chain         | MultisigProver Contract                                                        |
+| ------------- | ------------------------------------------------------------------------------ |
+| `flow`        | `axelar1rsuejfntt4rs2y8dn4dd3acszs00zyg9wpnsc6fmhevcp6plu5qspzn7e0`           |
+| `sui`         | `axelar1v8jrupu2rqpskwgtr69max0ajul92q8z5mdxd505m2hu3xc5jzcqm8zyc6`           |
+| `stellar`     | `axelar1wdgp5xyqjyv5zsq86n6pah2lsmd46mn0gt4055mvvk6mezn9skqs6p93dg`           |
+| `xrpl-evm`    | `axelar198xehj5htckk75s8wcamxerxtdc45669zdqjmr69guveqntj9f6s5rqq55`           |
+| `plume`       | `axelar1ll4yhqtldlgqwqthyffqln3cyr2f8ydzhv0djpjyp6sk4v5k4kqqrs60s7`           |
+| `hedera`      | `axelar1e7z2faehrvpwl3apq3srr8djp386urvm2fgw3yafmju6slphhe8skecrwk`           |
+| `berachain`   | `axelar1k483q898t5w0acqzxhdjlsmnpgcxxa49ye8m46757n8mtk70ugtsu927xw`           |
+| `hyperliquid` | `axelar1fxd8rq5j6wluyc07vl9vqr4xmdxxm25l2gd6m2an20mn5fdnzy6qll2nxx`           |
+| `monad`       | `axelar1dt6apz0m2lkuls3ah2h7zw277r0v50668fxytqtdxv83yzs4n69qlutnpk`           |
 
-## Preconditions
+`solana` was not included because its `MultisigProver` admin was already
+`axelar1w2ey0ek9e8q2dfmeznz6ah49zdywpdme0z0kly`.
 
-- `.env` is configured for mainnet Axelar operations, including `ENV=mainnet`, `AXELAR_RPC`, and proposer signing
-  configuration.
-- Confirm each included `MultisigProver` has the Axelar governance module as its governance address.
-- Review the prepared proposal file before submission. It should contain only `MsgExecuteContract` messages for
-  `MultisigProver` contracts that currently have the source admin.
+## Verification
 
-## Prepare Proposal
+After proposal execution, all nine included contracts were verified to have:
 
-Prepare a reviewed contract list containing only chain-specific `MultisigProver` contracts whose live admin is
-`axelar1pczf792wf3p3xssk4dmwfxrh6hcqnrjp70danj`.
-
-The reviewed contract list should have this shape:
-
-```json
-[
-  {
-    "chain": "<chain-name>",
-    "address": "<multisig-prover-address>",
-    "current_admin": "axelar1pczf792wf3p3xssk4dmwfxrh6hcqnrjp70danj"
-  }
-]
+```text
+adminAddress = axelar1w2ey0ek9e8q2dfmeznz6ah49zdywpdme0z0kly
 ```
 
-Build `multisig-prover-admin-transfer.json` from that reviewed list. The proposal should be an expedited governance
-proposal with one `/cosmwasm.wasm.v1.MsgExecuteContract` message per reviewed contract. Each message must:
-
-- use the Axelar governance module as `sender`: `axelar10d07y265gmmuvt4z0w9aw880jnsr700j7v9daj`
-- use the reviewed `MultisigProver` address as `contract`
-- execute `update_admin` with `new_admin_address` set to `axelar1w2ey0ek9e8q2dfmeznz6ah49zdywpdme0z0kly`
-- include no funds
-
-Example proposal messages:
-
-```json
-[
-  {
-    "@type": "/cosmwasm.wasm.v1.MsgExecuteContract",
-    "sender": "axelar10d07y265gmmuvt4z0w9aw880jnsr700j7v9daj",
-    "contract": "axelar1rsuejfntt4rs2y8dn4dd3acszs00zyg9wpnsc6fmhevcp6plu5qspzn7e0",
-    "msg": {
-      "update_admin": {
-        "new_admin_address": "axelar1w2ey0ek9e8q2dfmeznz6ah49zdywpdme0z0kly"
-      }
-    },
-    "funds": []
-  },
-  {
-    "@type": "/cosmwasm.wasm.v1.MsgExecuteContract",
-    "sender": "axelar10d07y265gmmuvt4z0w9aw880jnsr700j7v9daj",
-    "contract": "axelar1v8jrupu2rqpskwgtr69max0ajul92q8z5mdxd505m2hu3xc5jzcqm8zyc6",
-    "msg": {
-      "update_admin": {
-        "new_admin_address": "axelar1w2ey0ek9e8q2dfmeznz6ah49zdywpdme0z0kly"
-      }
-    },
-    "funds": []
-  }
-]
-```
-
-Review the proposal artifact:
-
-```bash
-jq -r '.[] | [.chain, .address, .current_admin] | @tsv' multisig-prover-admin-transfer-contracts.json
-jq -r '.messages[] | [.contract, (.msg.update_admin.new_admin_address)] | @tsv' multisig-prover-admin-transfer.json
-jq '.messages | length' multisig-prover-admin-transfer.json
-```
-
-## Submit Proposal
-
-```bash
-axelard tx gov submit-proposal multisig-prover-admin-transfer.json \
-  --from <proposer-key> \
-  --chain-id axelar-dojo-1 \
-  --node "$AXELAR_RPC" \
-  --gas auto \
-  --gas-adjustment 1.4 \
-  -y
-```
-
-Vote and wait for the proposal to pass.
-
-## Verify
-
-After the proposal executes, verify every contract included in `multisig-prover-admin-transfer.json` has
-`axelar1w2ey0ek9e8q2dfmeznz6ah49zdywpdme0z0kly` as its admin.
-
-The release is complete when every included contract returns the new admin address.
+The release is complete.


### PR DESCRIPTION
### why

rotate the multisig prover admins for amplifier connections.

### how
<!-- An agent will fill this out -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only PR with no runtime or config changes in the diff.
> 
> **Overview**
> Adds a **release note** documenting the completed mainnet rotation of `MultisigProver` contract admins for amplifier chains.
> 
> The write-up records that governance [proposal 481](https://axelarscan.io/proposals/481) executed `update_admin` on nine chain-specific provers (`flow`, `sui`, `stellar`, `xrpl-evm`, `plume`, `hedera`, `berachain`, `hyperliquid`, `monad`), moving admin from `axelar1pczf792wf3p3xssk4dmwfxrh6hcqnrjp70danj` to `axelar1w2ey0ek9e8q2dfmeznz6ah49zdywpdme0z0kly`, and notes that `solana` was already on the target admin. It also explains why the change required governance (Governance-gated `update_admin`, not Admin-only).
> 
> No application or deployment scripts are changed—this is operational documentation and verification only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9628b337a4961dbf430e8d79799c747ff8e55d7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->