### PR TITLE
feat: add Taifoon chain config

### DIFF
--- a/axelar-chains-config/info/mainnet.json
+++ b/axelar-chains-config/info/mainnet.json
@@ -808,7 +808,7 @@
       "name": "Taifoon",
       "axelarId": "Taifoon",
       "chainId": 36927,
-      "rpc": "https://rpc.taifoon.dev",
+      "rpc": "https://<taifoon-parachain-evm-rpc>",
       "tokenSymbol": "FOON",
       "decimals": 18,
       "chainType": "evm",
@@ -836,7 +836,7 @@
         },
         "AxelarDepositService": {
           "salt": "AxelarDepositService",
-          "wrappedSymbol": "WGLMR",
+          "wrappedSymbol": "WFOON",
           "refundIssuer": "0x4f671f34d2d23fec3eE3087E3A0221f8D314D9dF",
           "address": "0x0000000000000000000000000000000000000000",
           "implementation": "0x0000000000000000000000000000000000000000",

--- a/axelar-chains-config/info/mainnet.json
+++ b/axelar-chains-config/info/mainnet.json
@@ -804,6 +804,134 @@
       "finality": "finalized",
       "approxFinalityWaitTime": 1
     },
+    "taifoon": {
+      "name": "Taifoon",
+      "axelarId": "Taifoon",
+      "chainId": 36927,
+      "rpc": "https://rpc.taifoon.dev",
+      "tokenSymbol": "FOON",
+      "decimals": 18,
+      "chainType": "evm",
+      "contracts": {
+        "AxelarGateway": {
+          "address": "0x0000000000000000000000000000000000000000",
+          "deployer": "0x6f24A47Fc8AE5441Eb47EFfC3665e70e69Ac3F05",
+          "startingKeyIDs": [
+            "evm-taifoon-0"
+          ],
+          "implementation": "0x0000000000000000000000000000000000000000",
+          "implementationCodehash": "0x7d8ba71c940fc633465d77bc7c2b2d7c4d7fcc0d397d8f699d0345fcad136216",
+          "authModule": "0xE3B83f79Fbf01B25659f8A814945aB82186A8AD0",
+          "tokenDeployer": "0xb28478319B64f8D47e19A120209A211D902F8b8f",
+          "deploymentMethod": "create3",
+          "salt": "AxelarGateway v6.2",
+          "connectionType": "consensus"
+        },
+        "AxelarGasService": {
+          "salt": "AxelarGasService",
+          "address": "0x0000000000000000000000000000000000000000",
+          "implementation": "0x0000000000000000000000000000000000000000",
+          "deployer": "0x6f24A47Fc8AE5441Eb47EFfC3665e70e69Ac3F05",
+          "collector": "0x7DdB2d76b80B0AA19bDEa48EB1301182F4CeefbC"
+        },
+        "AxelarDepositService": {
+          "salt": "AxelarDepositService",
+          "wrappedSymbol": "WGLMR",
+          "refundIssuer": "0x4f671f34d2d23fec3eE3087E3A0221f8D314D9dF",
+          "address": "0x0000000000000000000000000000000000000000",
+          "implementation": "0x0000000000000000000000000000000000000000",
+          "deployer": "0xd55cd98cdE61c3CcE1286F9aF50cDbF16f5dba5b"
+        },
+        "ConstAddressDeployer": {
+          "address": "0x0000000000000000000000000000000000000000"
+        },
+        "Create3Deployer": {
+          "address": "0x0000000000000000000000000000000000000000",
+          "deployer": "0x6f24A47Fc8AE5441Eb47EFfC3665e70e69Ac3F05",
+          "deploymentMethod": "create2",
+          "salt": "Create3Deployer",
+          "codehash": "0xf0ad66defbe082df243d4d274e626f557f97579c5c9e19f33d8093d6160808b7",
+          "predeployCodehash": "0x73fc31262c4bad113c79439fd231281201c7c7d45b50328bd86bccf37684bf92"
+        },
+        "InterchainProposalSender": {
+          "address": "0x0000000000000000000000000000000000000000",
+          "deployer": "0x6f24A47Fc8AE5441Eb47EFfC3665e70e69Ac3F05",
+          "deploymentMethod": "create3",
+          "salt": "InterchainProposalSender v1.2"
+        },
+        "Multisig": {
+          "threshold": 3,
+          "signers": [
+            "0x3f5876a2b06E54949aB106651Ab6694d0289b2b4",
+            "0x9256Fd872118ed3a97754B0fB42c15015d17E0CC",
+            "0x1486157d505C7F7E546aD00E3E2Eee25BF665C9b",
+            "0x2eC991B5c0B742AbD9d2ea31fe6c14a85e91C821",
+            "0xf505462A29E36E26f25Ef0175Ca1eCBa09CC118f",
+            "0x027c1882B975E2cd771AE068b0389FA38B9dda73"
+          ],
+          "address": "0x0000000000000000000000000000000000000000",
+          "deployer": "0x6f24A47Fc8AE5441Eb47EFfC3665e70e69Ac3F05",
+          "deploymentMethod": "create3",
+          "codehash": "0x912095d5076ee40a9dd49c0f9d61d61334c47a78c7512852791652baef26c296",
+          "predeployCodehash": "0x912095d5076ee40a9dd49c0f9d61d61334c47a78c7512852791652baef26c296",
+          "salt": "Multisig v5.5"
+        },
+        "Operators": {
+          "owner": "0x6f24A47Fc8AE5441Eb47EFfC3665e70e69Ac3F05",
+          "address": "0x0000000000000000000000000000000000000000",
+          "deployer": "0x6f24A47Fc8AE5441Eb47EFfC3665e70e69Ac3F05",
+          "deploymentMethod": "create2",
+          "codehash": "0xc561dc32ef670c929db9d7fbf6b5f6c074a62a30602481ba3b88912ca6d79feb",
+          "predeployCodehash": "0xc561dc32ef670c929db9d7fbf6b5f6c074a62a30602481ba3b88912ca6d79feb",
+          "salt": "Operators"
+        },
+        "InterchainTokenService": {
+          "salt": "ITS v2.1.1",
+          "deployer": "0x6f24A47Fc8AE5441Eb47EFfC3665e70e69Ac3F05",
+          "proxySalt": "ITS v1.0.0",
+          "tokenManagerDeployer": "0xDFef5B38C1c080A4a82431b687989759cB207d24",
+          "interchainToken": "0x7F9F70Da4af54671a6abAc58e705b5634cac8819",
+          "interchainTokenDeployer": "0xB769ce7dC3D642B082A55f0c12622c6E516969a3",
+          "tokenManager": "0x8832F0381707bb29756eDECf42580800207F2a9e",
+          "tokenHandler": "0x383dF8E8f96b3dF53F9bdc607811c7e96239e7da",
+          "implementation": "0x0000000000000000000000000000000000000000",
+          "predeployCodehash": "0x08a4a556c4db879b4f24104d13a8baf86915d58b12c81b382dfea2a82d2856cf",
+          "address": "0x0000000000000000000000000000000000000000",
+          "gatewayCaller": "0xc15E449607224DB9ff8e6f7E5DB020C0E18BCff3",
+          "version": "2.1.1"
+        },
+        "InterchainTokenFactory": {
+          "salt": "ITS Factory v1.0.0",
+          "deployer": "0x6f24A47Fc8AE5441Eb47EFfC3665e70e69Ac3F05",
+          "implementation": "0x0000000000000000000000000000000000000000",
+          "address": "0x0000000000000000000000000000000000000000",
+          "version": "2.1.1"
+        },
+        "AxelarServiceGovernance": {
+          "governanceChain": "axelar",
+          "governanceAddress": "axelar10d07y265gmmuvt4z0w9aw880jnsr700j7v9daj",
+          "minimumTimeDelay": 259200,
+          "operator": "0xc8a8399c3D1207f4e109673be7047604737c1D56",
+          "deploymentMethod": "create3",
+          "salt": "v6.0.4-axelar",
+          "address": "0x0000000000000000000000000000000000000000",
+          "predeployCodehash": "0x4fc776e1bb827206e031bd9e0ea8afccda553c870451ef4f5bfe33cae022be13",
+          "deployer": "0xba76c6980428A0b10CFC5d8ccb61949677A61233",
+          "codehash": "0x297f8236f2b5cb952a7dbc1fa87a54b573159e455055d67c6c1a362e2b2c2fab"
+        }
+      },
+      "explorer": {
+        "name": "Moonscan",
+        "url": "https://moonbeam.moonscan.io",
+        "api": "https://api-moonbeam.moonscan.io/api"
+      },
+      "staticGasOptions": {
+        "gasLimit": 3000000,
+        "gasPrice": 625000000000
+      },
+      "finality": "finalized",
+      "approxFinalityWaitTime": 1
+    },
     "binance": {
       "name": "Binance",
       "axelarId": "binance",


### PR DESCRIPTION
Adds Taifoon (a Moonbeam-fork Polkadot parachain, EVM chainId 36927, native FOON) to `axelar-chains-config/info/mainnet.json`, copying the Moonbeam chain block structure (AxelarGateway + AxelarGasService, same Create3 salts). Pure insertion — no other chain's data changed.

Contract addresses are zeroed placeholders pending the Create3 deploy on the live Taifoon chain + Axelar validator support / axelar-core registration (governance, beyond this file).

🤖 Prepared as a Moonbeam-inheritance re-wiring.