### PR TITLE
fix(xrpl): use correct encoding for destination address

### DIFF
--- a/xrpl/README.md
+++ b/xrpl/README.md
@@ -85,7 +85,9 @@ Interchain token transfers from XRPL are initiated via a `Payment` transaction t
         {
             Memo: {
                 MemoType: "64657374696e6174696f6e5f61646472657373", // hex("destination_address")
-                // recipient's address, without the 0x prefix (in the EVM case), hex-encoded - hex("0A90c0Af1B07f6AC34f3520348Dbfae73BDa358E"), in this case:
+                // recipient's address, double-encoded: first to its canonical raw-bytes hex per destination chain
+                // (EVM/Sui: the address itself without 0x; Stellar/XRPL: hex of the ASCII address string; Solana: hex of the base58-decoded bytes),
+                // then hex-encoded for the memo - hex("0A90c0Af1B07f6AC34f3520348Dbfae73BDa358E") for this EVM case:
                 MemoData: "30413930633041663142303766364143333466333532303334384462666165373342446133353845"
             },
         },
@@ -154,8 +156,9 @@ GMP contract calls from XRPL are initiated via a `Payment` transaction that resp
         {
             Memo: {
                 MemoType: "64657374696e6174696f6e5f61646472657373", // hex("destination_address")
-                // // destination smart contract address, without the 0x prefix (in the EVM case), hex-encoded -
-                // hex("0A90c0Af1B07f6AC34f3520348Dbfae73BDa358E"), in this case:
+                // destination smart contract address, double-encoded: first to its canonical raw-bytes hex per destination chain
+                // (EVM/Sui: the address itself without 0x; Stellar/XRPL: hex of the ASCII address string; Solana: hex of the base58-decoded bytes),
+                // then hex-encoded for the memo - hex("0A90c0Af1B07f6AC34f3520348Dbfae73BDa358E") for this EVM case:
                 MemoData: "30413930633041663142303766364143333466333532303334384462666165373342446133353845"
             },
         },

--- a/xrpl/call-contract.js
+++ b/xrpl/call-contract.js
@@ -1,8 +1,12 @@
 const { Command, Option } = require('commander');
-const { mainProcessor, hex, parseTokenAmount } = require('./utils');
+const { mainProcessor, hex, parseTokenAmount, encodeITSDestination } = require('./utils');
 const { addBaseOptions, addSkipPromptOption } = require('./cli-utils');
 
-async function callContract(_config, wallet, client, chain, options, args) {
+async function callContract(config, wallet, client, chain, options, args) {
+    // Two encoding layers: encodeITSDestination produces the canonical raw-bytes hex
+    // for the destination chain type, then hex() wraps it for XRPL memo transport.
+    const destinationAddress = encodeITSDestination(config.chains, args.destinationChain, args.destinationAddress);
+
     await client.sendPayment(
         wallet,
         {
@@ -10,7 +14,7 @@ async function callContract(_config, wallet, client, chain, options, args) {
             amount: parseTokenAmount(options.gasFeeToken, options.gasFeeAmount), // token is either "XRP" or "<currency>.<issuer-address>"
             memos: [
                 { memoType: hex('type'), memoData: hex('call_contract') },
-                { memoType: hex('destination_address'), memoData: hex(args.destinationAddress.replace('0x', '')) },
+                { memoType: hex('destination_address'), memoData: hex(destinationAddress.replace('0x', '')) },
                 { memoType: hex('destination_chain'), memoData: hex(args.destinationChain) },
                 { memoType: hex('payload'), memoData: options.payload },
             ],

--- a/xrpl/interchain-transfer.js
+++ b/xrpl/interchain-transfer.js
@@ -1,8 +1,12 @@
 const { Command, Option } = require('commander');
-const { mainProcessor, hex, parseTokenAmount } = require('./utils');
+const { mainProcessor, hex, parseTokenAmount, encodeITSDestination } = require('./utils');
 const { addBaseOptions, addSkipPromptOption } = require('./cli-utils');
 
-async function interchainTransfer(_config, wallet, client, chain, options, args) {
+async function interchainTransfer(config, wallet, client, chain, options, args) {
+    // Two encoding layers: encodeITSDestination produces the canonical raw-bytes hex
+    // for the destination chain type, then hex() wraps it for XRPL memo transport.
+    const destinationAddress = encodeITSDestination(config.chains, args.destinationChain, args.destinationAddress);
+
     await client.sendPayment(
         wallet,
         {
@@ -10,7 +14,7 @@ async function interchainTransfer(_config, wallet, client, chain, options, args)
             amount: parseTokenAmount(args.token, args.amount), // token is either "XRP" or "<currency>.<issuer-address>"
             memos: [
                 { memoType: hex('type'), memoData: hex('interchain_transfer') },
-                { memoType: hex('destination_address'), memoData: hex(args.destinationAddress.replace('0x', '')) },
+                { memoType: hex('destination_address'), memoData: hex(destinationAddress.replace('0x', '')) },
                 { memoType: hex('destination_chain'), memoData: hex(args.destinationChain) },
                 { memoType: hex('gas_fee_amount'), memoData: hex(options.gasFeeAmount) },
                 ...(options.payload ? [{ memoType: hex('payload'), memoData: options.payload }] : []),


### PR DESCRIPTION
## Problem
  
xrpl/interchain-transfer.js and xrpl/call-contract.js encoded the destination_address memo as `hex(destinationAddress.replace('0x',''))`, i.e. a single layer with no chain-awareness. The XRPL memo actually needs two encoding layers:

1. ITS layer: the address as its canonical raw-bytes hex per destination chain type (what encodeITSDestination produces).
2. XRPL transport layer: hex(...) of that, like every other memo field.

This worked for EVM destinations only by coincidence (an EVM address string already is the hex of its 20 bytes). For Stellar/Solana/Sui it broke: the inner value was the raw address string (e.g. CB2J…, base58), which can't be hex-decoded.

## Fix

Route the address through encodeITSDestination(config.chains, destinationChain, destinationAddress) before the hex() transport wrap, in both scripts. Byte-for-byte identical for EVM (no regression); correct for Stellar/Solana/Sui. README examples updated to document the double encoding.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how cross-chain destination addresses are embedded in XRPL memos; wrong encoding would misroute funds or GMP, though EVM behavior is unchanged and the fix aligns with ITS expectations.
> 
> **Overview**
> Fixes **`destination_address`** memo construction in **`interchain-transfer.js`** and **`call-contract.js`** so XRPL ITS/GMP payments use the expected two-layer encoding instead of stripping `0x` and hex-wrapping the user string.
> 
> Both scripts now call **`encodeITSDestination(config.chains, destinationChain, destinationAddress)`** for the ITS canonical raw-bytes hex (per destination chain type), then apply **`hex(...)`** for XRPL memo transport. EVM destinations stay byte-for-byte the same; Stellar, Solana, and Sui destinations should encode correctly.
> 
> **`README.md`** interchain transfer and call-contract examples are updated to describe this double encoding and the per-chain canonical form.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c5fcffe75905341139aa4d4f34bb3aba98b834b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->