### PR TITLE
fix(stellar): upgrade @stellar/stellar-sdk 14.2.0 -> 16.0.1

### DIFF
--- a/.github/actions/setup-stellar/action.yaml
+++ b/.github/actions/setup-stellar/action.yaml
@@ -5,9 +5,9 @@ runs:
   using: 'composite'
   steps:
     - name: Install Stellar CLI
-      uses: stellar/stellar-cli@v25.2.0
+      uses: stellar/stellar-cli@v27.0.0
       with:
-        version: 25.2.0
+        version: 27.0.0
 
     - name: Set environment variables
       id: env
@@ -22,7 +22,7 @@ runs:
     - name: Start Stellar local network
       shell: bash
       run: |
-        stellar container start local --protocol-version 25 --limits unlimited
+        stellar container start local --protocol-version 27 --limits unlimited
 
     - name: Wait for Stellar network
       shell: bash

--- a/.github/workflows/node-lint.yaml
+++ b/.github/workflows/node-lint.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Install Node.js
         uses: useblacksmith/setup-node@v5
         with:
-          node-version: 22.x
+          node-version: 24.x
           cache: 'npm'
 
       - name: Install Dependencies

--- a/.github/workflows/node-lint.yaml
+++ b/.github/workflows/node-lint.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Install Node.js
         uses: useblacksmith/setup-node@v5
         with:
-          node-version: 18.x
+          node-version: 22.x
           cache: 'npm'
 
       - name: Install Dependencies

--- a/.github/workflows/publish-chains-config.yaml
+++ b/.github/workflows/publish-chains-config.yaml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: '22.x'
+          node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
         working-directory: ./axelar-chains-config

--- a/.github/workflows/publish-chains-config.yaml
+++ b/.github/workflows/publish-chains-config.yaml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: '18.x'
+          node-version: '22.x'
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
         working-directory: ./axelar-chains-config

--- a/.github/workflows/test-chains-config.yaml
+++ b/.github/workflows/test-chains-config.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Node.js
         uses: useblacksmith/setup-node@v5
         with:
-          node-version: 22.x
+          node-version: 24.x
           cache: 'npm'
 
       - name: Install

--- a/.github/workflows/test-chains-config.yaml
+++ b/.github/workflows/test-chains-config.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Node.js
         uses: useblacksmith/setup-node@v5
         with:
-          node-version: 18.x
+          node-version: 22.x
           cache: 'npm'
 
       - name: Install

--- a/.github/workflows/test-evm.yaml
+++ b/.github/workflows/test-evm.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Install Node.js
         uses: useblacksmith/setup-node@v5
         with:
-          node-version: 18.x
+          node-version: 22.x
           cache: 'npm'
 
       - name: Add node_modules/.bin to PATH

--- a/.github/workflows/test-evm.yaml
+++ b/.github/workflows/test-evm.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Install Node.js
         uses: useblacksmith/setup-node@v5
         with:
-          node-version: 22.x
+          node-version: 24.x
           cache: 'npm'
 
       - name: Add node_modules/.bin to PATH

--- a/.github/workflows/test-stellar.yaml
+++ b/.github/workflows/test-stellar.yaml
@@ -52,7 +52,7 @@ jobs:
       - name: Install Node.js
         uses: useblacksmith/setup-node@v5
         with:
-          node-version: 18.x
+          node-version: 22.x
           cache: 'npm'
 
       - name: Add node_modules/.bin to PATH

--- a/.github/workflows/test-stellar.yaml
+++ b/.github/workflows/test-stellar.yaml
@@ -52,7 +52,7 @@ jobs:
       - name: Install Node.js
         uses: useblacksmith/setup-node@v5
         with:
-          node-version: 22.x
+          node-version: 24.x
           cache: 'npm'
 
       - name: Add node_modules/.bin to PATH

--- a/.github/workflows/test-sui.yaml
+++ b/.github/workflows/test-sui.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18' # Hardcoded to ensure consistency.
+          node-version: '22' # Hardcoded to ensure consistency.
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
 

--- a/.github/workflows/test-sui.yaml
+++ b/.github/workflows/test-sui.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22' # Hardcoded to ensure consistency.
+          node-version: '24' # Hardcoded to ensure consistency.
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
 

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Install Node.js
         uses: useblacksmith/setup-node@v5
         with:
-          node-version: 22.x
+          node-version: 24.x
           cache: 'npm'
 
       - name: Install

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Install Node.js
         uses: useblacksmith/setup-node@v5
         with:
-          node-version: 18.x
+          node-version: 22.x
           cache: 'npm'
 
       - name: Install

--- a/.github/workflows/update-gas-info.yaml
+++ b/.github/workflows/update-gas-info.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: '22.x'
+          node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
       - run: npm run build

--- a/.github/workflows/update-gas-info.yaml
+++ b/.github/workflows/update-gas-info.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: '18.x'
+          node-version: '22.x'
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
       - run: npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@ledgerhq/hw-app-eth": "6.32.2",
         "@mysten/ledgerjs-hw-app-sui": "^0.4.1",
         "@mysten/sui": "^1.3.0",
-        "@stellar/stellar-sdk": "v14.2.0",
+        "@stellar/stellar-sdk": "16.0.1",
         "abort-controller": "^3.0.0",
         "axelar-chains-config": "file:axelar-chains-config",
         "axios": "^1.7.2",
@@ -3598,6 +3598,15 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@noble/ed25519": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-3.1.0.tgz",
+      "integrity": "sha512-pfcObRY3CtvwfaG9Mt5XqZdKmAQppl37tHUeuBhDUbiwJBCVY4/A4lbMvb1xKhMDx96AqAqZpMWuBX1HulhX4g==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@noble/hashes": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
@@ -5504,59 +5513,66 @@
       }
     },
     "node_modules/@stellar/js-xdr": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@stellar/js-xdr/-/js-xdr-3.1.2.tgz",
-      "integrity": "sha512-VVolPL5goVEIsvuGqDc5uiKxV03lzfWdvYg1KikvwheDmTBO68CKDji3bAZ/kppZrx5iTA8z3Ld5yuytcvhvOQ=="
-    },
-    "node_modules/@stellar/stellar-base": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-14.0.2.tgz",
-      "integrity": "sha512-2/zQLw3kwHOn4jka7pZDwu24++MDvW0gthuPINF2gCNl7V8LwjmkLTuZ/eUMJjwfo6uDpujgrCkSy9JFrgdVzg==",
-      "dependencies": {
-        "@noble/curves": "^1.9.6",
-        "@stellar/js-xdr": "^3.1.2",
-        "base32.js": "^0.1.0",
-        "bignumber.js": "^9.3.1",
-        "buffer": "^6.0.3",
-        "sha.js": "^2.4.12"
-      },
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@stellar/js-xdr/-/js-xdr-4.0.0.tgz",
+      "integrity": "sha512-+NmNa7Tk5BI5XFdy/6xGTqAN4J9a9KgCrCGhj2uEUTCBhLkch0M+QbKzNH8zEnejWe0p8w+0q5hUVX6L3OzoVA==",
+      "license": "Apache-2.0",
       "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@stellar/stellar-base/node_modules/bignumber.js": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
-      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
-      "engines": {
-        "node": "*"
+        "node": ">=20.0.0",
+        "pnpm": ">=9.0.0"
       }
     },
     "node_modules/@stellar/stellar-sdk": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/@stellar/stellar-sdk/-/stellar-sdk-14.2.0.tgz",
-      "integrity": "sha512-7nh2ogzLRMhfkIC0fGjn1LHUzk3jqVw8tjAuTt5ADWfL9CSGBL18ILucE9igz2L/RU2AZgeAvhujAnW91Ut/oQ==",
-      "hasInstallScript": true,
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-sdk/-/stellar-sdk-16.0.1.tgz",
+      "integrity": "sha512-bxKohaiyKVqoudRhbOOHeHhHIaeYV5Zab4rCjxhP4Ty1h1ozTLBOv8lWFnZz9ilBzXG8Bb7usQI3rlEcfvUynA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@stellar/stellar-base": "^14.0.1",
-        "axios": "^1.12.2",
-        "bignumber.js": "^9.3.1",
-        "eventsource": "^2.0.2",
+        "@noble/ed25519": "^3.1.0",
+        "@noble/hashes": "^2.2.0",
+        "@stellar/js-xdr": "4.0.0",
+        "axios": "1.16.1",
+        "base32.js": "^0.1.0",
+        "bignumber.js": "^11.1.1",
+        "buffer": "^6.0.3",
+        "commander": "^14.0.3",
+        "eventsource": "^4.1.0",
         "feaxios": "^0.0.23",
-        "randombytes": "^2.1.0",
-        "toml": "^3.0.0",
-        "urijs": "^1.19.1"
+        "smol-toml": "^1.6.1",
+        "uint8array-extras": "^1.5.0"
+      },
+      "bin": {
+        "stellar-js": "bin/stellar-js"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@stellar/stellar-sdk/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@stellar/stellar-sdk/node_modules/bignumber.js": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
-      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-11.1.4.tgz",
+      "integrity": "sha512-AJ9dSeaUGj2xu7tEwmdqb51dqdb633xo4njI9K8ZFfcLrNr0XN8/EPkkZUNaF9fkCblGt2zVwZymesUdGynEkQ==",
+      "license": "MIT"
+    },
+    "node_modules/@stellar/stellar-sdk/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "license": "MIT",
       "engines": {
-        "node": "*"
+        "node": ">=20"
       }
     },
     "node_modules/@trivago/prettier-plugin-sort-imports": {
@@ -6441,7 +6457,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "4"
@@ -6739,6 +6754,8 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
       "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "possible-typed-array-names": "^1.0.0"
       },
@@ -6754,13 +6771,15 @@
       "link": true
     },
     "node_modules/axios": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
-      "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+      "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
-        "proxy-from-env": "^1.1.0"
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/babel-jest": {
@@ -6880,6 +6899,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/base32.js/-/base32.js-0.1.0.tgz",
       "integrity": "sha512-n3TkB02ixgBOhTvANakDb4xaMXnYUVkNoRFJjQflcqMQhyEKxEHdj3E6N8t8sUQ0mjH/3/JxzlXuz3ul/J90pQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
       }
@@ -7283,6 +7303,8 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
       "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.0",
         "es-define-property": "^1.0.0",
@@ -7312,6 +7334,8 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "get-intrinsic": "^1.3.0"
@@ -9083,11 +9107,24 @@
       }
     },
     "node_modules/eventsource": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
-      "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-4.1.0.tgz",
+      "integrity": "sha512-2GuF51iuHX6A9xdTccMTsNb7VO0lHZihApxhvQzJB5A03DvHDd2FQepodbMaztPBmBcE/ox7o2gqaxGhYB9LhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/evp_bytestokey": {
@@ -9368,15 +9405,16 @@
       "peer": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },
@@ -9390,6 +9428,8 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
       "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "is-callable": "^1.2.7"
       },
@@ -10436,7 +10476,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "6",
@@ -10673,6 +10712,8 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -10840,6 +10881,8 @@
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
       "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "which-typed-array": "^1.1.16"
       },
@@ -13215,6 +13258,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
       "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "dev": true,
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -13446,9 +13491,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/pump": {
       "version": "3.0.3",
@@ -13543,6 +13592,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
       "dependencies": {
         "safe-buffer": "^5.1.0"
       }
@@ -14243,6 +14293,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -14589,6 +14640,8 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
       "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "define-data-property": "^1.1.4",
         "es-errors": "^1.3.0",
@@ -14616,6 +14669,8 @@
       "version": "2.4.12",
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
       "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "inherits": "^2.0.4",
         "safe-buffer": "^5.2.1",
@@ -14924,9 +14979,10 @@
       }
     },
     "node_modules/smol-toml": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.5.2.tgz",
-      "integrity": "sha512-QlaZEqcAH3/RtNyet1IPIYPsEWAaYyXXv1Krsi+1L/QHppjX4Ifm8MQsBISz9vE8cHicIq3clogsheili5vhaQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.7.0.tgz",
+      "integrity": "sha512-aqVvWoyO21L23mb+drl4RmMXbf6N7FdHjAhTRA9ZBL7apWBgfWC16KjrASI+1p9GAroljyMHj6fK67i0UiTNvQ==",
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 18"
       },
@@ -15809,6 +15865,8 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
       "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "isarray": "^2.0.5",
         "safe-buffer": "^5.2.1",
@@ -15821,7 +15879,9 @@
     "node_modules/to-buffer/node_modules/isarray": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -16128,6 +16188,8 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
       "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.3",
         "es-errors": "^1.3.0",
@@ -16194,6 +16256,18 @@
       },
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/uint8array-extras": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/undici": {
@@ -16297,11 +16371,6 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
-    },
-    "node_modules/urijs": {
-      "version": "1.19.11",
-      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.11.tgz",
-      "integrity": "sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ=="
     },
     "node_modules/usb": {
       "version": "2.9.0",
@@ -16971,6 +17040,8 @@
       "version": "1.1.19",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
       "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
         "call-bind": "^1.0.8",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@ledgerhq/hw-app-eth": "6.32.2",
     "@mysten/ledgerjs-hw-app-sui": "^0.4.1",
     "@mysten/sui": "^1.3.0",
-    "@stellar/stellar-sdk": "v14.2.0",
+    "@stellar/stellar-sdk": "16.0.1",
     "abort-controller": "^3.0.0",
     "axelar-chains-config": "file:axelar-chains-config",
     "axios": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "typescript": "^5.8.3"
   },
   "engines": {
-    "node": ">=22"
+    "node": ">=24"
   },
   "overrides": {
     "@scure/base": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "typescript": "^5.8.3"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "overrides": {
     "@scure/base": "^1.2.0",

--- a/stellar/contract.js
+++ b/stellar/contract.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { Contract, SorobanRpc } = require('@stellar/stellar-sdk');
+const { Contract, rpc } = require('@stellar/stellar-sdk');
 const { Command, Option } = require('commander');
 const { execSync } = require('child_process');
 const { loadConfig, printInfo, saveConfig } = require('../evm/utils');
@@ -45,7 +45,7 @@ async function getTtl(_wallet, chain, contractName, contract, _args, _options) {
 
 async function getLedgerEntry(chain, contract) {
     const instance = contract.getFootprint();
-    const server = new SorobanRpc.Server(chain.rpc);
+    const server = new rpc.Server(chain.rpc);
     return server.getLedgerEntries(...[instance]);
 }
 

--- a/stellar/its.js
+++ b/stellar/its.js
@@ -208,7 +208,7 @@ async function deployRemoteCanonicalToken(wallet, config, chain, contract, args,
 async function interchainTransfer(wallet, config, chain, contract, args, options) {
     const caller = addressToScVal(wallet.publicKey());
     const [tokenId, destinationChain, destinationAddress, amount] = args;
-    const data = options.data === '' ? nativeToScVal(null, { type: 'null' }) : hexToScVal(options.data);
+    const data = options.data === '' ? nativeToScVal(null) : hexToScVal(options.data);
     const gasTokenAddress = options.gasTokenAddress || chain.tokenAddress;
 
     validateParameters({

--- a/stellar/utils.ts
+++ b/stellar/utils.ts
@@ -1,23 +1,22 @@
 'use strict';
 
-import {
-    Address,
-    BASE_FEE,
-    Horizon,
-    Keypair,
-    Networks,
-    TransactionBuilder,
-    authorizeInvocation,
-    nativeToScVal,
-    rpc,
-    xdr,
-} from '@stellar/stellar-sdk';
+// @stellar/stellar-sdk v16 is a dual package published as "type":"module" but ships
+// only ESM type declarations. Under this project's node16 resolution (required for
+// @mysten/sui's exports subpaths) tsc refuses to `require` an ESM-typed module from a
+// CommonJS file (TS1479). The package's "require" export condition provides a working
+// CJS build at runtime, so import the types only (erased, no diagnostic) and pull the
+// runtime values via require(), casting to the module type to keep full type-safety.
+import type * as StellarSdk from '@stellar/stellar-sdk' with { 'resolution-mode': 'import' };
 import { Command, Option } from 'commander';
 import { ethers } from 'ethers';
 
 import { addEnvOption, getCurrentVerifierSet, printError, printInfo, printWarn, sleep } from '../common';
 import { SHORT_COMMIT_HASH_REGEX, VERSION_REGEX, downloadContractCode } from '../common/utils';
 import { itsCustomMigrationDataToScValV112 } from './type-utils';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports -- see note above; require() hits the CJS build
+const stellarSdk: typeof StellarSdk = require('@stellar/stellar-sdk');
+const { Address, BASE_FEE, Horizon, Keypair, Networks, TransactionBuilder, authorizeInvocation, nativeToScVal, rpc, xdr } = stellarSdk;
 
 const {
     utils: { arrayify, hexZeroPad, id, isHexString, keccak256 },
@@ -226,7 +225,7 @@ function parseSimulatedResponse(response) {
     return response.result.retval._value;
 }
 
-function isReadOnly(response: rpc.Api.SimulateTransactionResponse, action?: string): boolean {
+function isReadOnly(response: StellarSdk.rpc.Api.SimulateTransactionResponse, action?: string): boolean {
     if (
         !rpc.Api.isSimulationSuccess(response) ||
         response.transactionData.getReadWrite().length > 0 ||
@@ -519,7 +518,7 @@ function hexToScVal(hexString) {
 
 function tokenToScVal(tokenAddress, tokenAmount) {
     return tokenAmount === 0
-        ? nativeToScVal(null, { type: 'null' })
+        ? nativeToScVal(null)
         : nativeToScVal(
               {
                   address: Address.fromString(tokenAddress),

--- a/stellar/utils.ts
+++ b/stellar/utils.ts
@@ -1,22 +1,23 @@
 'use strict';
 
-// @stellar/stellar-sdk v16 is a dual package published as "type":"module" but ships
-// only ESM type declarations. Under this project's node16 resolution (required for
-// @mysten/sui's exports subpaths) tsc refuses to `require` an ESM-typed module from a
-// CommonJS file (TS1479). The package's "require" export condition provides a working
-// CJS build at runtime, so import the types only (erased, no diagnostic) and pull the
-// runtime values via require(), casting to the module type to keep full type-safety.
-import type * as StellarSdk from '@stellar/stellar-sdk' with { 'resolution-mode': 'import' };
+import {
+    Address,
+    BASE_FEE,
+    Horizon,
+    Keypair,
+    Networks,
+    TransactionBuilder,
+    authorizeInvocation,
+    nativeToScVal,
+    rpc,
+    xdr,
+} from '@stellar/stellar-sdk';
 import { Command, Option } from 'commander';
 import { ethers } from 'ethers';
 
 import { addEnvOption, getCurrentVerifierSet, printError, printInfo, printWarn, sleep } from '../common';
 import { SHORT_COMMIT_HASH_REGEX, VERSION_REGEX, downloadContractCode } from '../common/utils';
 import { itsCustomMigrationDataToScValV112 } from './type-utils';
-
-// eslint-disable-next-line @typescript-eslint/no-require-imports -- see note above; require() hits the CJS build
-const stellarSdk: typeof StellarSdk = require('@stellar/stellar-sdk');
-const { Address, BASE_FEE, Horizon, Keypair, Networks, TransactionBuilder, authorizeInvocation, nativeToScVal, rpc, xdr } = stellarSdk;
 
 const {
     utils: { arrayify, hexZeroPad, id, isHexString, keccak256 },
@@ -225,7 +226,7 @@ function parseSimulatedResponse(response) {
     return response.result.retval._value;
 }
 
-function isReadOnly(response: StellarSdk.rpc.Api.SimulateTransactionResponse, action?: string): boolean {
+function isReadOnly(response: rpc.Api.SimulateTransactionResponse, action?: string): boolean {
     if (
         !rpc.Api.isSimulationSuccess(response) ||
         response.transactionData.getReadWrite().length > 0 ||

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
     "compilerOptions": {
         "target": "es2020",
-        "module": "node16",
-        "moduleResolution": "node16",
+        "module": "nodenext",
+        "moduleResolution": "nodenext",
         "esModuleInterop": true,
         "forceConsistentCasingInFileNames": true,
         "strict": false, // false for easier migration


### PR DESCRIPTION
### why
Upgrade @stellar/stellar-sdk 14.2.0 → 16.0.1 so our tooling is compatible with Protocol 27. P27 is already live on testnet and pubnet votes to upgrade on July 8th, so this brings our deployment tooling in line with the released ecosystem. This unblocks the Stellar deploy step in the e2e/integration-tests pipeline, which was failing against the P27 localnet.

- Localnet → Protocol 27: bumped the setup-stellar action to stellar-cli 27.0.0 and start the localnet with --protocol-version 27
- Node 18 → 22
- The SorobanRpc namespace was renamed to rpc
- Switched tsconfig module/moduleResolution from node16 to nodenext

Part of CPI-417

### how
<!-- An agent will fill this out -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Major Stellar SDK upgrade plus a repo-wide Node 24 requirement changes CI and deployment scripts; risk is integration/regression in Stellar flows rather than security-critical paths.
> 
> **Overview**
> Aligns Stellar deployment tooling with **Protocol 27** by bumping **`@stellar/stellar-sdk`** from 14.2.0 to **16.0.1**, raising the package **`engines.node`** requirement to **>=24**, and switching all affected GitHub workflows from Node **18.x** to **24.x**.
> 
> CI local Stellar setup now uses **stellar-cli v27.0.0** and starts the container with **`--protocol-version 27`** (was 25). Stellar scripts adopt SDK v16 APIs: **`SorobanRpc` → `rpc`** in `stellar/contract.js`, and optional null SCVals use **`nativeToScVal(null)`** without an explicit `{ type: 'null' }` in `stellar/its.js` and `stellar/utils.ts`. **`tsconfig.json`** moves **`module` / `moduleResolution`** from **node16** to **nodenext** to match the newer SDK/toolchain expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10519ccd7e2639f0a2d1fe5b68959b4b9c6372b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->