### PR TITLE
docs(axelard): add v1.4.9 release notes

### DIFF
--- a/releases/axelard/2026-07-v1.4.9.md
+++ b/releases/axelard/2026-07-v1.4.9.md
@@ -5,12 +5,12 @@
 | **Created By** | @jakovmitrovski, @h4writer, @dolfje |
 | **Deployment** | @jakovmitrovski, @h4writer, @dolfje |
 
-| **Network**          | **Deployment Status** | **Date** |
-| -------------------- | --------------------- | -------- |
-| **Devnet Amplifier** | Pending               | TBD      |
-| **Stagenet**         | Pending               | TBD      |
-| **Testnet**          | Pending               | TBD      |
-| **Mainnet**          | Pending               | TBD      |
+| **Network**          | **Deployment Status** | **Date**   |
+| -------------------- | --------------------- | ---------- |
+| **Devnet Amplifier** | Deployed              | 2026-07-08 |
+| **Stagenet**         | Deployed              | 2026-07-08 |
+| **Testnet**          | Deployed              | 2026-07-10 |
+| **Mainnet**          | Deployed              | 2026-07-13 |
 
 [Release v1.4.9](https://github.com/axelarnetwork/axelar-core/releases/tag/v1.4.9)
 

--- a/releases/axelard/2026-07-v1.4.9.md
+++ b/releases/axelard/2026-07-v1.4.9.md
@@ -1,0 +1,87 @@
+# axelard v1.4.9
+
+|                | **Owner**                             |
+| -------------- | ------------------------------------- |
+| **Created By** | @jakovmitrovski, @h4writer, @dolfje |
+| **Deployment** | @jakovmitrovski, @h4writer, @dolfje |
+
+| **Network**          | **Deployment Status** | **Date** |
+| -------------------- | --------------------- | -------- |
+| **Devnet Amplifier** | Pending               | TBD      |
+| **Stagenet**         | Pending               | TBD      |
+| **Testnet**          | Pending               | TBD      |
+| **Mainnet**          | Pending               | TBD      |
+
+[Release v1.4.9](https://github.com/axelarnetwork/axelar-core/releases/tag/v1.4.9)
+
+## Background
+
+`v1.4.9` is the recommended binary on the `v1.4.x` line. It is a drop-in patch on top of `v1.4.8`.
+
+### Changes since v1.4.8
+
+- **`vald` now broadcasts an empty vote when a gateway tx confirmation yields more than `MaxEventsPerVote` (500) events** ([#2357](https://github.com/axelarnetwork/axelar-core/pull/2357)). Before this fix, `vald` could not build a valid vote in that case, so the poll never completed and maintainer rewards for that poll were cleared. With the fix, `vald` casts an empty vote, the poll completes, and maintainer rewards are preserved. This is the only change in `v1.4.9` relative to `v1.4.8`.
+
+This is an off-chain `vald` fix. It is **not** consensus-breaking: there is no governance software-upgrade proposal, no `axelard` upgrade handler, and no block-time activation gate (unlike `v1.4.8`). Nodes running `v1.4.8` and `v1.4.9` interoperate, so the binary can be swapped at any time with no coordinated activation.
+
+No dependency versions change relative to `v1.4.8`: `libwasmvm` stays at `v2.2.6`, CometBFT at `v0.38.23`, Cosmos SDK at `v0.50.15`, and ibc-go at `v8.8.0`.
+
+For the full list of changes, see the [v1.4.9 changelog](https://github.com/axelarnetwork/axelar-core/blob/v1.4.9/CHANGELOG.md).
+
+## Migrate CosmWasm Contracts
+
+No Amplifier contract migrations are required for this release.
+
+## Deployment Steps for Axelar Maintainers
+
+There is no governance proposal and no coordinated activation for `v1.4.9`. The only action required is to get validator and maintainer nodes onto the `v1.4.9` binary.
+
+1. Inform validators of the `v1.4.9` `vald` fix. There is no activation time, so no hard deadline applies.
+2. Do a rolling binary swap so nodes move from `v1.4.8` to `v1.4.9` at a convenient time. Because the two versions interoperate, the fleet does not need to swap together.
+
+### Post-Upgrade Checklist for Maintainers
+
+- [ ] Validator nodes are running `v1.4.9`
+- [ ] Validator nodes continue producing blocks after the swap
+- [ ] `vald` gateway-tx confirmations with more than 500 events now complete with an empty vote instead of stalling the poll
+- [ ] Maintainer rewards are preserved for those polls
+- [ ] Testing
+    - [ ] General testing: GMP calls, IBC transfers, key rotation
+
+## Deployment Steps for Axelar Validators
+
+### Prerequisites
+
+- **Building from source:** If building from source, use `Go 1.25`. The recommended approach is static linking with `make build-static`, which avoids extra libwasmvm handling. As a fallback, if you need a dynamically linked binary using `make build`, make sure `libwasmvm` is `v2.2.6` (unchanged from `v1.4.8`).
+- **Latest prebuilt binaries:** Available on the [release page](https://github.com/axelarnetwork/axelar-core/releases/tag/v1.4.9). For Linux, we recommend the statically linked binary [axelard-linux-amd64-v1.4.9-static](https://github.com/axelarnetwork/axelar-core/releases/download/v1.4.9/axelard-linux-amd64-v1.4.9-static), which runs on any Linux distribution without requiring libwasmvm to be installed on your system.
+
+### Upgrade Process
+
+There is no stop-at-height and no activation time. Swap the binary at any convenient point:
+
+1. Stop the validator `axelard` node, `vald`, and `ampd` (if you are running a verifier).
+2. Replace the binaries:
+   - `axelard` to `v1.4.9`
+   - `vald` to `v1.4.9` (bundled in the same `axelard` build)
+   - `tofnd` stays at `v1.0.1` (no change vs. `v1.4.8`)
+3. No `app.toml` or `config.toml` changes are required relative to a node already running `v1.4.8`.
+4. Restart the validator node, `vald`, and `ampd` with the new binaries. When restarting `axelard` do not do a rollback.
+5. Please also upgrade any other Axelar nodes you operate (RPC nodes etc.), and restart your IBC relayer (e.g. hermes).
+
+### Post-Deployment Checklist
+
+- [ ] Verify that nodes are producing new blocks after the binary swap.
+- [ ] Verify the node is on `v1.4.9`.
+- [ ] Verify `vald` is participating in message validation, signing, heartbeats etc.
+
+## Troubleshooting
+
+### `libwasmvm` errors with the dynamic binary
+
+`libwasmvm` is `v2.2.6` (unchanged from `v1.4.8`). Replace the library on every dynamic-binary node before starting the new binary, otherwise it refuses to launch with a wasmvm version-mismatch error. Ensure the system environment variable `LD_LIBRARY_PATH` points to its correct location if using the dynamic binary. For the docker image no change is necessary.
+
+If you hit the error `undefined symbol: migrate_with_info`, switch to the statically linked binary ([axelard-linux-amd64-v1.4.9-static](https://github.com/axelarnetwork/axelar-core/releases/download/v1.4.9/axelard-linux-amd64-v1.4.9-static)). If you need a dynamically linked binary, make sure you have `libwasmvm` `v2.2.6`.
+
+### Rollback
+
+`v1.4.9` is an off-chain `vald` fix with no activation gate, so it can be freely rolled back to `v1.4.8` if needed. Rolling back only restores the previous `vald` voting behavior for gateway-tx confirmations above `MaxEventsPerVote`.


### PR DESCRIPTION
Adds the validator upgrade note for axelard v1.4.9, following the v1.4.6/v1.4.7/v1.4.8 pattern.

v1.4.9 is a drop-in patch on top of v1.4.8. The only change is [#2357](https://github.com/axelarnetwork/axelar-core/pull/2357): vald broadcasts an empty vote when a gateway tx confirmation yields more than MaxEventsPerVote (500) events, so the poll completes and maintainer rewards are not cleared.

It is not consensus-breaking: no governance proposal, no upgrade handler, no block-time activation gate. v1.4.8 and v1.4.9 nodes interoperate, so it is a plain binary swap with no coordinated activation. Dependencies are unchanged from v1.4.8.

Release: https://github.com/axelarnetwork/axelar-core/releases/tag/v1.4.9

Network deployment dates are left as Pending until it rolls out.