### PR TITLE
feat(evm): consensus gateway pause actions and deploy script rename

### DIFF
--- a/.github/workflows/test-evm.yaml
+++ b/.github/workflows/test-evm.yaml
@@ -156,9 +156,9 @@ jobs:
       - name: Deploy AxelarGasService using create2
         run: ts-node evm/deploy-upgradable.js -c AxelarGasService -m create2 -y
 
-      # same implementation address as the one deployed, since it's derivation must always be the same
+      # read the implementation deployed by the previous step
       - name: Generate AxelarGasService upgrade proposal via AxelarServiceGovernance
-        run: ts-node evm/governance.js schedule upgrade 2100-01-01T12:00:00 --targetContractName AxelarGasService --implementation 0x61678eED43cd62094BcEE9c725260F0b0ECfaE7c --contractName AxelarServiceGovernance --generate-only ./service-governance-axelargasservice-upgrade.json -y
+        run: ts-node evm/governance.js schedule upgrade 2100-01-01T12:00:00 --targetContractName AxelarGasService --implementation $(jq -r '.chains.test.contracts.AxelarGasService.implementation' ./axelar-chains-config/info/local.json) --contractName AxelarServiceGovernance --generate-only ./service-governance-axelargasservice-upgrade.json -y
 
       - name: Deploy ITS using create2
         run: ts-node evm/deploy-its.js -s "v1.0.0" -m create2 -y

--- a/.github/workflows/test-evm.yaml
+++ b/.github/workflows/test-evm.yaml
@@ -121,7 +121,7 @@ jobs:
         run: ts-node evm/deploy-amplifier-gateway.js --deployMethod create3 -s "AxelarAmplifierGateway v5.8" --owner 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --keyID 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --domainSeparator 0x361b9fa2ae14de79d4b32164841b42ebc840b9d3ddb98cba1a45dc79a13214fc -y
 
       - name: Deploy AxelarGateway
-        run: ts-node evm/deploy-gateway-v6.2.x.js --deployMethod create3 -s "AxelarGateway v6.2" --governance 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --mintLimiter 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --keyID 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 -y
+        run: ts-node evm/deploy-consensus-gateway.js --deployMethod create3 --governance 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --mintLimiter 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --keyID 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 -y
 
       - name: Call Method on Gateway
         run: ts-node evm/gateway.js --action callContract --destinationChain test2 -y
@@ -215,7 +215,7 @@ jobs:
           jq '.chains.test += {"gasOptions": {"gasLimit": 8000000}} | .chains.test.contracts.AxelarGateway += {"gasOptions": {"gasLimit": 8000000}}' ./axelar-chains-config/info/local.json > temp.json && mv temp.json ./axelar-chains-config/info/local.json
 
       - name: Redeploy AxelarGateway with gasOptions
-        run: ts-node evm/deploy-gateway-v6.2.x.js -m create3 -s "AxelarGateway v6.2" --governance 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --mintLimiter 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --keyID 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 -y
+        run: ts-node evm/deploy-consensus-gateway.js -m create3 --governance 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --mintLimiter 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --keyID 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 -y
 
       - name: Redeploy ITS with gasOptions in Chain Config
         run: ts-node evm/deploy-its.js -s "v1.0.0" -m create2 -y

--- a/evm/README.md
+++ b/evm/README.md
@@ -47,17 +47,17 @@ ts-node evm/gateway.js --action submitProof --multisigSessionId [session id]
 
 Deploy the original Axelar gateway contract for legacy consensus-based connection. Set the governance and mint limiter via the `--governance` and `--mintLimiter` flags.
 
-`ts-node evm/deploy-gateway-v6.2.x.js`
+`ts-node evm/deploy-consensus-gateway.js`
 
 ## Gateway Upgrade
 
 1. When upgrading the gateway, the proxy contract will be reused.
 2. Depending on the upgrade process, Axelar auth and token deployer helper contracts might be reused as well.
-3. `ts-node evm/deploy-gateway-v6.2.x.js --reuseProxy` OR
-4. `ts-node evm/deploy-gateway-v6.2.x.js --reuseProxy --reuseHelpers`
+3. `ts-node evm/deploy-consensus-gateway.js --reuseProxy` OR
+4. `ts-node evm/deploy-consensus-gateway.js --reuseProxy --reuseHelpers`
 5. This sets the new `implementation` in the chain config.
 6. Upgrade to the new implementation contract
-   `ts-node evm/deploy-gateway-v6.2.x.js --upgrade`
+   `ts-node evm/deploy-consensus-gateway.js --upgrade`
 
 ## AxelarGasService
 

--- a/evm/contracts-deployment-test.js
+++ b/evm/contracts-deployment-test.js
@@ -25,7 +25,7 @@ async function processCommand(_axelar, chain, _chains, options) {
     const cmds = [
         `ts-node evm/deploy-contract.js -c ConstAddressDeployer -m create --artifactPath ../evm/legacy/ConstAddressDeployer.json`,
         `ts-node evm/deploy-contract.js -c Create3Deployer -m create2`,
-        `ts-node evm/deploy-gateway-v6.2.x.js -m create3 --keyID ${wallet.address} --mintLimiter ${wallet.address} --governance ${wallet.address}`,
+        `ts-node evm/deploy-consensus-gateway.js -m create3 --keyID ${wallet.address} --mintLimiter ${wallet.address} --governance ${wallet.address}`,
         `ts-node evm/gateway.js --action params`,
         `ts-node evm/deploy-contract.js -c Operators -m create2`,
         `ts-node evm/deploy-upgradable.js -c AxelarGasService -m ${deploymentMethod} --args '${argsAxelarGasService}'`,

--- a/evm/deploy-consensus-gateway.js
+++ b/evm/deploy-consensus-gateway.js
@@ -228,7 +228,7 @@ async function deploy(axelar, chain, chains, options) {
     printInfo(`Deploying gateway implementation contract`);
     printInfo('Gateway Implementation args', `${auth.address},${tokenDeployer.address}`);
 
-    const salt = 'AxelarGateway v6.2' + (options.salt || '');
+    const salt = options.salt || 'AxelarGateway';
 
     let implementation;
 
@@ -501,7 +501,7 @@ async function main(options) {
 async function programHandler() {
     const program = new Command();
 
-    program.name('deploy-gateway-v6.2.x').description('Deploy gateway v6.2.x');
+    program.name('deploy-consensus-gateway').description('Deploy the consensus (legacy) AxelarGateway');
 
     addEvmOptions(program, { salt: true, deployMethod: 'create', skipExisting: true, upgrade: true, predictOnly: true });
 

--- a/evm/docs/emergency-response.md
+++ b/evm/docs/emergency-response.md
@@ -8,7 +8,7 @@ Actions that require governance proposal submission, voting period, and timelock
 **Upgrade**
 
 - **Before upgrading**: Deploy new implementation with `--reuseProxy` flag:
-  - **Legacy connection**: Use `deploy-gateway-v6.2.x.js` with `--reuseProxy`. See [Gateway Upgrade](../README.md#gateway-upgrade).
+  - **Legacy connection**: Use `deploy-consensus-gateway.js` with `--reuseProxy`. See [Gateway Upgrade](../README.md#gateway-upgrade).
   - **Amplifier connection**: Use `deploy-amplifier-gateway.js` with `--reuseProxy`. See [Axelar Amplifier Gateway](../README.md#axelar-amplifier-gateway).
 - Replace `schedule` with `schedule-operator` to skip timelock.
 - Documentation: [Upgrade Workflow](./governance-workflows.md#upgrade-workflow)

--- a/evm/gateway.js
+++ b/evm/gateway.js
@@ -581,9 +581,7 @@ async function processCommand(axelar, chain, _chains, options) {
         }
 
         case 'setPauseStatus': {
-            if (contracts.AxelarGateway?.connectionType !== 'amplifier') {
-                throw new Error('setPauseStatus is only available for Amplifier Gateway');
-            }
+            const isAmplifierGateway = contracts.AxelarGateway?.connectionType === 'amplifier';
 
             if (options.pause !== 'true' && options.pause !== 'false') {
                 throw new Error(`Invalid --pause value '${options.pause}', expected 'true' or 'false'`);
@@ -599,28 +597,51 @@ async function processCommand(axelar, chain, _chains, options) {
                 return;
             }
 
-            const operator = await gateway.operator();
-            const owner = await gateway.owner();
-            const isOperator = operator.toLowerCase() === walletAddress.toLowerCase();
-            const isOwner = owner.toLowerCase() === walletAddress.toLowerCase();
+            if (isAmplifierGateway) {
+                const operator = await gateway.operator();
+                const owner = await gateway.owner();
+                const isOperator = operator.toLowerCase() === walletAddress.toLowerCase();
+                const isOwner = owner.toLowerCase() === walletAddress.toLowerCase();
 
-            if (options.governance) {
-                const { data: calldata } = await gateway.populateTransaction.setPauseStatus(isPaused, gasOptions);
+                if (options.governance) {
+                    const { data: calldata } = await gateway.populateTransaction.setPauseStatus(isPaused, gasOptions);
 
-                return createGovernanceProposal({
-                    chain,
-                    options,
-                    targetAddress: gatewayAddress,
-                    calldata,
-                    ProposalType,
-                    encodeGovernanceProposal,
-                    createGMPProposalJSON,
-                    dateToEta,
-                });
-            }
+                    return createGovernanceProposal({
+                        chain,
+                        options,
+                        targetAddress: gatewayAddress,
+                        calldata,
+                        ProposalType,
+                        encodeGovernanceProposal,
+                        createGMPProposalJSON,
+                        dateToEta,
+                    });
+                }
 
-            if (!isOperator && !isOwner) {
-                throw new Error(`Caller ${walletAddress} is neither the operator (${operator}) nor the owner (${owner})`);
+                if (!isOperator && !isOwner) {
+                    throw new Error(`Caller ${walletAddress} is neither the operator (${operator}) nor the owner (${owner})`);
+                }
+            } else {
+                // Consensus gateway authorizes via onlyPauserOrGovernance. The pauser is an
+                // emergency role that bypasses the governance timelock, so this is a direct tx.
+                if (options.governance) {
+                    throw new Error(
+                        'The --governance flow submits a legacy CallContractsProposal that axelar-core no longer routes. Use: governance.js schedule raw <activationTime> --target <gateway> --calldata <calldata>',
+                    );
+                }
+
+                const pauserAddress = await gateway.pauser();
+                const governanceAddress = await gateway.governance();
+                printInfo('Gateway pauser', pauserAddress);
+
+                const isPauser = pauserAddress.toLowerCase() === walletAddress.toLowerCase();
+                const isGovernance = governanceAddress.toLowerCase() === walletAddress.toLowerCase();
+
+                if (!isPauser && !isGovernance) {
+                    throw new Error(
+                        `Caller ${walletAddress} is neither the pauser (${pauserAddress}) nor the governance (${governanceAddress})`,
+                    );
+                }
             }
 
             if (prompt(`Proceed with setting pause status to ${chalk.cyan(isPaused)}`, yes)) {
@@ -640,6 +661,62 @@ async function processCommand(axelar, chain, _chains, options) {
 
             const updatedPauseStatus = await gateway.paused();
             printInfo('New pause status', updatedPauseStatus);
+
+            break;
+        }
+
+        case 'paused': {
+            printInfo('Gateway paused', await gateway.paused());
+            break;
+        }
+
+        case 'pauser': {
+            if (contracts.AxelarGateway?.connectionType === 'amplifier') {
+                throw new Error('pauser is only available for consensus gateways');
+            }
+
+            printInfo('Gateway pauser', await gateway.pauser());
+            break;
+        }
+
+        case 'transferPauser': {
+            if (contracts.AxelarGateway?.connectionType === 'amplifier') {
+                throw new Error('transferPauser is only available for consensus gateways');
+            }
+
+            const newPauser = options.destination;
+
+            if (!isValidAddress(newPauser)) {
+                throw new Error('Invalid new pauser address');
+            }
+
+            const currPauser = await gateway.pauser();
+            const governanceAddress = await gateway.governance();
+            printInfo('Current pauser', currPauser);
+
+            const isPauser = currPauser.toLowerCase() === walletAddress.toLowerCase();
+            const isGovernance = governanceAddress.toLowerCase() === walletAddress.toLowerCase();
+
+            if (!isPauser && !isGovernance) {
+                throw new Error(
+                    `Caller ${walletAddress} is neither the pauser (${currPauser}) nor the governance (${governanceAddress}). If governance is a contract, route this through governance.js schedule raw instead.`,
+                );
+            }
+
+            if (prompt(`Proceed with pauser transfer to ${chalk.cyan(newPauser)}`, yes)) {
+                return;
+            }
+
+            const tx = await gateway.transferPauser(newPauser, gasOptions);
+            printInfo('Transfer pauser tx', tx.hash);
+
+            const receipt = await tx.wait(chain.confirmations);
+
+            if (!wasEventEmitted(receipt, gateway, 'PauserTransferred')) {
+                throw new Error('Event not emitted in receipt.');
+            }
+
+            printInfo('New pauser', await gateway.pauser());
 
             break;
         }
@@ -781,6 +858,9 @@ if (require.main === module) {
                 'submitProof',
                 'transferOperatorship',
                 'setPauseStatus',
+                'paused',
+                'pauser',
+                'transferPauser',
             ])
             .makeOptionMandatory(true),
     );

--- a/evm/index.js
+++ b/evm/index.js
@@ -3,7 +3,7 @@
 const { printObj, readJSON, writeJSON, importNetworks, verifyContract, getBytecodeHash } = require('./utils');
 const { deployITS } = require('./deploy-its');
 const { deployAmplifierGateway } = require('./deploy-amplifier-gateway');
-const { deployLegacyGateway } = require('./deploy-gateway-v6.2.x');
+const { deployLegacyGateway } = require('./deploy-consensus-gateway');
 
 module.exports = {
     printObj,

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@axelar-network/axelar-cgp-solidity": "6.4.0",
+        "@axelar-network/axelar-cgp-solidity": "6.5.0",
         "@axelar-network/axelar-cgp-sui": "1.2.0",
         "@axelar-network/axelar-gmp-sdk-solidity": "6.2.0",
         "@axelar-network/interchain-token-service": "2.2.0",
@@ -205,20 +205,22 @@
       "dev": true
     },
     "node_modules/@axelar-network/axelar-cgp-solidity": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@axelar-network/axelar-cgp-solidity/-/axelar-cgp-solidity-6.4.0.tgz",
-      "integrity": "sha512-Xnw5xi234B1cmTCzgudV8zq+DDjJ1d1U362CM0vKH1FWmZprKIdqgmOYkiRyu+QiVhnznKiBURiSEHVrNjtYpw==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@axelar-network/axelar-cgp-solidity/-/axelar-cgp-solidity-6.5.0.tgz",
+      "integrity": "sha512-y/XjHToyZvAwheo2PxG2TOsphCy26GqaNBv4YGacVEF0PN7Yb6G/jKLhfVHSl8IaLdHj1ZJqzRnFIPK9lhO18A==",
+      "license": "MIT",
       "dependencies": {
-        "@axelar-network/axelar-gmp-sdk-solidity": "5.10.0"
+        "@axelar-network/axelar-gmp-sdk-solidity": "6.1.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@axelar-network/axelar-cgp-solidity/node_modules/@axelar-network/axelar-gmp-sdk-solidity": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/@axelar-network/axelar-gmp-sdk-solidity/-/axelar-gmp-sdk-solidity-5.10.0.tgz",
-      "integrity": "sha512-s8SImALvYB+5AeiT3tbfWNBI2Mhqw1x91i/zM3DNpVUCnAR2HKtsB9T84KnUn/OJjOVgb4h0lv7q9smeYniRPw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@axelar-network/axelar-gmp-sdk-solidity/-/axelar-gmp-sdk-solidity-6.1.0.tgz",
+      "integrity": "sha512-//m3rPb/mRpyzy4WXrrZN/5Z21PW1l7mHmn4cCujorTQeMwaPTecWq/5s15iemmOvr2xVozRWJ5vGbsRfcXn7A==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
@@ -429,10 +431,52 @@
         "node": ">=18"
       }
     },
+    "node_modules/@axelar-network/interchain-token-service-v2.1.1/node_modules/@axelar-network/axelar-cgp-solidity": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@axelar-network/axelar-cgp-solidity/-/axelar-cgp-solidity-6.4.0.tgz",
+      "integrity": "sha512-Xnw5xi234B1cmTCzgudV8zq+DDjJ1d1U362CM0vKH1FWmZprKIdqgmOYkiRyu+QiVhnznKiBURiSEHVrNjtYpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@axelar-network/axelar-gmp-sdk-solidity": "5.10.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@axelar-network/interchain-token-service-v2.1.1/node_modules/@axelar-network/axelar-cgp-solidity/node_modules/@axelar-network/axelar-gmp-sdk-solidity": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@axelar-network/axelar-gmp-sdk-solidity/-/axelar-gmp-sdk-solidity-5.10.0.tgz",
+      "integrity": "sha512-s8SImALvYB+5AeiT3tbfWNBI2Mhqw1x91i/zM3DNpVUCnAR2HKtsB9T84KnUn/OJjOVgb4h0lv7q9smeYniRPw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@axelar-network/interchain-token-service-v2.1.1/node_modules/@axelar-network/axelar-gmp-sdk-solidity": {
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/@axelar-network/axelar-gmp-sdk-solidity/-/axelar-gmp-sdk-solidity-6.0.4.tgz",
       "integrity": "sha512-o8pv+krIAlEwzid0Ac8qwykDsavc+1DRPvyFQ3V0R0zTQFtYLJIIXXXt7FRb8b+LJDAuX+E0bB3N2X+hlcxk/g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@axelar-network/interchain-token-service/node_modules/@axelar-network/axelar-cgp-solidity": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@axelar-network/axelar-cgp-solidity/-/axelar-cgp-solidity-6.4.0.tgz",
+      "integrity": "sha512-Xnw5xi234B1cmTCzgudV8zq+DDjJ1d1U362CM0vKH1FWmZprKIdqgmOYkiRyu+QiVhnznKiBURiSEHVrNjtYpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@axelar-network/axelar-gmp-sdk-solidity": "5.10.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@axelar-network/interchain-token-service/node_modules/@axelar-network/axelar-cgp-solidity/node_modules/@axelar-network/axelar-gmp-sdk-solidity": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@axelar-network/axelar-gmp-sdk-solidity/-/axelar-gmp-sdk-solidity-5.10.0.tgz",
+      "integrity": "sha512-s8SImALvYB+5AeiT3tbfWNBI2Mhqw1x91i/zM3DNpVUCnAR2HKtsB9T84KnUn/OJjOVgb4h0lv7q9smeYniRPw==",
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/axelarnetwork/axelar-contract-deployments#readme",
   "dependencies": {
-    "@axelar-network/axelar-cgp-solidity": "6.4.0",
+    "@axelar-network/axelar-cgp-solidity": "6.5.0",
     "@axelar-network/axelar-cgp-sui": "1.2.0",
     "@axelar-network/axelar-gmp-sdk-solidity": "6.2.0",
     "@axelar-network/interchain-token-service": "2.2.0",
@@ -57,11 +57,11 @@
   },
   "devDependencies": {
     "@aikidosec/safe-chain": "1.0.18",
-    "@sentry/node": "9.47.1",
     "@ledgerhq/hw-transport-node-hid": "^6.27.21",
     "@nomicfoundation/hardhat-toolbox": "^2.0.2",
     "@nomiclabs/hardhat-ethers": "^2.2.3",
     "@openzeppelin/defender-relay-client": "^1.54.1",
+    "@sentry/node": "9.47.1",
     "@trivago/prettier-plugin-sort-imports": "^5.2.2",
     "@typechain/ethers-v5": "^10.2.1",
     "@typechain/hardhat": "^6.1.6",


### PR DESCRIPTION
### why

Two prerequisites for rolling the pausable consensus gateway (cgp-solidity #318, shipping in v6.5.0) out to the legacy EVM fleet.

1. `gateway.js --action setPauseStatus` was amplifier-only and authorized via `operator()`/`owner()`. Consensus gateways gain a pauser role in v6.5.0 and had no tooling at all.
2. `evm/deploy-gateway-v6.2.x.js` has been misnamed since v6.2, and its salt hardcoded `AxelarGateway v6.2` as a *prefix* that `--salt` could only append to. CI was consequently deploying with the salt `AxelarGateway v6.2AxelarGateway v6.2`.

### how

Pause actions:

- `setPauseStatus` now branches on `connectionType`. Consensus authorizes via `pauser()`/`governance()`, matching the contract's `onlyPauserOrGovernance`. The amplifier path is unchanged.
- New `paused` and `pauser` read actions, plus `transferPauser`.
- Consensus combined with `--governance` throws and points at `governance.js schedule raw`. 