### PR TITLE
fix(common): use native fetch for WASM download to fix ERR_STREAM_PREMATURE_CLOSE on Node >=22

### DIFF
--- a/common/utils.js
+++ b/common/utils.js
@@ -13,7 +13,6 @@ const {
     BigNumber,
 } = ethers;
 const { bech32 } = require('bech32');
-const fetch = require('node-fetch');
 const StellarSdk = require('@stellar/stellar-sdk');
 const bs58 = require('bs58');
 const { AsyncLocalStorage } = require('async_hooks');
@@ -738,7 +737,7 @@ const downloadContractCode = async (url, contractName, version) => {
         throw new Error(`Failed to download WASM file: ${response.statusText}`);
     }
 
-    const buffer = await response.buffer();
+    const buffer = Buffer.from(await response.arrayBuffer());
     writeFileSync(outputPath, buffer);
 
     return outputPath;


### PR DESCRIPTION
### why

On Node >= 22, downloading the contract WASM through node-fetch intermittently fails with ERR_STREAM_PREMATURE_CLOSE. Native fetch (stable since Node 18, and the standard going forward) doesn't exhibit this issue. Since the repo now targets Node 24, node-fetch is redundant.

(This removes the need to move all workflows to 20, which I did in https://github.com/axelarnetwork/axelarate/pull/2428)

Part of CPI-417

### how
<!-- An agent will fill this out -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single utility change to HTTP download/buffer handling with no auth or persistence impact; behavior should match aside from fixing the stream error.
> 
> **Overview**
> **WASM contract downloads** in `downloadContractCode` no longer depend on `node-fetch`. The `node-fetch` import is removed, and the download path uses Node’s built-in `fetch` with `Buffer.from(await response.arrayBuffer())` instead of `response.buffer()`.
> 
> This targets intermittent `ERR_STREAM_PREMATURE_CLOSE` failures on Node 22+ when fetching `.wasm` artifacts and drops a redundant dependency now that the repo targets Node 24.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1c68eb01fb62848e8ee29314c54dd9540e8fa4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->