### PR TITLE
chore: axe legacy chains config

### DIFF
--- a/axelar-chains-config/info/mainnet.json
+++ b/axelar-chains-config/info/mainnet.json
@@ -677,6 +677,15 @@
           "predeployCodehash": "0x4fc776e1bb827206e031bd9e0ea8afccda553c870451ef4f5bfe33cae022be13",
           "deployer": "0xba76c6980428A0b10CFC5d8ccb61949677A61233",
           "codehash": "0x33780d536e3b7a7699be0f241c7c4627f6dcedb52126fdd3b619e9e41acf5f85"
+        },
+        "AXE": {
+          "tokenId": "0xbe1d7843a1110e56b4e14d8b6c78becf8fc328e44144266c148fffcf2a9f140e",
+          "name": "AXE",
+          "symbol": "AXE",
+          "decimals": 18,
+          "originChain": "xrpl-evm",
+          "address": "0x54BEdCF8fc56faf4FbffF88DBb3efb9BDa0c655f",
+          "notes": "Canonical mainnet AXE (home xrpl-evm, salt axe_AXE_mainnet_v2) registered on polygon legacy (consensus) ITS edge via deployRemoteInterchainToken (MOU-108). Deterministic address: polygon shares ITS proxy 0xB5FB4BE0… with xrpl-evm so Create3 yields the same address for the same tokenId. Cron wallet 0xba76… seeded 200 AXE from xrpl-evm for use as an ITS source."
         }
       },
       "explorer": {
@@ -808,6 +817,15 @@
           "predeployCodehash": "0x4fc776e1bb827206e031bd9e0ea8afccda553c870451ef4f5bfe33cae022be13",
           "deployer": "0xba76c6980428A0b10CFC5d8ccb61949677A61233",
           "codehash": "0x297f8236f2b5cb952a7dbc1fa87a54b573159e455055d67c6c1a362e2b2c2fab"
+        },
+        "AXE": {
+          "tokenId": "0xbe1d7843a1110e56b4e14d8b6c78becf8fc328e44144266c148fffcf2a9f140e",
+          "name": "AXE",
+          "symbol": "AXE",
+          "decimals": 18,
+          "originChain": "xrpl-evm",
+          "address": "0x54BEdCF8fc56faf4FbffF88DBb3efb9BDa0c655f",
+          "notes": "Canonical mainnet AXE (home xrpl-evm, salt axe_AXE_mainnet_v2) registered on moonbeam legacy (consensus) ITS edge via deployRemoteInterchainToken (MOU-108). Deterministic address: moonbeam shares ITS proxy 0xB5FB4BE0… with xrpl-evm so Create3 yields the same address for the same tokenId. Cron wallet 0xba76… seeded 200 AXE from xrpl-evm for use as an ITS source."
         }
       },
       "explorer": {
@@ -947,6 +965,15 @@
           "predeployCodehash": "0x4fc776e1bb827206e031bd9e0ea8afccda553c870451ef4f5bfe33cae022be13",
           "codehash": "0x970071662bc3afd04e7bed09c7fdfe27d410f0eab14314a39e4803427479265f",
           "deployer": "0xba76c6980428A0b10CFC5d8ccb61949677A61233"
+        },
+        "AXE": {
+          "tokenId": "0xbe1d7843a1110e56b4e14d8b6c78becf8fc328e44144266c148fffcf2a9f140e",
+          "name": "AXE",
+          "symbol": "AXE",
+          "decimals": 18,
+          "originChain": "xrpl-evm",
+          "address": "0x54BEdCF8fc56faf4FbffF88DBb3efb9BDa0c655f",
+          "notes": "Canonical mainnet AXE (home xrpl-evm, salt axe_AXE_mainnet_v2) registered on binance legacy (consensus) ITS edge via deployRemoteInterchainToken (MOU-108). Deterministic address: binance shares ITS proxy 0xB5FB4BE0… with xrpl-evm so Create3 yields the same address for the same tokenId. Cron wallet 0xba76… seeded 200 AXE from xrpl-evm for use as an ITS source."
         }
       },
       "explorer": {
@@ -1079,6 +1106,15 @@
           "predeployCodehash": "0x4fc776e1bb827206e031bd9e0ea8afccda553c870451ef4f5bfe33cae022be13",
           "deployer": "0xba76c6980428A0b10CFC5d8ccb61949677A61233",
           "codehash": "0xfc011a5cbbd9aa747ec8a2fea646ef09b15eb8859dac153984e1df481a8f2df0"
+        },
+        "AXE": {
+          "tokenId": "0xbe1d7843a1110e56b4e14d8b6c78becf8fc328e44144266c148fffcf2a9f140e",
+          "name": "AXE",
+          "symbol": "AXE",
+          "decimals": 18,
+          "originChain": "xrpl-evm",
+          "address": "0x54BEdCF8fc56faf4FbffF88DBb3efb9BDa0c655f",
+          "notes": "Canonical mainnet AXE (home xrpl-evm, salt axe_AXE_mainnet_v2) registered on arbitrum legacy (consensus) ITS edge via deployRemoteInterchainToken (MOU-108). Deterministic address: arbitrum shares ITS proxy 0xB5FB4BE0… with xrpl-evm so Create3 yields the same address for the same tokenId. Cron wallet 0xba76… seeded 200 AXE from xrpl-evm for use as an ITS source."
         }
       },
       "explorer": {
@@ -1212,6 +1248,15 @@
           "predeployCodehash": "0x4fc776e1bb827206e031bd9e0ea8afccda553c870451ef4f5bfe33cae022be13",
           "deployer": "0xba76c6980428A0b10CFC5d8ccb61949677A61233",
           "codehash": "0xfc011a5cbbd9aa747ec8a2fea646ef09b15eb8859dac153984e1df481a8f2df0"
+        },
+        "AXE": {
+          "tokenId": "0xbe1d7843a1110e56b4e14d8b6c78becf8fc328e44144266c148fffcf2a9f140e",
+          "name": "AXE",
+          "symbol": "AXE",
+          "decimals": 18,
+          "originChain": "xrpl-evm",
+          "address": "0x54BEdCF8fc56faf4FbffF88DBb3efb9BDa0c655f",
+          "notes": "Canonical mainnet AXE (home xrpl-evm, salt axe_AXE_mainnet_v2) registered on kava legacy (consensus) ITS edge via deployRemoteInterchainToken (MOU-108). Deterministic address: kava shares ITS proxy 0xB5FB4BE0… with xrpl-evm so Create3 yields the same address for the same tokenId. Cron wallet 0xba76… seeded 200 AXE from xrpl-evm for use as an ITS source."
         }
       },
       "explorer": {
@@ -1340,6 +1385,15 @@
           "predeployCodehash": "0x4fc776e1bb827206e031bd9e0ea8afccda553c870451ef4f5bfe33cae022be13",
           "deployer": "0xba76c6980428A0b10CFC5d8ccb61949677A61233",
           "codehash": "0xfc011a5cbbd9aa747ec8a2fea646ef09b15eb8859dac153984e1df481a8f2df0"
+        },
+        "AXE": {
+          "tokenId": "0xbe1d7843a1110e56b4e14d8b6c78becf8fc328e44144266c148fffcf2a9f140e",
+          "name": "AXE",
+          "symbol": "AXE",
+          "decimals": 18,
+          "originChain": "xrpl-evm",
+          "address": "0x54BEdCF8fc56faf4FbffF88DBb3efb9BDa0c655f",
+          "notes": "Canonical mainnet AXE (home xrpl-evm, salt axe_AXE_mainnet_v2) registered on filecoin legacy (consensus) ITS edge via deployRemoteInterchainToken (MOU-108). Deterministic address: filecoin shares ITS proxy 0xB5FB4BE0… with xrpl-evm so Create3 yields the same address for the same tokenId. Cron wallet 0xba76… seeded 200 AXE from xrpl-evm for use as an ITS source."
         }
       },
       "confirmations": 3,
@@ -1473,6 +1527,15 @@
           "predeployCodehash": "0x4fc776e1bb827206e031bd9e0ea8afccda553c870451ef4f5bfe33cae022be13",
           "deployer": "0xba76c6980428A0b10CFC5d8ccb61949677A61233",
           "codehash": "0xfc011a5cbbd9aa747ec8a2fea646ef09b15eb8859dac153984e1df481a8f2df0"
+        },
+        "AXE": {
+          "tokenId": "0xbe1d7843a1110e56b4e14d8b6c78becf8fc328e44144266c148fffcf2a9f140e",
+          "name": "AXE",
+          "symbol": "AXE",
+          "decimals": 18,
+          "originChain": "xrpl-evm",
+          "address": "0x54BEdCF8fc56faf4FbffF88DBb3efb9BDa0c655f",
+          "notes": "Canonical mainnet AXE (home xrpl-evm, salt axe_AXE_mainnet_v2) registered on optimism legacy (consensus) ITS edge via deployRemoteInterchainToken (MOU-108). Deterministic address: optimism shares ITS proxy 0xB5FB4BE0… with xrpl-evm so Create3 yields the same address for the same tokenId. Cron wallet 0xba76… seeded 200 AXE from xrpl-evm for use as an ITS source."
         }
       },
       "explorer": {
@@ -1610,6 +1673,15 @@
           "predeployCodehash": "0x4fc776e1bb827206e031bd9e0ea8afccda553c870451ef4f5bfe33cae022be13",
           "deployer": "0xba76c6980428A0b10CFC5d8ccb61949677A61233",
           "codehash": "0xfc011a5cbbd9aa747ec8a2fea646ef09b15eb8859dac153984e1df481a8f2df0"
+        },
+        "AXE": {
+          "tokenId": "0xbe1d7843a1110e56b4e14d8b6c78becf8fc328e44144266c148fffcf2a9f140e",
+          "name": "AXE",
+          "symbol": "AXE",
+          "decimals": 18,
+          "originChain": "xrpl-evm",
+          "address": "0x54BEdCF8fc56faf4FbffF88DBb3efb9BDa0c655f",
+          "notes": "Canonical mainnet AXE (home xrpl-evm, salt axe_AXE_mainnet_v2) registered on linea legacy (consensus) ITS edge via deployRemoteInterchainToken (MOU-108). Deterministic address: linea shares ITS proxy 0xB5FB4BE0… with xrpl-evm so Create3 yields the same address for the same tokenId. Cron wallet 0xba76… seeded 200 AXE from xrpl-evm for use as an ITS source."
         }
       },
       "explorer": {
@@ -1742,6 +1814,15 @@
           "predeployCodehash": "0x4fc776e1bb827206e031bd9e0ea8afccda553c870451ef4f5bfe33cae022be13",
           "deployer": "0xba76c6980428A0b10CFC5d8ccb61949677A61233",
           "codehash": "0xfc011a5cbbd9aa747ec8a2fea646ef09b15eb8859dac153984e1df481a8f2df0"
+        },
+        "AXE": {
+          "tokenId": "0xbe1d7843a1110e56b4e14d8b6c78becf8fc328e44144266c148fffcf2a9f140e",
+          "name": "AXE",
+          "symbol": "AXE",
+          "decimals": 18,
+          "originChain": "xrpl-evm",
+          "address": "0x54BEdCF8fc56faf4FbffF88DBb3efb9BDa0c655f",
+          "notes": "Canonical mainnet AXE (home xrpl-evm, salt axe_AXE_mainnet_v2) registered on base legacy (consensus) ITS edge via deployRemoteInterchainToken (MOU-108). Deterministic address: base shares ITS proxy 0xB5FB4BE0… with xrpl-evm so Create3 yields the same address for the same tokenId. Cron wallet 0xba76… seeded 200 AXE from xrpl-evm for use as an ITS source."
         }
       },
       "confirmations": 2,
@@ -1876,6 +1957,15 @@
           "predeployCodehash": "0x4fc776e1bb827206e031bd9e0ea8afccda553c870451ef4f5bfe33cae022be13",
           "deployer": "0xba76c6980428A0b10CFC5d8ccb61949677A61233",
           "codehash": "0xfc011a5cbbd9aa747ec8a2fea646ef09b15eb8859dac153984e1df481a8f2df0"
+        },
+        "AXE": {
+          "tokenId": "0xbe1d7843a1110e56b4e14d8b6c78becf8fc328e44144266c148fffcf2a9f140e",
+          "name": "AXE",
+          "symbol": "AXE",
+          "decimals": 18,
+          "originChain": "xrpl-evm",
+          "address": "0x54BEdCF8fc56faf4FbffF88DBb3efb9BDa0c655f",
+          "notes": "Canonical mainnet AXE (home xrpl-evm, salt axe_AXE_mainnet_v2) registered on mantle legacy (consensus) ITS edge via deployRemoteInterchainToken (MOU-108). Deterministic address: mantle shares ITS proxy 0xB5FB4BE0… with xrpl-evm so Create3 yields the same address for the same tokenId. Cron wallet 0xba76… seeded 200 AXE from xrpl-evm for use as an ITS source."
         }
       },
       "confirmations": 2,
@@ -2008,6 +2098,15 @@
           "predeployCodehash": "0x4fc776e1bb827206e031bd9e0ea8afccda553c870451ef4f5bfe33cae022be13",
           "deployer": "0xba76c6980428A0b10CFC5d8ccb61949677A61233",
           "codehash": "0xfc011a5cbbd9aa747ec8a2fea646ef09b15eb8859dac153984e1df481a8f2df0"
+        },
+        "AXE": {
+          "tokenId": "0xbe1d7843a1110e56b4e14d8b6c78becf8fc328e44144266c148fffcf2a9f140e",
+          "name": "AXE",
+          "symbol": "AXE",
+          "decimals": 18,
+          "originChain": "xrpl-evm",
+          "address": "0x54BEdCF8fc56faf4FbffF88DBb3efb9BDa0c655f",
+          "notes": "Canonical mainnet AXE (home xrpl-evm, salt axe_AXE_mainnet_v2) registered on scroll legacy (consensus) ITS edge via deployRemoteInterchainToken (MOU-108). Deterministic address: scroll shares ITS proxy 0xB5FB4BE0… with xrpl-evm so Create3 yields the same address for the same tokenId. Cron wallet 0xba76… seeded 200 AXE from xrpl-evm for use as an ITS source."
         }
       },
       "explorer": {
@@ -2230,6 +2329,15 @@
           "predeployCodehash": "0x4fc776e1bb827206e031bd9e0ea8afccda553c870451ef4f5bfe33cae022be13",
           "deployer": "0xba76c6980428A0b10CFC5d8ccb61949677A61233",
           "codehash": "0xfc011a5cbbd9aa747ec8a2fea646ef09b15eb8859dac153984e1df481a8f2df0"
+        },
+        "AXE": {
+          "tokenId": "0xbe1d7843a1110e56b4e14d8b6c78becf8fc328e44144266c148fffcf2a9f140e",
+          "name": "AXE",
+          "symbol": "AXE",
+          "decimals": 18,
+          "originChain": "xrpl-evm",
+          "address": "0x54BEdCF8fc56faf4FbffF88DBb3efb9BDa0c655f",
+          "notes": "Canonical mainnet AXE (home xrpl-evm, salt axe_AXE_mainnet_v2) registered on immutable legacy (consensus) ITS edge via deployRemoteInterchainToken (MOU-108). Deterministic address: immutable shares ITS proxy 0xB5FB4BE0… with xrpl-evm so Create3 yields the same address for the same tokenId. Cron wallet 0xba76… seeded 200 AXE from xrpl-evm for use as an ITS source."
         }
       },
       "gasOptions": {
@@ -2475,6 +2583,15 @@
           "predeployCodehash": "0x4fc776e1bb827206e031bd9e0ea8afccda553c870451ef4f5bfe33cae022be13",
           "deployer": "0xba76c6980428A0b10CFC5d8ccb61949677A61233",
           "codehash": "0xfc011a5cbbd9aa747ec8a2fea646ef09b15eb8859dac153984e1df481a8f2df0"
+        },
+        "AXE": {
+          "tokenId": "0xbe1d7843a1110e56b4e14d8b6c78becf8fc328e44144266c148fffcf2a9f140e",
+          "name": "AXE",
+          "symbol": "AXE",
+          "decimals": 18,
+          "originChain": "xrpl-evm",
+          "address": "0x54BEdCF8fc56faf4FbffF88DBb3efb9BDa0c655f",
+          "notes": "Canonical mainnet AXE (home xrpl-evm, salt axe_AXE_mainnet_v2) registered on blast legacy (consensus) ITS edge via deployRemoteInterchainToken (MOU-108). Deterministic address: blast shares ITS proxy 0xB5FB4BE0… with xrpl-evm so Create3 yields the same address for the same tokenId. Cron wallet 0xba76… seeded 200 AXE from xrpl-evm for use as an ITS source."
         }
       },
       "gasOptions": {

--- a/axelar-chains-config/info/mainnet.json
+++ b/axelar-chains-config/info/mainnet.json
@@ -270,6 +270,15 @@
           "predeployCodehash": "0x4fc776e1bb827206e031bd9e0ea8afccda553c870451ef4f5bfe33cae022be13",
           "deployer": "0xba76c6980428A0b10CFC5d8ccb61949677A61233",
           "codehash": "0x297f8236f2b5cb952a7dbc1fa87a54b573159e455055d67c6c1a362e2b2c2fab"
+        },
+        "AXE": {
+          "tokenId": "0xbe1d7843a1110e56b4e14d8b6c78becf8fc328e44144266c148fffcf2a9f140e",
+          "name": "AXE",
+          "symbol": "AXE",
+          "decimals": 18,
+          "originChain": "xrpl-evm",
+          "address": "0x54BEdCF8fc56faf4FbffF88DBb3efb9BDa0c655f",
+          "notes": "Canonical mainnet AXE (home xrpl-evm, salt axe_AXE_mainnet_v2) deployed on Ethereum legacy (consensus) ITS edge via deployRemoteInterchainToken. Same address as xrpl-evm/avalanche: all three share ITS proxy 0xB5FB4BE0… so Create3 yields the same address for the same tokenId. Used as destination in daily cron Avalanche->Ethereum legacy-legacy ITS route."
         }
       },
       "explorer": {
@@ -401,6 +410,15 @@
           "predeployCodehash": "0x4fc776e1bb827206e031bd9e0ea8afccda553c870451ef4f5bfe33cae022be13",
           "deployer": "0xba76c6980428A0b10CFC5d8ccb61949677A61233",
           "codehash": "0x7ae5bcb4ec7e41574c0f2f44dda624a45ea15ced386ab507551e55e8613c8d9d"
+        },
+        "AXE": {
+          "tokenId": "0xbe1d7843a1110e56b4e14d8b6c78becf8fc328e44144266c148fffcf2a9f140e",
+          "name": "AXE",
+          "symbol": "AXE",
+          "decimals": 18,
+          "originChain": "xrpl-evm",
+          "address": "0x54BEdCF8fc56faf4FbffF88DBb3efb9BDa0c655f",
+          "notes": "Canonical mainnet AXE (home xrpl-evm, salt axe_AXE_mainnet_v2) deployed on Avalanche legacy (consensus) ITS edge via deployRemoteInterchainToken. Address is deterministic: same ITS proxy 0xB5FB4BE0… as xrpl-evm yields same Create3 address for the same tokenId. Reused by daily cron legacy ITS routes (Avalanche↔Monad). Wallet supply seeded from xrpl-evm."
         }
       },
       "explorer": {

--- a/axelar-chains-config/info/mainnet.json
+++ b/axelar-chains-config/info/mainnet.json
@@ -278,7 +278,7 @@
           "decimals": 18,
           "originChain": "xrpl-evm",
           "address": "0x54BEdCF8fc56faf4FbffF88DBb3efb9BDa0c655f",
-          "notes": "Canonical mainnet AXE (home xrpl-evm, salt axe_AXE_mainnet_v2) deployed on Ethereum legacy (consensus) ITS edge via deployRemoteInterchainToken. Same address as xrpl-evm/avalanche: all three share ITS proxy 0xB5FB4BE0… so Create3 yields the same address for the same tokenId. Used as destination in daily cron Avalanche->Ethereum legacy-legacy ITS route."
+          "notes": "Canonical mainnet AXE (home xrpl-evm, salt axe_AXE_mainnet_v2)"
         }
       },
       "explorer": {
@@ -418,7 +418,7 @@
           "decimals": 18,
           "originChain": "xrpl-evm",
           "address": "0x54BEdCF8fc56faf4FbffF88DBb3efb9BDa0c655f",
-          "notes": "Canonical mainnet AXE (home xrpl-evm, salt axe_AXE_mainnet_v2) deployed on Avalanche legacy (consensus) ITS edge via deployRemoteInterchainToken. Address is deterministic: same ITS proxy 0xB5FB4BE0… as xrpl-evm yields same Create3 address for the same tokenId. Reused by daily cron legacy ITS routes (Avalanche↔Monad). Wallet supply seeded from xrpl-evm."
+          "notes": "Canonical mainnet AXE (home xrpl-evm, salt axe_AXE_mainnet_v2)"
         }
       },
       "explorer": {
@@ -685,7 +685,7 @@
           "decimals": 18,
           "originChain": "xrpl-evm",
           "address": "0x54BEdCF8fc56faf4FbffF88DBb3efb9BDa0c655f",
-          "notes": "Canonical mainnet AXE (home xrpl-evm, salt axe_AXE_mainnet_v2) registered on polygon legacy (consensus) ITS edge via deployRemoteInterchainToken (MOU-108). Deterministic address: polygon shares ITS proxy 0xB5FB4BE0… with xrpl-evm so Create3 yields the same address for the same tokenId. Cron wallet 0xba76… seeded 200 AXE from xrpl-evm for use as an ITS source."
+          "notes": "Canonical mainnet AXE (home xrpl-evm, salt axe_AXE_mainnet_v2)"
         }
       },
       "explorer": {
@@ -825,7 +825,7 @@
           "decimals": 18,
           "originChain": "xrpl-evm",
           "address": "0x54BEdCF8fc56faf4FbffF88DBb3efb9BDa0c655f",
-          "notes": "Canonical mainnet AXE (home xrpl-evm, salt axe_AXE_mainnet_v2) registered on moonbeam legacy (consensus) ITS edge via deployRemoteInterchainToken (MOU-108). Deterministic address: moonbeam shares ITS proxy 0xB5FB4BE0… with xrpl-evm so Create3 yields the same address for the same tokenId. Cron wallet 0xba76… seeded 200 AXE from xrpl-evm for use as an ITS source."
+          "notes": "Canonical mainnet AXE (home xrpl-evm, salt axe_AXE_mainnet_v2)"
         }
       },
       "explorer": {
@@ -973,7 +973,7 @@
           "decimals": 18,
           "originChain": "xrpl-evm",
           "address": "0x54BEdCF8fc56faf4FbffF88DBb3efb9BDa0c655f",
-          "notes": "Canonical mainnet AXE (home xrpl-evm, salt axe_AXE_mainnet_v2) registered on binance legacy (consensus) ITS edge via deployRemoteInterchainToken (MOU-108). Deterministic address: binance shares ITS proxy 0xB5FB4BE0… with xrpl-evm so Create3 yields the same address for the same tokenId. Cron wallet 0xba76… seeded 200 AXE from xrpl-evm for use as an ITS source."
+          "notes": "Canonical mainnet AXE (home xrpl-evm, salt axe_AXE_mainnet_v2)"
         }
       },
       "explorer": {
@@ -1114,7 +1114,7 @@
           "decimals": 18,
           "originChain": "xrpl-evm",
           "address": "0x54BEdCF8fc56faf4FbffF88DBb3efb9BDa0c655f",
-          "notes": "Canonical mainnet AXE (home xrpl-evm, salt axe_AXE_mainnet_v2) registered on arbitrum legacy (consensus) ITS edge via deployRemoteInterchainToken (MOU-108). Deterministic address: arbitrum shares ITS proxy 0xB5FB4BE0… with xrpl-evm so Create3 yields the same address for the same tokenId. Cron wallet 0xba76… seeded 200 AXE from xrpl-evm for use as an ITS source."
+          "notes": "Canonical mainnet AXE (home xrpl-evm, salt axe_AXE_mainnet_v2)"
         }
       },
       "explorer": {
@@ -1256,7 +1256,7 @@
           "decimals": 18,
           "originChain": "xrpl-evm",
           "address": "0x54BEdCF8fc56faf4FbffF88DBb3efb9BDa0c655f",
-          "notes": "Canonical mainnet AXE (home xrpl-evm, salt axe_AXE_mainnet_v2) registered on kava legacy (consensus) ITS edge via deployRemoteInterchainToken (MOU-108). Deterministic address: kava shares ITS proxy 0xB5FB4BE0… with xrpl-evm so Create3 yields the same address for the same tokenId. Cron wallet 0xba76… seeded 200 AXE from xrpl-evm for use as an ITS source."
+          "notes": "Canonical mainnet AXE (home xrpl-evm, salt axe_AXE_mainnet_v2)"
         }
       },
       "explorer": {
@@ -1393,7 +1393,7 @@
           "decimals": 18,
           "originChain": "xrpl-evm",
           "address": "0x54BEdCF8fc56faf4FbffF88DBb3efb9BDa0c655f",
-          "notes": "Canonical mainnet AXE (home xrpl-evm, salt axe_AXE_mainnet_v2) registered on filecoin legacy (consensus) ITS edge via deployRemoteInterchainToken (MOU-108). Deterministic address: filecoin shares ITS proxy 0xB5FB4BE0… with xrpl-evm so Create3 yields the same address for the same tokenId. Cron wallet 0xba76… seeded 200 AXE from xrpl-evm for use as an ITS source."
+          "notes": "Canonical mainnet AXE (home xrpl-evm, salt axe_AXE_mainnet_v2)"
         }
       },
       "confirmations": 3,
@@ -1535,7 +1535,7 @@
           "decimals": 18,
           "originChain": "xrpl-evm",
           "address": "0x54BEdCF8fc56faf4FbffF88DBb3efb9BDa0c655f",
-          "notes": "Canonical mainnet AXE (home xrpl-evm, salt axe_AXE_mainnet_v2) registered on optimism legacy (consensus) ITS edge via deployRemoteInterchainToken (MOU-108). Deterministic address: optimism shares ITS proxy 0xB5FB4BE0… with xrpl-evm so Create3 yields the same address for the same tokenId. Cron wallet 0xba76… seeded 200 AXE from xrpl-evm for use as an ITS source."
+          "notes": "Canonical mainnet AXE (home xrpl-evm, salt axe_AXE_mainnet_v2)"
         }
       },
       "explorer": {
@@ -1681,7 +1681,7 @@
           "decimals": 18,
           "originChain": "xrpl-evm",
           "address": "0x54BEdCF8fc56faf4FbffF88DBb3efb9BDa0c655f",
-          "notes": "Canonical mainnet AXE (home xrpl-evm, salt axe_AXE_mainnet_v2) registered on linea legacy (consensus) ITS edge via deployRemoteInterchainToken (MOU-108). Deterministic address: linea shares ITS proxy 0xB5FB4BE0… with xrpl-evm so Create3 yields the same address for the same tokenId. Cron wallet 0xba76… seeded 200 AXE from xrpl-evm for use as an ITS source."
+          "notes": "Canonical mainnet AXE (home xrpl-evm, salt axe_AXE_mainnet_v2)"
         }
       },
       "explorer": {
@@ -1822,7 +1822,7 @@
           "decimals": 18,
           "originChain": "xrpl-evm",
           "address": "0x54BEdCF8fc56faf4FbffF88DBb3efb9BDa0c655f",
-          "notes": "Canonical mainnet AXE (home xrpl-evm, salt axe_AXE_mainnet_v2) registered on base legacy (consensus) ITS edge via deployRemoteInterchainToken (MOU-108). Deterministic address: base shares ITS proxy 0xB5FB4BE0… with xrpl-evm so Create3 yields the same address for the same tokenId. Cron wallet 0xba76… seeded 200 AXE from xrpl-evm for use as an ITS source."
+          "notes": "Canonical mainnet AXE (home xrpl-evm, salt axe_AXE_mainnet_v2)"
         }
       },
       "confirmations": 2,
@@ -1965,7 +1965,7 @@
           "decimals": 18,
           "originChain": "xrpl-evm",
           "address": "0x54BEdCF8fc56faf4FbffF88DBb3efb9BDa0c655f",
-          "notes": "Canonical mainnet AXE (home xrpl-evm, salt axe_AXE_mainnet_v2) registered on mantle legacy (consensus) ITS edge via deployRemoteInterchainToken (MOU-108). Deterministic address: mantle shares ITS proxy 0xB5FB4BE0… with xrpl-evm so Create3 yields the same address for the same tokenId. Cron wallet 0xba76… seeded 200 AXE from xrpl-evm for use as an ITS source."
+          "notes": "Canonical mainnet AXE (home xrpl-evm, salt axe_AXE_mainnet_v2)"
         }
       },
       "confirmations": 2,
@@ -2106,7 +2106,7 @@
           "decimals": 18,
           "originChain": "xrpl-evm",
           "address": "0x54BEdCF8fc56faf4FbffF88DBb3efb9BDa0c655f",
-          "notes": "Canonical mainnet AXE (home xrpl-evm, salt axe_AXE_mainnet_v2) registered on scroll legacy (consensus) ITS edge via deployRemoteInterchainToken (MOU-108). Deterministic address: scroll shares ITS proxy 0xB5FB4BE0… with xrpl-evm so Create3 yields the same address for the same tokenId. Cron wallet 0xba76… seeded 200 AXE from xrpl-evm for use as an ITS source."
+          "notes": "Canonical mainnet AXE (home xrpl-evm, salt axe_AXE_mainnet_v2)"
         }
       },
       "explorer": {
@@ -2337,7 +2337,7 @@
           "decimals": 18,
           "originChain": "xrpl-evm",
           "address": "0x54BEdCF8fc56faf4FbffF88DBb3efb9BDa0c655f",
-          "notes": "Canonical mainnet AXE (home xrpl-evm, salt axe_AXE_mainnet_v2) registered on immutable legacy (consensus) ITS edge via deployRemoteInterchainToken (MOU-108). Deterministic address: immutable shares ITS proxy 0xB5FB4BE0… with xrpl-evm so Create3 yields the same address for the same tokenId. Cron wallet 0xba76… seeded 200 AXE from xrpl-evm for use as an ITS source."
+          "notes": "Canonical mainnet AXE (home xrpl-evm, salt axe_AXE_mainnet_v2)"
         }
       },
       "gasOptions": {
@@ -2591,7 +2591,7 @@
           "decimals": 18,
           "originChain": "xrpl-evm",
           "address": "0x54BEdCF8fc56faf4FbffF88DBb3efb9BDa0c655f",
-          "notes": "Canonical mainnet AXE (home xrpl-evm, salt axe_AXE_mainnet_v2) registered on blast legacy (consensus) ITS edge via deployRemoteInterchainToken (MOU-108). Deterministic address: blast shares ITS proxy 0xB5FB4BE0… with xrpl-evm so Create3 yields the same address for the same tokenId. Cron wallet 0xba76… seeded 200 AXE from xrpl-evm for use as an ITS source."
+          "notes": "Canonical mainnet AXE (home xrpl-evm, salt axe_AXE_mainnet_v2)"
         }
       },
       "gasOptions": {

--- a/axelar-chains-config/info/testnet.json
+++ b/axelar-chains-config/info/testnet.json
@@ -509,6 +509,15 @@
           "predeployCodehash": "0x4fc776e1bb827206e031bd9e0ea8afccda553c870451ef4f5bfe33cae022be13",
           "deployer": "0xba76c6980428A0b10CFC5d8ccb61949677A61233",
           "codehash": "0x486c91290d369662d6b62a2148003df09b6b2540725034002c69be9ccec2b6f8"
+        },
+        "AXE": {
+          "tokenId": "0xbcbec67efab1cf2e7a6d301d4374d0da5a05330d6936314d2a707841596ace92",
+          "name": "AXE",
+          "symbol": "AXE",
+          "decimals": 18,
+          "originChain": "monad-3",
+          "address": "0xdd648c3D2558167d919389E1b844509035bA90e8",
+          "notes": "Canonical testnet AXE (home monad-3) registered on moonbeam legacy (consensus) ITS edge via deployRemoteInterchainToken from monad-3 (MOU-108). Deterministic address: moonbeam shares ITS proxy 0xB5FB4BE0… so Create3 yields the same address for the same tokenId. Cron wallet 0xba76… seeded 200 AXE from monad-3."
         }
       },
       "explorer": {
@@ -759,6 +768,15 @@
           "predeployCodehash": "0x4fc776e1bb827206e031bd9e0ea8afccda553c870451ef4f5bfe33cae022be13",
           "deployer": "0xba76c6980428A0b10CFC5d8ccb61949677A61233",
           "codehash": "0x77e86f75c0b5a37cd17705700d78c77456653b604f45247f8ea9f8ebfbf6b029"
+        },
+        "AXE": {
+          "tokenId": "0xbcbec67efab1cf2e7a6d301d4374d0da5a05330d6936314d2a707841596ace92",
+          "name": "AXE",
+          "symbol": "AXE",
+          "decimals": 18,
+          "originChain": "monad-3",
+          "address": "0xdd648c3D2558167d919389E1b844509035bA90e8",
+          "notes": "Canonical testnet AXE (home monad-3) registered on kava legacy (consensus) ITS edge via deployRemoteInterchainToken from monad-3 (MOU-108). Deterministic address: kava shares ITS proxy 0xB5FB4BE0… so Create3 yields the same address for the same tokenId. Cron wallet 0xba76… seeded 200 AXE from monad-3."
         }
       },
       "explorer": {
@@ -874,6 +892,15 @@
           "predeployCodehash": "0x4fc776e1bb827206e031bd9e0ea8afccda553c870451ef4f5bfe33cae022be13",
           "deployer": "0xba76c6980428A0b10CFC5d8ccb61949677A61233",
           "codehash": "0x1f05ceab48052e86c780500ca6f2e84786ebd71537fcb6b8a6236d0c6ba6174e"
+        },
+        "AXE": {
+          "tokenId": "0xbcbec67efab1cf2e7a6d301d4374d0da5a05330d6936314d2a707841596ace92",
+          "name": "AXE",
+          "symbol": "AXE",
+          "decimals": 18,
+          "originChain": "monad-3",
+          "address": "0xdd648c3D2558167d919389E1b844509035bA90e8",
+          "notes": "Canonical testnet AXE (home monad-3) registered on filecoin-2 legacy (consensus) ITS edge via deployRemoteInterchainToken from monad-3 (MOU-108). Deterministic address: filecoin-2 shares ITS proxy 0xB5FB4BE0… so Create3 yields the same address for the same tokenId. Cron wallet 0xba76… seeded 200 AXE from monad-3."
         }
       },
       "explorer": {
@@ -1113,6 +1140,15 @@
           "predeployCodehash": "0x4fc776e1bb827206e031bd9e0ea8afccda553c870451ef4f5bfe33cae022be13",
           "deployer": "0xba76c6980428A0b10CFC5d8ccb61949677A61233",
           "codehash": "0x0afcb3c43205f100e66dfb328cde7c518026acf060e1b2d287c9b412f9546823"
+        },
+        "AXE": {
+          "tokenId": "0xbcbec67efab1cf2e7a6d301d4374d0da5a05330d6936314d2a707841596ace92",
+          "name": "AXE",
+          "symbol": "AXE",
+          "decimals": 18,
+          "originChain": "monad-3",
+          "address": "0xdd648c3D2558167d919389E1b844509035bA90e8",
+          "notes": "Canonical testnet AXE (home monad-3) registered on immutable legacy (consensus) ITS edge via deployRemoteInterchainToken from monad-3 (MOU-108). Deterministic address: immutable shares ITS proxy 0xB5FB4BE0… so Create3 yields the same address for the same tokenId. Cron wallet 0xba76… seeded 200 AXE from monad-3."
         }
       },
       "gasOptions": {
@@ -1230,6 +1266,15 @@
           "predeployCodehash": "0x4fc776e1bb827206e031bd9e0ea8afccda553c870451ef4f5bfe33cae022be13",
           "deployer": "0xba76c6980428A0b10CFC5d8ccb61949677A61233",
           "codehash": "0xf8bcaec89c550bc2eac4d275ddc9dcbefa4f62e29374439fea644d6ce4483827"
+        },
+        "AXE": {
+          "tokenId": "0xbcbec67efab1cf2e7a6d301d4374d0da5a05330d6936314d2a707841596ace92",
+          "name": "AXE",
+          "symbol": "AXE",
+          "decimals": 18,
+          "originChain": "monad-3",
+          "address": "0xdd648c3D2558167d919389E1b844509035bA90e8",
+          "notes": "Canonical testnet AXE (home monad-3) registered on arbitrum-sepolia legacy (consensus) ITS edge via deployRemoteInterchainToken from monad-3 (MOU-108). Deterministic address: arbitrum-sepolia shares ITS proxy 0xB5FB4BE0… so Create3 yields the same address for the same tokenId. Cron wallet 0xba76… seeded 200 AXE from monad-3."
         }
       },
       "explorer": {
@@ -1448,6 +1493,15 @@
           "predeployCodehash": "0x4fc776e1bb827206e031bd9e0ea8afccda553c870451ef4f5bfe33cae022be13",
           "deployer": "0xba76c6980428A0b10CFC5d8ccb61949677A61233",
           "codehash": "0x0afcb3c43205f100e66dfb328cde7c518026acf060e1b2d287c9b412f9546823"
+        },
+        "AXE": {
+          "tokenId": "0xbcbec67efab1cf2e7a6d301d4374d0da5a05330d6936314d2a707841596ace92",
+          "name": "AXE",
+          "symbol": "AXE",
+          "decimals": 18,
+          "originChain": "monad-3",
+          "address": "0xdd648c3D2558167d919389E1b844509035bA90e8",
+          "notes": "Canonical testnet AXE (home monad-3) registered on optimism-sepolia legacy (consensus) ITS edge via deployRemoteInterchainToken from monad-3 (MOU-108). Deterministic address: optimism-sepolia shares ITS proxy 0xB5FB4BE0… so Create3 yields the same address for the same tokenId. Cron wallet 0xba76… seeded 200 AXE from monad-3."
         }
       },
       "finality": "finalized",
@@ -1568,6 +1622,15 @@
           "predeployCodehash": "0x4fc776e1bb827206e031bd9e0ea8afccda553c870451ef4f5bfe33cae022be13",
           "deployer": "0xba76c6980428A0b10CFC5d8ccb61949677A61233",
           "codehash": "0x0afcb3c43205f100e66dfb328cde7c518026acf060e1b2d287c9b412f9546823"
+        },
+        "AXE": {
+          "tokenId": "0xbcbec67efab1cf2e7a6d301d4374d0da5a05330d6936314d2a707841596ace92",
+          "name": "AXE",
+          "symbol": "AXE",
+          "decimals": 18,
+          "originChain": "monad-3",
+          "address": "0xdd648c3D2558167d919389E1b844509035bA90e8",
+          "notes": "Canonical testnet AXE (home monad-3) registered on base-sepolia legacy (consensus) ITS edge via deployRemoteInterchainToken from monad-3 (MOU-108). Deterministic address: base-sepolia shares ITS proxy 0xB5FB4BE0… so Create3 yields the same address for the same tokenId. Cron wallet 0xba76… seeded 200 AXE from monad-3."
         }
       },
       "finality": "finalized",
@@ -1803,6 +1866,15 @@
           "predeployCodehash": "0x4fc776e1bb827206e031bd9e0ea8afccda553c870451ef4f5bfe33cae022be13",
           "deployer": "0xba76c6980428A0b10CFC5d8ccb61949677A61233",
           "codehash": "0x77e86f75c0b5a37cd17705700d78c77456653b604f45247f8ea9f8ebfbf6b029"
+        },
+        "AXE": {
+          "tokenId": "0xbcbec67efab1cf2e7a6d301d4374d0da5a05330d6936314d2a707841596ace92",
+          "name": "AXE",
+          "symbol": "AXE",
+          "decimals": 18,
+          "originChain": "monad-3",
+          "address": "0xdd648c3D2558167d919389E1b844509035bA90e8",
+          "notes": "Canonical testnet AXE (home monad-3) registered on mantle-sepolia legacy (consensus) ITS edge via deployRemoteInterchainToken from monad-3 (MOU-108). Deterministic address: mantle-sepolia shares ITS proxy 0xB5FB4BE0… so Create3 yields the same address for the same tokenId. Cron wallet 0xba76… seeded 200 AXE from monad-3."
         }
       },
       "finality": "finalized",
@@ -1910,6 +1982,15 @@
           "predeployCodehash": "0x4fc776e1bb827206e031bd9e0ea8afccda553c870451ef4f5bfe33cae022be13",
           "deployer": "0xba76c6980428A0b10CFC5d8ccb61949677A61233",
           "codehash": "0x0afcb3c43205f100e66dfb328cde7c518026acf060e1b2d287c9b412f9546823"
+        },
+        "AXE": {
+          "tokenId": "0xbcbec67efab1cf2e7a6d301d4374d0da5a05330d6936314d2a707841596ace92",
+          "name": "AXE",
+          "symbol": "AXE",
+          "decimals": 18,
+          "originChain": "monad-3",
+          "address": "0xdd648c3D2558167d919389E1b844509035bA90e8",
+          "notes": "Canonical testnet AXE (home monad-3) registered on polygon-sepolia legacy (consensus) ITS edge via deployRemoteInterchainToken from monad-3 (MOU-108). Deterministic address: polygon-sepolia shares ITS proxy 0xB5FB4BE0… so Create3 yields the same address for the same tokenId. Cron wallet 0xba76… seeded 200 AXE from monad-3."
         }
       },
       "explorer": {

--- a/axelar-chains-config/info/testnet.json
+++ b/axelar-chains-config/info/testnet.json
@@ -124,6 +124,15 @@
           "predeployCodehash": "0x4fc776e1bb827206e031bd9e0ea8afccda553c870451ef4f5bfe33cae022be13",
           "deployer": "0xba76c6980428A0b10CFC5d8ccb61949677A61233",
           "codehash": "0x0afcb3c43205f100e66dfb328cde7c518026acf060e1b2d287c9b412f9546823"
+        },
+        "AXE": {
+          "tokenId": "0xbcbec67efab1cf2e7a6d301d4374d0da5a05330d6936314d2a707841596ace92",
+          "name": "AXE",
+          "symbol": "AXE",
+          "decimals": 18,
+          "originChain": "monad-3",
+          "address": "0xdd648c3D2558167d919389E1b844509035bA90e8",
+          "notes": "Canonical testnet AXE (home monad-3) registered on ethereum-sepolia legacy (consensus) ITS edge. Destination of the daily cron Avalanche->Ethereum legacy->legacy ITS route. Same tokenId/address as the Avalanche legacy edge."
         }
       },
       "explorer": {
@@ -248,6 +257,15 @@
           "predeployCodehash": "0x4fc776e1bb827206e031bd9e0ea8afccda553c870451ef4f5bfe33cae022be13",
           "deployer": "0xba76c6980428A0b10CFC5d8ccb61949677A61233",
           "codehash": "0x989947b1646890093db39a46aad056df049d599345771681e66f7ececbe9f4db"
+        },
+        "AXE": {
+          "tokenId": "0xbcbec67efab1cf2e7a6d301d4374d0da5a05330d6936314d2a707841596ace92",
+          "name": "AXE",
+          "symbol": "AXE",
+          "decimals": 18,
+          "originChain": "monad-3",
+          "address": "0xdd648c3D2558167d919389E1b844509035bA90e8",
+          "notes": "Canonical testnet AXE (home monad-3) registered on Avalanche legacy (consensus) ITS edge. Reused by daily cron legacy ITS routes (Avalanche<->Monad legacy source, Avalanche->Ethereum legacy->legacy). Same 32-byte tokenId as monad-3/hedera; on-chain interchain-token address differs from monad-3 because Avalanche legacy ITS derives its own Create3 address. Wallet supply seeded from monad-3."
         }
       },
       "explorer": {

--- a/axelar-chains-config/info/testnet.json
+++ b/axelar-chains-config/info/testnet.json
@@ -132,7 +132,7 @@
           "decimals": 18,
           "originChain": "monad-3",
           "address": "0xdd648c3D2558167d919389E1b844509035bA90e8",
-          "notes": "Canonical testnet AXE (home monad-3) registered on ethereum-sepolia legacy (consensus) ITS edge. Destination of the daily cron Avalanche->Ethereum legacy->legacy ITS route. Same tokenId/address as the Avalanche legacy edge."
+          "notes": "Canonical testnet AXE (home monad-3)"
         }
       },
       "explorer": {
@@ -265,7 +265,7 @@
           "decimals": 18,
           "originChain": "monad-3",
           "address": "0xdd648c3D2558167d919389E1b844509035bA90e8",
-          "notes": "Canonical testnet AXE (home monad-3) registered on Avalanche legacy (consensus) ITS edge. Reused by daily cron legacy ITS routes (Avalanche<->Monad legacy source, Avalanche->Ethereum legacy->legacy). Same 32-byte tokenId as monad-3/hedera; on-chain interchain-token address differs from monad-3 because Avalanche legacy ITS derives its own Create3 address. Wallet supply seeded from monad-3."
+          "notes": "Canonical testnet AXE (home monad-3)"
         }
       },
       "explorer": {
@@ -517,7 +517,7 @@
           "decimals": 18,
           "originChain": "monad-3",
           "address": "0xdd648c3D2558167d919389E1b844509035bA90e8",
-          "notes": "Canonical testnet AXE (home monad-3) registered on moonbeam legacy (consensus) ITS edge via deployRemoteInterchainToken from monad-3 (MOU-108). Deterministic address: moonbeam shares ITS proxy 0xB5FB4BE0… so Create3 yields the same address for the same tokenId. Cron wallet 0xba76… seeded 200 AXE from monad-3."
+          "notes": "Canonical testnet AXE (home monad-3)"
         }
       },
       "explorer": {
@@ -776,7 +776,7 @@
           "decimals": 18,
           "originChain": "monad-3",
           "address": "0xdd648c3D2558167d919389E1b844509035bA90e8",
-          "notes": "Canonical testnet AXE (home monad-3) registered on kava legacy (consensus) ITS edge via deployRemoteInterchainToken from monad-3 (MOU-108). Deterministic address: kava shares ITS proxy 0xB5FB4BE0… so Create3 yields the same address for the same tokenId. Cron wallet 0xba76… seeded 200 AXE from monad-3."
+          "notes": "Canonical testnet AXE (home monad-3)"
         }
       },
       "explorer": {
@@ -900,7 +900,7 @@
           "decimals": 18,
           "originChain": "monad-3",
           "address": "0xdd648c3D2558167d919389E1b844509035bA90e8",
-          "notes": "Canonical testnet AXE (home monad-3) registered on filecoin-2 legacy (consensus) ITS edge via deployRemoteInterchainToken from monad-3 (MOU-108). Deterministic address: filecoin-2 shares ITS proxy 0xB5FB4BE0… so Create3 yields the same address for the same tokenId. Cron wallet 0xba76… seeded 200 AXE from monad-3."
+          "notes": "Canonical testnet AXE (home monad-3)"
         }
       },
       "explorer": {
@@ -1148,7 +1148,7 @@
           "decimals": 18,
           "originChain": "monad-3",
           "address": "0xdd648c3D2558167d919389E1b844509035bA90e8",
-          "notes": "Canonical testnet AXE (home monad-3) registered on immutable legacy (consensus) ITS edge via deployRemoteInterchainToken from monad-3 (MOU-108). Deterministic address: immutable shares ITS proxy 0xB5FB4BE0… so Create3 yields the same address for the same tokenId. Cron wallet 0xba76… seeded 200 AXE from monad-3."
+          "notes": "Canonical testnet AXE (home monad-3)"
         }
       },
       "gasOptions": {
@@ -1274,7 +1274,7 @@
           "decimals": 18,
           "originChain": "monad-3",
           "address": "0xdd648c3D2558167d919389E1b844509035bA90e8",
-          "notes": "Canonical testnet AXE (home monad-3) registered on arbitrum-sepolia legacy (consensus) ITS edge via deployRemoteInterchainToken from monad-3 (MOU-108). Deterministic address: arbitrum-sepolia shares ITS proxy 0xB5FB4BE0… so Create3 yields the same address for the same tokenId. Cron wallet 0xba76… seeded 200 AXE from monad-3."
+          "notes": "Canonical testnet AXE (home monad-3)"
         }
       },
       "explorer": {
@@ -1501,7 +1501,7 @@
           "decimals": 18,
           "originChain": "monad-3",
           "address": "0xdd648c3D2558167d919389E1b844509035bA90e8",
-          "notes": "Canonical testnet AXE (home monad-3) registered on optimism-sepolia legacy (consensus) ITS edge via deployRemoteInterchainToken from monad-3 (MOU-108). Deterministic address: optimism-sepolia shares ITS proxy 0xB5FB4BE0… so Create3 yields the same address for the same tokenId. Cron wallet 0xba76… seeded 200 AXE from monad-3."
+          "notes": "Canonical testnet AXE (home monad-3)"
         }
       },
       "finality": "finalized",
@@ -1630,7 +1630,7 @@
           "decimals": 18,
           "originChain": "monad-3",
           "address": "0xdd648c3D2558167d919389E1b844509035bA90e8",
-          "notes": "Canonical testnet AXE (home monad-3) registered on base-sepolia legacy (consensus) ITS edge via deployRemoteInterchainToken from monad-3 (MOU-108). Deterministic address: base-sepolia shares ITS proxy 0xB5FB4BE0… so Create3 yields the same address for the same tokenId. Cron wallet 0xba76… seeded 200 AXE from monad-3."
+          "notes": "Canonical testnet AXE (home monad-3)"
         }
       },
       "finality": "finalized",
@@ -1874,7 +1874,7 @@
           "decimals": 18,
           "originChain": "monad-3",
           "address": "0xdd648c3D2558167d919389E1b844509035bA90e8",
-          "notes": "Canonical testnet AXE (home monad-3) registered on mantle-sepolia legacy (consensus) ITS edge via deployRemoteInterchainToken from monad-3 (MOU-108). Deterministic address: mantle-sepolia shares ITS proxy 0xB5FB4BE0… so Create3 yields the same address for the same tokenId. Cron wallet 0xba76… seeded 200 AXE from monad-3."
+          "notes": "Canonical testnet AXE (home monad-3)"
         }
       },
       "finality": "finalized",
@@ -1990,7 +1990,7 @@
           "decimals": 18,
           "originChain": "monad-3",
           "address": "0xdd648c3D2558167d919389E1b844509035bA90e8",
-          "notes": "Canonical testnet AXE (home monad-3) registered on polygon-sepolia legacy (consensus) ITS edge via deployRemoteInterchainToken from monad-3 (MOU-108). Deterministic address: polygon-sepolia shares ITS proxy 0xB5FB4BE0… so Create3 yields the same address for the same tokenId. Cron wallet 0xba76… seeded 200 AXE from monad-3."
+          "notes": "Canonical testnet AXE (home monad-3)"
         }
       },
       "explorer": {


### PR DESCRIPTION
### why
- <!-- Explain the reason for this change -->

### how
<!-- An agent will fill this out -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wrong tokenId or address on any chain would misroute AXE bridges and tooling that read this config; changes are repetitive but operationally sensitive.
> 
> **Overview**
> Registers the **AXE** interchain token on many existing mainnet and testnet EVM chain entries in `axelar-chains-config`, so legacy chains pick up the same canonical AXE metadata as newer deployments.
> 
> On **mainnet**, each affected chain’s `contracts` map gains an `AXE` entry with shared `tokenId`, 18 decimals, home chain `xrpl-evm`, and token address `0x54BEdCF8fc56faf4FbffF88DBb3efb9BDa0c655f` (noted as canonical mainnet AXE, salt `axe_AXE_mainnet_v2`). The same block is repeated across the listed chains (e.g. Ethereum, Avalanche, Polygon, Moonbeam, BSC, Arbitrum, and other L2s in the diff).
> 
> On **testnet**, the same pattern adds `AXE` with testnet `tokenId`, home chain `monad-3`, and address `0xdd648c3D2558167d919389E1b844509035bA90e8` on each updated testnet chain (Sepolia-family and related entries in the diff). Each addition also fixes JSON structure by closing `AxelarServiceGovernance` before the new `AXE` sibling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0685c61cebf94ab04afedf6131dbaddfc3992346. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->