### PR TITLE
docs(axelard): add v1.4.8 upgrade release notes

### DIFF
--- a/releases/axelard/2026-07-v1.4.8.md
+++ b/releases/axelard/2026-07-v1.4.8.md
@@ -36,9 +36,10 @@ No Amplifier contract migrations are required for this upgrade.
 
 There is **no governance software-upgrade proposal** for `v1.4.8`. The fix is gated by block time in the binary, so the only action required is to get every validator onto the `v1.4.8` binary before its network's activation time.
 
-1. Inform all validators of the `v1.4.8` release and their network's activation time (see [Activation Times by Network](#activation-times-by-network)).
+1. All validators were informed with a code blue alert notice of the `v1.4.8` release (by a blue notice) and their network's activation time (see [Activation Times by Network](#activation-times-by-network)).
 2. Coordinate a rolling binary swap so that every validator is running `v1.4.8` **before** the activation time. 
 3. As the activation time approaches, confirm that all validators (and other maintainer-operated nodes) are on `v1.4.8`. Any node still on `v1.4.7` at the activation time will diverge from the fixed nodes and halt with an `app hash` mismatch.
+4. While waiting on the fix, a temporary monitor was deployed for the messages with a malformed payload
 
 ### Post-Upgrade Checklist for Maintainers
 
@@ -60,12 +61,12 @@ There is **no governance software-upgrade proposal** for `v1.4.8`. The fix is ga
 
 The consensus-breaking fix activates at the following block times (from [`utils/timed_fix.go`](https://github.com/axelarnetwork/axelar-core/blob/releases/1.4.x/utils/timed_fix.go)). You must be running `v1.4.8` before your network's activation time.
 
-| Network              | Chain ID              | Activation Time (UTC) |
-| -------------------- | --------------------- | --------------------- |
-| **Devnet Amplifier** | `*devnet*`            | 2026-07-02 12:00:00   |
-| **Stagenet**         | `axelar-stagenet-*`   | 2026-07-02 12:00:00   |
-| **Testnet**          | `axelar-testnet-*`    | 2026-07-03 08:00:00   |
-| **Mainnet**          | `axelar-dojo-1`       | 2026-07-07 08:00:00   |
+| Network              | Chain ID              | Activation Time (UTC) | Activation Height |
+| -------------------- | --------------------- | --------------------- |------------------ |
+| **Devnet Amplifier** | `*devnet*`            | 2026-07-02 12:00:00   | 31,168,834        |
+| **Stagenet**         | `axelar-stagenet-*`   | 2026-07-02 12:00:00   | 32,873,744        |
+| **Testnet**          | `axelar-testnet-*`    | 2026-07-03 08:00:00   | 19,736,228        |
+| **Mainnet**          | `axelar-dojo-1`       | 2026-07-07 08:00:00   | 24,047,518        |
 
 ### Upgrade Process
 

--- a/releases/axelard/2026-07-v1.4.8.md
+++ b/releases/axelard/2026-07-v1.4.8.md
@@ -1,0 +1,106 @@
+# axelard v1.4.8
+
+|                | **Owner**                             |
+| -------------- | ------------------------------------- |
+| **Created By** | @jakovmitrovski, @h4writer, @dolfje |
+| **Deployment** | @jakovmitrovski, @h4writer, @dolfje |
+
+| **Network**          | **Deployment Status** | **Date**   |
+| -------------------- | --------------------- | ---------- |
+| **Devnet Amplifier** | Deployed               | 2026-07-02 |
+| **Stagenet**         | Deployed               | 2026-07-02 |
+| **Testnet**          | Deployed               | 2026-07-03 |
+| **Mainnet**          | Deployed               | 2026-07-07 |
+
+[Release v1.4.8](https://github.com/axelarnetwork/axelar-core/releases/tag/v1.4.8)
+
+## Background
+
+`v1.4.8` is the recommended binary on the `v1.4.x` line. `v1.4.6` was the first public release on the `v1.4.x` line, `v1.4.7` was a follow-up patch, and `v1.4.8` is a further patch on top of `v1.4.7`. `v1.4.8` is the version that should be deployed.
+
+### Changes since v1.4.7
+
+- **Guards against super-linear ABI amplification when routing a `MsgRouteMessage` with a malformed payload** ([#2352](https://github.com/axelarnetwork/axelar-core/pull/2352)). Adds an extra validation guard so that a message with a malformed payload can no longer trigger super-linear work during routing. This is the only change in `v1.4.8` relative to `v1.4.7`.
+
+This is a **consensus-breaking bug fix**. Unlike the `v1.4.7` upgrade (which ran through a governance software-upgrade proposal at a fixed block height), `v1.4.8` does **not** require a governance proposal or an `axelard` upgrade handler. Instead, the fix is gated by **block time**: every node running `v1.4.8` keeps the old behavior until its network's activation timestamp, then switches to the fixed behavior at the same block on every node, preserving consensus. Operators only need to be running the `v1.4.8` binary **before** their network's activation time.
+
+No dependency versions change relative to `v1.4.7`: `libwasmvm` stays at `v2.2.6`, CometBFT at `v0.38.23`, Cosmos SDK at `v0.50.15`, and ibc-go at `v8.8.0`.
+
+For the full list of changes, see the [v1.4.8 changelog](https://github.com/axelarnetwork/axelar-core/blob/v1.4.8/CHANGELOG.md).
+
+## Migrate CosmWasm Contracts
+
+No Amplifier contract migrations are required for this upgrade.
+
+## Deployment Steps for Axelar Maintainers
+
+There is **no governance software-upgrade proposal** for `v1.4.8`. The fix is gated by block time in the binary, so the only action required is to get every validator onto the `v1.4.8` binary before its network's activation time.
+
+1. Inform all validators of the `v1.4.8` release and their network's activation time (see [Activation Times by Network](#activation-times-by-network)).
+2. Coordinate a rolling binary swap so that every validator is running `v1.4.8` **before** the activation time. 
+3. As the activation time approaches, confirm that all validators (and other maintainer-operated nodes) are on `v1.4.8`. Any node still on `v1.4.7` at the activation time will diverge from the fixed nodes and halt with an `app hash` mismatch.
+
+### Post-Upgrade Checklist for Maintainers
+
+- [x] All validator nodes are running `v1.4.8` before the activation time
+- [x] All validator nodes continue producing blocks across the activation time
+- [x] No live signing/voting sessions are stuck after the activation time
+- [x] Testing
+    - [x] General testing: GMP calls, IBC transfers, key rotation
+    - [ ] Confirm malformed-payload `MsgRouteMessage` requests are rejected by the new guard once the fix is active
+
+## Deployment Steps for Axelar Validators
+
+### Prerequisites
+
+- **Building from source:** If building from source, use `Go 1.25`. The recommended approach is static linking with `make build-static`, which eliminates additional libwasmvm handling. As a fallback, if you need a dynamically linked binary using `make build`, make sure to update libwasmvm to `v2.2.6` (unchanged from `v1.4.7`; bumped from `v2.2.4` in `v1.3.x`).
+- **Latest Prebuilt binaries:** Available on the [release page](https://github.com/axelarnetwork/axelar-core/releases/tag/v1.4.8). For Linux, we recommend the statically linked binary [axelard-linux-amd64-v1.4.8-static](https://github.com/axelarnetwork/axelar-core/releases/download/v1.4.8/axelard-linux-amd64-v1.4.8-static) which runs on any Linux distribution without requiring libwasmvm to be installed on your system.
+
+### Activation Times by Network
+
+The consensus-breaking fix activates at the following block times (from [`utils/timed_fix.go`](https://github.com/axelarnetwork/axelar-core/blob/releases/1.4.x/utils/timed_fix.go)). You must be running `v1.4.8` before your network's activation time.
+
+| Network              | Chain ID              | Activation Time (UTC) |
+| -------------------- | --------------------- | --------------------- |
+| **Devnet Amplifier** | `*devnet*`            | 2026-07-02 12:00:00   |
+| **Stagenet**         | `axelar-stagenet-*`   | 2026-07-02 12:00:00   |
+| **Testnet**          | `axelar-testnet-*`    | 2026-07-03 08:00:00   |
+| **Mainnet**          | `axelar-dojo-1`       | 2026-07-07 08:00:00   |
+
+### Upgrade Process
+
+Unlike a height-based upgrade, there is no coordinated stop-at-height. Swap the binary at any point before the activation time:
+
+1. Stop the validator `axelard` node, `vald`, and `ampd` (if you are running a verifier).
+2. Replace the binaries:
+   - `axelard` → `v1.4.8`
+   - `vald` → `v1.4.8` (bundled in the same `axelard` build)
+   - `tofnd` → `v1.0.1` (no change vs. v1.3.x)
+3. No `app.toml` / `config.toml` changes are required relative to a node already running `v1.3.x` or `v1.4.7` with the post-v1.3.0 settings (`iavl-cache-size = 0`, `iavl-disable-fastnode = true`, `timeout_commit = 1s`).
+4. Restart the validator node, `vald`, and `ampd` with the new binaries. When restarting `axelard` do not do a rollback.
+5. Please also upgrade any other Axelar nodes you operate (RPC nodes etc.), and restart your IBC relayer (e.g. hermes).
+6. Confirm the node is on `v1.4.8` and producing blocks well before the activation time.
+
+### Post-Deployment Checklist
+
+- [x] Verify that nodes are producing new blocks after the binary swap.
+- [x] Verify the node is on `v1.4.8` before the activation time.
+- [x] Verify vald is participating in message validation, signing, heartbeats etc.
+- [x] Verify the node continues producing blocks across the activation time (no `app hash` mismatch).
+- [x] Test [GMP calls](../evm/EVM-GMP-Release-Template.md)
+
+## Troubleshooting
+
+### `app hash` mismatch
+
+Make sure all replicas across your fleet were swapped to `v1.4.8` before the activation time. A node still on `v1.4.7` (or with a different `FIX_ACTIVATION_TIME` override) at the activation time applies different routing logic and will fork.
+
+### `libwasmvm` errors with the dynamic binary
+
+`libwasmvm` is `v2.2.6` (unchanged from `v1.4.7`; bumped from v2.2.4 in v1.3.x). Replace the library on every dynamic-binary node before starting the new binary, otherwise it refuses to launch with a wasmvm version-mismatch error. Ensure system environment variable `LD_LIBRARY_PATH` is specified to its correct location if using the dynamic binary. For docker image no change is necessary.
+
+If you hit the error: `undefined symbol: migrate_with_info`, switch to using the statically linked binary ([axelard-linux-amd64-v1.4.8-static](https://github.com/axelarnetwork/axelar-core/releases/download/v1.4.8/axelard-linux-amd64-v1.4.8-static)). If you need to use a dynamically linked binary, make sure you have the correct `libwasmvm` version (`2.2.6`).
+
+### Rollback
+
+This is a consensus-breaking fix. Before the activation time, `v1.4.8` behaves identically to `v1.4.7`, so a node can be freely rolled back to `v1.4.7`. **After the activation time there is no in-place rollback**: once the fix is active, reverting to `v1.4.7` (which lacks the guard) could diverge from the rest of the network. If a rollback is required after activation, restore from a pre-activation snapshot.


### PR DESCRIPTION
Operator-facing release note for the axelar-core v1.4 upgrade (binary v1.4.8).