### PR TITLE
docs(axelard): add v1.4.10 release notes

### DIFF
--- a/releases/axelard/2026-07-v1.4.10.md
+++ b/releases/axelard/2026-07-v1.4.10.md
@@ -1,0 +1,118 @@
+# axelard v1.4.10
+
+|                | **Owner**                             |
+| -------------- | ------------------------------------- |
+| **Created By** | @jakovmitrovski, @h4writer, @dolfje |
+| **Deployment** | @jakovmitrovski, @h4writer, @dolfje |
+
+| **Network**          | **Deployment Status** | **Date**   |
+| -------------------- | --------------------- | ---------- |
+| **Devnet Amplifier** | Deployed              | 2026-07-20 |
+| **Stagenet**         | Deployed              | 2026-07-20 |
+| **Testnet**          | Deployed              | 2026-07-24 |
+| **Mainnet**          | Deployed              | 2026-07-28 |
+
+Release: [v1.4.10](https://github.com/axelarnetwork/axelar-core/releases/tag/v1.4.10)
+
+Changelog: [v1.4.10 changelog](https://github.com/axelarnetwork/axelar-core/blob/v1.4.10/CHANGELOG.md)
+
+## Background
+
+`v1.4.10` is the recommended binary on the `v1.4.x` line. It is a patch on top of `v1.4.9` and hardens the ABI inflation guard that was introduced in `v1.4.8`. `v1.4.10` is the version that should be deployed.
+
+### Changes since v1.4.9
+
+All changes come from a single PR, **Add extra guards for ABI encoding and decoding** ([#2362](https://github.com/axelarnetwork/axelar-core/pull/2362), private `#70`). It closes remaining ways to amplify decoding work through `ConstructWasmMessageV1` (the Amplifier → CosmWasm GMP translation path) that the `v1.4.8` guard did not cover:
+
+- **Argument types are now restricted to an allowlist.** `buildArguments` only accepts `bool`, `address`, `string`, `bytes`, `uint8`, `uint64` and `string[]`. Previously any type string that go-ethereum's `abi.NewType` accepted was allowed, including deeply nested tuple and array types whose construction alone is expensive.
+- **The inflation-cost budget is tightened from 1 MB to 50 KB** (`maxArgCost`). The old 1 MB value is kept as `oldMaxArgCost` and is used on the pre-activation code path so behavior before the activation time is unchanged.
+- **Empty dynamic arrays no longer cost zero.** A zero-length slice used to short-circuit to a cost of `0`, even though the decoder still materializes the element type. `walkElements` now walks the element type in a new type-only mode, and empty `string`/`bytes` elements count one word instead of zero, which removes a multiply-by-zero bypass in the cost accounting.
+- **`checkBrackets` (max 100 `[` across all argument types) and `ABIInflationGuard` now always run**, instead of only when the fix is active. Before the activation time the guard runs with the old 1 MB budget.
+
+This is a **consensus-breaking bug fix**, handled the same way as `v1.4.8`: there is **no** governance software-upgrade proposal and **no** `axelard` upgrade handler. The fix is gated by **block time** — every node running `v1.4.10` keeps the `v1.4.9` behavior until its network's activation timestamp, then switches to the tightened guards at the same block on every node, preserving consensus. The activation times in [`utils/timed_fix.go`](https://github.com/axelarnetwork/axelar-core/blob/v1.4.10/utils/timed_fix.go) were moved forward for this release (the `v1.4.8` timestamps have already passed, so they no longer gate anything). Operators only need to be running the `v1.4.10` binary **before** their network's activation time.
+
+No dependency versions change relative to `v1.4.9`: `libwasmvm` stays at `v2.2.6`, CometBFT at `v0.38.23`, Cosmos SDK at `v0.50.15`, and ibc-go at `v8.8.0`. `tofnd` stays at `v1.0.1`.
+
+## Migrate CosmWasm Contracts
+
+No Amplifier contract migrations are required for this upgrade.
+
+## Deployment Steps for Axelar Maintainers
+
+There is **no governance software-upgrade proposal** for `v1.4.10`. The fix is gated by block time in the binary, so the only action required is to get every validator onto the `v1.4.10` binary before its network's activation time.
+
+1. Inform all validators of the `v1.4.10` release and their network's activation time (see [Activation Times by Network](#activation-times-by-network)).
+2. Coordinate a rolling binary swap so that every validator is running `v1.4.10` **before** the activation time.
+3. As the activation time approaches, confirm that all validators (and other maintainer-operated nodes) are on `v1.4.10`. Any node still on `v1.4.9` at the activation time applies the looser guards and will halt with an `app hash` mismatch.
+
+### Post-Upgrade Checklist for Maintainers
+
+- [x] All validator nodes are running `v1.4.10` before the activation time
+- [x] All validator nodes continue producing blocks across the activation time
+- [x] No live signing/voting sessions are stuck after the activation time
+- [ ] Testing
+    - [x] General testing: GMP calls, IBC transfers, key rotation
+    - [x] Confirm Amplifier → CosmWasm GMP calls using the allowed argument types (`bool`, `address`, `string`, `bytes`, `uint8`, `uint64`, `string[]`) still route successfully
+    - [ ] Confirm payloads with argument types outside the allowlist, or above the 50 KB inflation-cost budget, are rejected once the fix is active
+
+## Deployment Steps for Axelar Validators
+
+### Prerequisites
+
+- **Building from source:** If building from source, use `Go 1.25`. The recommended approach is static linking with `make build-static`, which avoids extra libwasmvm handling. As a fallback, if you need a dynamically linked binary using `make build`, make sure `libwasmvm` is `v2.2.6` (unchanged from `v1.4.9`).
+- **Latest prebuilt binaries:** Available on the [release page](https://github.com/axelarnetwork/axelar-core/releases/tag/v1.4.10). For Linux, we recommend the statically linked binary [axelard-linux-amd64-v1.4.10-static](https://github.com/axelarnetwork/axelar-core/releases/download/v1.4.10/axelard-linux-amd64-v1.4.10-static), which runs on any Linux distribution without requiring libwasmvm to be installed on your system.
+
+### Activation Times by Network
+
+The consensus-breaking fix activates at the following block times (from [`utils/timed_fix.go`](https://github.com/axelarnetwork/axelar-core/blob/v1.4.10/utils/timed_fix.go)). You must be running `v1.4.10` before your network's activation time.
+
+| Network              | Chain ID              | Activation Time (UTC) | Activation Height |
+| -------------------- | --------------------- | --------------------- | ----------------- |
+| **Devnet Amplifier** | `*devnet*`            | 2026-07-20 08:00:00   | 25,166,493        |
+| **Stagenet**         | `axelar-stagenet-*`   | 2026-07-20 08:00:00   | 20,696,171        |
+| **Testnet**          | `axelar-testnet-*`    | 2026-07-24 08:00:00   | 33,966,022        |
+| **Mainnet**          | `axelar-dojo-1`       | 2026-07-28 08:00:00   | 32,221,200        |
+
+The activation height is the first block whose header time is at or after the activation time; it can be overridden per node with the `FIX_ACTIVATION_TIME` environment variable (RFC3339), which must not be used on a production network.
+
+### Upgrade Process
+
+Unlike a height-based upgrade, there is no coordinated stop-at-height. Swap the binary at any point before the activation time:
+
+1. Stop the validator `axelard` node, `vald`, and `ampd` (if you are running a verifier).
+2. Replace the binaries:
+   - `axelard` → `v1.4.10`
+   - `vald` → `v1.4.10` (bundled in the same `axelard` build)
+   - `tofnd` → `v1.0.1` (no change vs. `v1.4.9`)
+3. No `app.toml` / `config.toml` changes are required relative to a node already running `v1.4.9` with the post-v1.3.0 settings (`iavl-cache-size = 0`, `iavl-disable-fastnode = true`, `timeout_commit = 1s`).
+4. Restart the validator node, `vald`, and `ampd` with the new binaries. When restarting `axelard` do not do a rollback.
+5. Please also upgrade any other Axelar nodes you operate (RPC nodes etc.), and restart your IBC relayer (e.g. hermes).
+6. Confirm the node is on `v1.4.10` and producing blocks well before the activation time.
+
+### Post-Deployment Checklist
+
+- [x] Verify that nodes are producing new blocks after the binary swap.
+- [x] Verify the node is on `v1.4.10` before the activation time.
+- [x] Verify `vald` is participating in message validation, signing, heartbeats etc.
+- [x] Verify the node continues producing blocks across the activation time (no `app hash` mismatch).
+- [x] Test [GMP calls](../evm/EVM-GMP-Release-Template.md)
+
+## Troubleshooting
+
+### `app hash` mismatch
+
+Make sure all replicas across your fleet were swapped to `v1.4.10` before the activation time. A node still on `v1.4.9` (or with a different `FIX_ACTIVATION_TIME` override) at the activation time applies the looser ABI guards and will fork.
+
+### Replaying history from genesis
+
+`v1.4.10` also runs `checkBrackets` and the (1 MB) inflation guard on the pre-activation code path, which `v1.4.7` and earlier did not do at all. If you rebuild an archive node by replaying from genesis rather than from a snapshot, a historical `MsgRouteMessage` that trips those checks would be handled differently than it was originally. Restoring from a snapshot taken after the `v1.4.8` activation avoids this entirely.
+
+### `libwasmvm` errors with the dynamic binary
+
+`libwasmvm` is `v2.2.6` (unchanged from `v1.4.9`). Replace the library on every dynamic-binary node before starting the new binary, otherwise it refuses to launch with a wasmvm version-mismatch error. Ensure the system environment variable `LD_LIBRARY_PATH` points to its correct location if using the dynamic binary. For the docker image no change is necessary.
+
+If you hit the error `undefined symbol: migrate_with_info`, switch to the statically linked binary ([axelard-linux-amd64-v1.4.10-static](https://github.com/axelarnetwork/axelar-core/releases/download/v1.4.10/axelard-linux-amd64-v1.4.10-static)). If you need a dynamically linked binary, make sure you have `libwasmvm` `v2.2.6`.
+
+### Rollback
+
+This is a consensus-breaking fix. Before the activation time, `v1.4.10` behaves like `v1.4.9`, so a node can be freely rolled back to `v1.4.9`. **After the activation time there is no in-place rollback**: once the fix is active, reverting to `v1.4.9` (which lacks the tightened guards) could diverge from the rest of the network. If a rollback is required after activation, restore from a pre-activation snapshot.

--- a/releases/axelard/2026-07-v1.4.8.md
+++ b/releases/axelard/2026-07-v1.4.8.md
@@ -63,10 +63,10 @@ The consensus-breaking fix activates at the following block times (from [`utils/
 
 | Network              | Chain ID              | Activation Time (UTC) | Activation Height |
 | -------------------- | --------------------- | --------------------- |------------------ |
-| **Devnet Amplifier** | `*devnet*`            | 2026-07-02 12:00:00   | 31,168,834        |
-| **Stagenet**         | `axelar-stagenet-*`   | 2026-07-02 12:00:00   | 32,873,744        |
-| **Testnet**          | `axelar-testnet-*`    | 2026-07-03 08:00:00   | 19,736,228        |
-| **Mainnet**          | `axelar-dojo-1`       | 2026-07-07 08:00:00   | 24,047,518        |
+| **Devnet Amplifier** | `*devnet*`            | 2026-07-02 12:00:00   | 24,047,518        |
+| **Stagenet**         | `axelar-stagenet-*`   | 2026-07-02 12:00:00   | 19,736,228        |
+| **Testnet**          | `axelar-testnet-*`    | 2026-07-03 08:00:00   | 32,873,744        |
+| **Mainnet**          | `axelar-dojo-1`       | 2026-07-07 08:00:00   | 31,168,834        |
 
 ### Upgrade Process
 


### PR DESCRIPTION
### why
- Adds release notes for axelard v1.4.10, a consensus-breaking patch (PR #2362)
  tightening the ABI inflation guard introduced in v1.4.8. Activation is gated by
  block time, not a governance proposal, so the doc follows the v1.4.8 structure.
- Also corrects the activation-height column in the v1.4.8 notes: all four heights
  were real but assigned to the wrong networks (devnet↔mainnet and stagenet↔testnet
  were swapped). Verified against each chain's RPC.

### how
<!-- An agent will fill this out -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to release notes; no runtime or consensus logic is modified in this PR.
> 
> **Overview**
> Adds **axelard v1.4.10** release documentation (`releases/axelard/2026-07-v1.4.10.md`), mirroring the v1.4.8 time-gated upgrade pattern. The doc explains the consensus-breaking ABI inflation hardening from PR #2362 (type allowlist, 50 KB budget, empty-array cost fixes, always-on bracket/guard checks), per-network activation times/heights, maintainer and validator rollout steps, checklists, and troubleshooting (app hash, genesis replay, libwasmvm, rollback).
> 
> **Corrects the v1.4.8 activation-height table** so each network’s height matches RPC-verified values—previously devnet↔mainnet and stagenet↔testnet heights were swapped; UTC activation times are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 220f86bf77a7f3f62284d2574337429a0cccb8fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->