### PR TITLE
feat(cosmwasm): add jail-verifiers governance command

### DIFF
--- a/cosmwasm/rotate-signers.js
+++ b/cosmwasm/rotate-signers.js
@@ -96,6 +96,17 @@ const unauthorizeVerifier = async (client, config, options, [serviceName, verifi
     executeByGovernance(client, config, { ...options, contractName: 'ServiceRegistry', msg: JSON.stringify(message) }, undefined, fee);
 };
 
+const jailVerifier = async (client, config, options, [serviceName, verifiers], fee) => {
+    const message = {
+        jail_verifiers: {
+            service_name: serviceName,
+            verifiers,
+        },
+    };
+
+    executeByGovernance(client, config, { ...options, contractName: 'ServiceRegistry', msg: JSON.stringify(message) }, undefined, fee);
+};
+
 const rotateSigners = async (client, config, options, [sessionId], _fee) => {
     const { privateKey, chainName } = options;
 
@@ -175,6 +186,16 @@ const programHandler = () => {
             mainProcessor(unauthorizeVerifier, options, [serviceName, verifiers]);
         });
     addAmplifierOptions(unauthorizeVerifiersCmd, {
+        proposalOptions: true,
+    });
+
+    const jailVerifiersCmd = program
+        .command('jail-verifiers <serviceName> <verifiers...>')
+        .description('Jail verifiers')
+        .action((serviceName, verifiers, options) => {
+            mainProcessor(jailVerifier, options, [serviceName, verifiers]);
+        });
+    addAmplifierOptions(jailVerifiersCmd, {
         proposalOptions: true,
     });
 


### PR DESCRIPTION
Adds a `jail-verifiers <serviceName> <verifiers...>` subcommand to cosmwasm/rotate-signers.js, mirroring `unauthorize-verifiers`. It submits a `{"jail_verifiers":{service_name,verifiers}}` ExecuteMsg to the ServiceRegistry via governance (executeByGovernance) — the op is `#[permission(Governance)]`, so it can only run through a gov proposal.

`authorize`/`unauthorize` were already wired (#1244); `jail` was the missing member of the ServiceRegistry verifier-accountability trio, needed for incident response (block a misbehaving verifier from unbonding / claiming stake pending slashing).

### why
- For the [amplifier handbook](https://app.notion.com/p/commonprefix/network-wide-global-kill-switches-39fbf672de82819fae68cad2d90f4538). 

### how
<!-- An agent will fill this out -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CLI addition that reuses the existing governance proposal flow; no changes to on-chain logic or auth in this repo.
> 
> **Overview**
> Adds **`jail-verifiers <serviceName> <verifiers...>`** to the `rotate-signers` CLI, completing the ServiceRegistry verifier-accountability path alongside existing `authorize-verifiers` and `unauthorize-verifiers`.
> 
> The handler builds a `jail_verifiers` ExecuteMsg and submits it to **ServiceRegistry** through **`executeByGovernance`** (with `proposalOptions` on the command), so operators can propose jailing verifiers during incident response without a bespoke script.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2605b60cf50814fcc0efbb2fc71fe0aeda874f5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->