### PR TITLE
feat(evm): add --authModule override to consensus gateway deploy

### DIFF
--- a/evm/consensus-auth.js
+++ b/evm/consensus-auth.js
@@ -23,7 +23,7 @@ const {
 } = require('./utils');
 const { addEvmOptions } = require('./cli-utils');
 const { getWallet } = require('./sign-utils');
-const { getAuthParams } = require('./deploy-consensus-gateway');
+const { getAuthParams, OLD_KEY_RETENTION } = require('./deploy-consensus-gateway');
 
 const AxelarGateway = require('@axelar-network/axelar-cgp-solidity/artifacts/contracts/AxelarGateway.sol/AxelarGateway.json');
 const AxelarAuthWeighted = require('@axelar-network/axelar-cgp-solidity/artifacts/contracts/auth/AxelarAuthWeighted.sol/AxelarAuthWeighted.json');
@@ -31,9 +31,6 @@ const IDeployer = require('@axelar-network/axelar-gmp-sdk-solidity/interfaces/ID
 
 // deploying with no seed keeps the init code, and therefore the CREATE2 address, independent of the operator sets
 const EMPTY_SEED = [[]];
-
-// AxelarAuthWeighted rejects a proof whose operator set is this many epochs behind the current one
-const OLD_KEY_RETENTION = 16;
 
 function authFactory(wallet) {
     return new ContractFactory(AxelarAuthWeighted.abi, AxelarAuthWeighted.bytecode, wallet);

--- a/evm/consensus-auth.js
+++ b/evm/consensus-auth.js
@@ -364,7 +364,9 @@ async function handoff(axelar, chain, chains, options) {
     printInfo('Transfer ownership tx', tx.hash);
     await tx.wait(chain.confirmations);
 
-    await reportState(auth, proxy);
+    if (!(await reportState(auth, proxy))) {
+        throw new Error(`Ownership did not transfer to ${proxy}; auth is not ready, run \`verify\``);
+    }
 
     printInfo('Auth module ready', address);
 }

--- a/evm/deploy-consensus-gateway.js
+++ b/evm/deploy-consensus-gateway.js
@@ -83,6 +83,16 @@ async function deploy(axelar, chain, chains, options) {
 
     const contractName = 'AxelarGateway';
 
+    if (options.authModule) {
+        if (!reuseProxy) {
+            throw new Error('--authModule requires --reuseProxy');
+        }
+
+        if (reuseAuth) {
+            throw new Error('--authModule cannot be combined with --reuseAuth');
+        }
+    }
+
     const rpc = options.rpc || chain.rpc;
     const provider = getDefaultProvider(rpc);
 
@@ -179,7 +189,14 @@ async function deploy(axelar, chain, chains, options) {
 
     contractConfig.deployer = wallet.address;
 
-    if (options.skipExisting && contractConfig.authModule) {
+    if (options.authModule) {
+        // the gateway constructor reverts InvalidAuthModule on a codeless address
+        if (!(await isContract(options.authModule, wallet.provider))) {
+            throw new Error(`Auth module ${options.authModule} has no code; deploy it before the implementation`);
+        }
+
+        auth = authFactory.attach(options.authModule);
+    } else if (options.skipExisting && contractConfig.authModule) {
         auth = authFactory.attach(contractConfig.authModule);
     } else if (reuseProxy && (reuseHelpers || reuseAuth)) {
         auth = authFactory.attach(await gateway.authModule());
@@ -514,6 +531,12 @@ async function programHandler() {
         new Option('--reuseHelpers', 'reuse helper auth and token deployer contract modules for new implementation deployment'),
     );
     program.addOption(new Option('--reuseAuth', 'reuse auth module contract for new implementation deployment'));
+    program.addOption(
+        new Option(
+            '--authModule <authModule>',
+            'bind the implementation to this already deployed auth module instead of the live one (requires --reuseProxy)',
+        ),
+    );
     program.addOption(new Option('--governance <governance>', 'governance address').env('GOVERNANCE'));
     program.addOption(new Option('--mintLimiter <mintLimiter>', 'mint limiter address').env('MINT_LIMITER'));
     program.addOption(new Option('--keyID <keyID>', 'key ID').env('KEY_ID'));

--- a/evm/deploy-consensus-gateway.js
+++ b/evm/deploy-consensus-gateway.js
@@ -360,8 +360,13 @@ async function deploy(axelar, chain, chains, options) {
     const authOwner = await auth.owner();
 
     if (authOwner !== gateway.address) {
-        printError(`ERROR: Auth module owner is set to ${authOwner} instead of proxy address ${gateway.address}`);
-        error = true;
+        // an --authModule retrofit hands ownership over later, when the auth is seeded
+        if (options.authModule) {
+            printWarn(`Auth module owner is ${authOwner}, not the proxy yet. Run \`consensus-auth seed\` to hand ownership over.`);
+        } else {
+            printError(`ERROR: Auth module owner is set to ${authOwner} instead of proxy address ${gateway.address}`);
+            error = true;
+        }
     }
 
     const gatewayImplementation = await gateway.implementation();

--- a/evm/deploy-consensus-gateway.js
+++ b/evm/deploy-consensus-gateway.js
@@ -91,6 +91,11 @@ async function deploy(axelar, chain, chains, options) {
         if (reuseAuth) {
             throw new Error('--authModule cannot be combined with --reuseAuth');
         }
+
+        // skipExisting would reuse the recorded implementation, which is bound to the old auth
+        if (options.skipExisting) {
+            throw new Error('--authModule cannot be combined with --skipExisting');
+        }
     }
 
     const rpc = options.rpc || chain.rpc;
@@ -193,6 +198,13 @@ async function deploy(axelar, chain, chains, options) {
         // the gateway constructor reverts InvalidAuthModule on a codeless address
         if (!(await isContract(options.authModule, wallet.provider))) {
             throw new Error(`Auth module ${options.authModule} has no code; deploy it before the implementation`);
+        }
+
+        const deployedHash = await getBytecodeHash(options.authModule, chain.axelarId, provider);
+        const expectedHash = await getBytecodeHash(AxelarAuthWeighted, chain.axelarId);
+
+        if (deployedHash !== expectedHash) {
+            throw new Error(`Auth module ${options.authModule} codehash is ${deployedHash}, expected ${expectedHash}`);
         }
 
         auth = authFactory.attach(options.authModule);
@@ -299,7 +311,10 @@ async function deploy(axelar, chain, chains, options) {
         });
     }
 
-    if (!(reuseProxy && (reuseHelpers || reuseAuth))) {
+    if (options.authModule) {
+        // handing ownership over now would make the auth unseedable; `consensus-auth handoff` does it later
+        printInfo('Skipping auth ownership transfer', 'run `consensus-auth seed` then `consensus-auth handoff` before the upgrade');
+    } else if (!(reuseProxy && (reuseHelpers || reuseAuth))) {
         printInfo('Transferring auth ownership');
         await auth.transferOwnership(gateway.address, { gasLimit: 5e6, ...gasOptions }).then((tx) => tx.wait(chain.confirmations));
         printInfo('Transferred auth ownership. All done!');
@@ -362,7 +377,7 @@ async function deploy(axelar, chain, chains, options) {
     if (authOwner !== gateway.address) {
         // an --authModule retrofit hands ownership over later, when the auth is seeded
         if (options.authModule) {
-            printWarn(`Auth module owner is ${authOwner}, not the proxy yet. Run \`consensus-auth seed\` to hand ownership over.`);
+            printWarn(`Auth module owner is ${authOwner}, not the proxy yet. Run \`consensus-auth handoff\` to hand ownership over.`);
         } else {
             printError(`ERROR: Auth module owner is set to ${authOwner} instead of proxy address ${gateway.address}`);
             error = true;
@@ -414,6 +429,11 @@ async function deploy(axelar, chain, chains, options) {
 async function upgrade(_, chain, options) {
     const { privateKey, yes, offline, env, predictOnly } = options;
     const contractName = 'AxelarGateway';
+
+    // this path calls gateway.upgrade() from the wallet; the auth binding is fixed in the implementation
+    if (options.authModule) {
+        throw new Error('--authModule applies to the implementation deployment, not --upgrade');
+    }
 
     const rpc = options.rpc || chain.rpc;
     const provider = getDefaultProvider(rpc);

--- a/evm/deploy-consensus-gateway.js
+++ b/evm/deploy-consensus-gateway.js
@@ -7,7 +7,7 @@ const {
     ContractFactory,
     Contract,
     Wallet,
-    utils: { defaultAbiCoder, getContractAddress, AddressZero },
+    utils: { defaultAbiCoder, getContractAddress, keccak256, AddressZero },
     getDefaultProvider,
 } = ethers;
 
@@ -35,6 +35,9 @@ const AxelarGatewayProxy = require('@axelar-network/axelar-cgp-solidity/artifact
 const AxelarGateway = require('@axelar-network/axelar-cgp-solidity/artifacts/contracts/AxelarGateway.sol/AxelarGateway.json');
 const AxelarAuthWeighted = require('@axelar-network/axelar-cgp-solidity/artifacts/contracts/auth/AxelarAuthWeighted.sol/AxelarAuthWeighted.json');
 const TokenDeployer = require('@axelar-network/axelar-cgp-solidity/artifacts/contracts/TokenDeployer.sol/TokenDeployer.json');
+
+// AxelarAuthWeighted rejects a proof whose operator set is this many epochs behind the current one
+const OLD_KEY_RETENTION = 16;
 
 async function checkKeyRotation(axelar, chain) {
     let resp;
@@ -78,25 +81,130 @@ function getProxyParams(governance, mintLimiter) {
     return defaultAbiCoder.encode(['address', 'address', 'bytes'], [governance, mintLimiter, '0x']);
 }
 
+function validateAuthModuleOptions({ authModule, reuseProxy, reuseAuth, skipExisting }) {
+    if (!authModule) {
+        return;
+    }
+
+    if (!reuseProxy) {
+        throw new Error('--authModule requires --reuseProxy');
+    }
+
+    if (reuseAuth) {
+        throw new Error('--authModule cannot be combined with --reuseAuth');
+    }
+
+    // skipExisting would reuse the recorded implementation, which is bound to the old auth
+    if (skipExisting) {
+        throw new Error('--authModule cannot be combined with --skipExisting');
+    }
+}
+
+function authReadinessProblems({ auth, codehash, expectedCodehash, owner, proxy, seeder, currentEpoch, liveOperatorsEpoch }) {
+    const problems = [];
+    const isSame = (a, b) => Boolean(a) && Boolean(b) && a.toLowerCase() === b.toLowerCase();
+
+    if (codehash !== expectedCodehash) {
+        problems.push(`codehash is ${codehash}, expected ${expectedCodehash}`);
+    }
+
+    // only the owner can register operator sets, and the proxy can only do so inside a batch that already validated
+    if (!isSame(owner, proxy) && !isSame(owner, seeder)) {
+        problems.push(`owner ${owner} is neither the gateway proxy ${proxy} nor the seeding wallet ${seeder}`);
+    }
+
+    if (currentEpoch === 0) {
+        problems.push('it is unseeded; run `consensus-auth seed`');
+    } else if (liveOperatorsEpoch === 0) {
+        problems.push('the live operator set is not registered; run `consensus-auth seed` again');
+    } else if (currentEpoch - liveOperatorsEpoch >= OLD_KEY_RETENTION) {
+        problems.push(
+            `the live operator set is ${currentEpoch - liveOperatorsEpoch} epochs behind, past OLD_KEY_RETENTION of ${OLD_KEY_RETENTION}`,
+        );
+    }
+
+    return problems;
+}
+
+// An implementation's authModule is immutable, so an upgrade routes every inbound batch through it the moment it lands.
+// A batch that fails validateProof cannot be repaired by another batch, so this has to be checked before the upgrade.
+async function assertAuthReady(axelar, chain, options, { auth, proxy, seeder, provider }) {
+    if (!(await isContract(auth, provider))) {
+        throw new Error(`Auth module ${auth} has no code`);
+    }
+
+    const contract = new Contract(auth, AxelarAuthWeighted.abi, provider);
+
+    const { params } = await getAuthParams(axelar, chain.axelarId, options);
+    const liveOperatorsHash = keccak256(params[params.length - 1]);
+
+    const [codehash, expectedCodehash, owner, currentEpoch, liveOperatorsEpoch] = await Promise.all([
+        getBytecodeHash(auth, chain.axelarId, provider),
+        getBytecodeHash(AxelarAuthWeighted, chain.axelarId),
+        contract.owner(),
+        contract.currentEpoch(),
+        contract.epochForHash(liveOperatorsHash),
+    ]);
+
+    printInfo('Auth module', auth);
+    printInfo('Auth owner', owner);
+    printInfo('Auth currentEpoch', currentEpoch.toString());
+    printInfo('Live operator set hash', liveOperatorsHash);
+    printInfo('Live operator set epoch', liveOperatorsEpoch.toString());
+
+    const problems = authReadinessProblems({
+        auth,
+        codehash,
+        expectedCodehash,
+        owner,
+        proxy,
+        seeder,
+        currentEpoch: currentEpoch.toNumber(),
+        liveOperatorsEpoch: liveOperatorsEpoch.toNumber(),
+    });
+
+    if (problems.length > 0) {
+        problems.forEach((problem) => printError(`Auth module ${auth}`, problem));
+        throw new Error(`Auth module ${auth} is not ready; do not upgrade the gateway`);
+    }
+
+    printInfo('Auth module ready', auth);
+}
+
+// `upgrade()` is onlyGovernance, so a direct call only lands where the wallet itself is governance.
+async function assertCanUpgradeDirectly(chain, gateway, wallet) {
+    let governance;
+
+    try {
+        governance = await gateway.governance();
+    } catch (e) {
+        // pre-governance implementations do not expose it, and those are owned by the wallet
+        printWarn('Gateway does not expose governance()', 'assuming a direct upgrade is allowed');
+        return;
+    }
+
+    if (governance.toLowerCase() === wallet.address.toLowerCase()) {
+        return;
+    }
+
+    if (await isContract(governance, wallet.provider)) {
+        throw new Error(
+            `Gateway governance is the contract ${governance}, so upgrade() cannot be called from ${wallet.address}. ` +
+                `Route it through governance instead:\n` +
+                `  node evm/governance.js schedule upgrade <activationTime> -n ${chain.axelarId} --targetContractName AxelarGateway\n` +
+                `  node evm/governance.js execute -n ${chain.axelarId} --target ${gateway.address} --calldata <upgrade calldata>`,
+        );
+    }
+
+    throw new Error(`Gateway governance is ${governance}, not the wallet ${wallet.address}; upgrade() would revert NotGovernance`);
+}
+
 async function deploy(axelar, chain, chains, options) {
     const { privateKey, reuseProxy, reuseHelpers, reuseAuth, verify, yes, predictOnly } = options;
 
     const contractName = 'AxelarGateway';
 
-    if (options.authModule) {
-        if (!reuseProxy) {
-            throw new Error('--authModule requires --reuseProxy');
-        }
-
-        if (reuseAuth) {
-            throw new Error('--authModule cannot be combined with --reuseAuth');
-        }
-
-        // skipExisting would reuse the recorded implementation, which is bound to the old auth
-        if (options.skipExisting) {
-            throw new Error('--authModule cannot be combined with --skipExisting');
-        }
-    }
+    validateAuthModuleOptions(options);
 
     const rpc = options.rpc || chain.rpc;
     const provider = getDefaultProvider(rpc);
@@ -401,7 +509,13 @@ async function deploy(axelar, chain, chains, options) {
     contractConfig.address = gateway.address;
     contractConfig.implementation = implementation.address;
     contractConfig.implementationCodehash = implementationCodehash;
-    contractConfig.authModule = auth.address;
+    if (options.authModule) {
+        // the proxy keeps using the live auth until the upgrade executes, so do not record this one as current yet
+        contractConfig.pendingAuthModule = auth.address;
+    } else {
+        contractConfig.authModule = auth.address;
+    }
+
     contractConfig.tokenDeployer = tokenDeployer.address;
     contractConfig.deployer = wallet.address;
     contractConfig.deploymentMethod = options.deployMethod;
@@ -426,14 +540,41 @@ async function deploy(axelar, chain, chains, options) {
     }
 }
 
-async function upgrade(_, chain, options) {
+// The auth binding lives in the implementation, so --authModule is a cross-check here rather than an override.
+async function assertUpgradeAuthReady(axelar, chain, options, gateway, implementation, wallet) {
+    const provider = wallet.provider;
+
+    const [newAuth, liveAuth] = await Promise.all([
+        new Contract(implementation, AxelarGateway.abi, provider).authModule(),
+        gateway.authModule(),
+    ]);
+
+    printInfo('Live auth module', liveAuth);
+    printInfo('Implementation auth module', newAuth);
+
+    if (options.authModule && options.authModule.toLowerCase() !== newAuth.toLowerCase()) {
+        throw new Error(`Implementation ${implementation} is bound to auth ${newAuth}, not the --authModule ${options.authModule}`);
+    }
+
+    if (newAuth.toLowerCase() === liveAuth.toLowerCase()) {
+        return undefined;
+    }
+
+    printWarn('This upgrade replaces the auth module', `${liveAuth} -> ${newAuth}`);
+
+    await assertAuthReady(axelar, chain, options, {
+        auth: newAuth,
+        proxy: gateway.address,
+        seeder: options.authSeeder || wallet.address,
+        provider,
+    });
+
+    return newAuth;
+}
+
+async function upgrade(axelar, chain, options) {
     const { privateKey, yes, offline, env, predictOnly } = options;
     const contractName = 'AxelarGateway';
-
-    // this path calls gateway.upgrade() from the wallet; the auth binding is fixed in the implementation
-    if (options.authModule) {
-        throw new Error('--authModule applies to the implementation deployment, not --upgrade');
-    }
 
     const rpc = options.rpc || chain.rpc;
     const provider = getDefaultProvider(rpc);
@@ -449,10 +590,14 @@ async function upgrade(_, chain, options) {
     let governance = options.governance || chain.contracts.InterchainGovernance?.address;
     let mintLimiter = options.mintLimiter || chain.contracts.Multisig?.address;
     let setupParams = '0x';
+    let swappedAuth;
     contractConfig.governance = governance;
     contractConfig.mintLimiter = mintLimiter;
 
     if (!offline) {
+        await assertCanUpgradeDirectly(chain, gateway, wallet);
+        swappedAuth = await assertUpgradeAuthReady(axelar, chain, options, gateway, contractConfig.implementation, wallet);
+
         if (governance && !(await isContract(governance, provider))) {
             throw new Error('governance address is not a contract');
         }
@@ -528,6 +673,12 @@ async function upgrade(_, chain, options) {
         }
 
         printInfo('Upgraded!');
+
+        if (swappedAuth) {
+            contractConfig.authModule = swappedAuth;
+            delete contractConfig.pendingAuthModule;
+            printInfo('Recorded new auth module', swappedAuth);
+        }
     }
 }
 
@@ -562,6 +713,12 @@ async function programHandler() {
             'bind the implementation to this already deployed auth module instead of the live one (requires --reuseProxy)',
         ),
     );
+    program.addOption(
+        new Option(
+            '--authSeeder <authSeeder>',
+            'wallet expected to hold a retrofit auth module until the handoff (defaults to the signer)',
+        ),
+    );
     program.addOption(new Option('--governance <governance>', 'governance address').env('GOVERNANCE'));
     program.addOption(new Option('--mintLimiter <mintLimiter>', 'mint limiter address').env('MINT_LIMITER'));
     program.addOption(new Option('--keyID <keyID>', 'key ID').env('KEY_ID'));
@@ -582,4 +739,8 @@ if (require.main === module) {
 
 module.exports = {
     deployLegacyGateway: deploy,
+    validateAuthModuleOptions,
+    authReadinessProblems,
+    assertAuthReady,
+    OLD_KEY_RETENTION,
 };

--- a/evm/governance.js
+++ b/evm/governance.js
@@ -620,6 +620,9 @@ async function processCommand(axelar, chain, _chains, action, options) {
                 throw new Error('Operator proposal is not approved. Submit (or wait for) approval before executing.');
             }
 
+            // the operator path skips the timelock, so guard the auth swap here too
+            const swappedAuth = await assertGatewayUpgradeAuthReady(axelar, chain, options, target, calldata, wallet);
+
             if (prompt('Proceed with executing this operator proposal?', options.yes)) {
                 throw new Error('Operator proposal execution cancelled.');
             }
@@ -629,6 +632,13 @@ async function processCommand(axelar, chain, _chains, action, options) {
             const tx = await governance.executeOperatorProposal(target, calldata, nativeValue, { value: nativeValue, ...gasOptions });
             await handleTransactionWithEvent(tx, chain, governance, 'Operator proposal execution', 'OperatorProposalExecuted');
             printInfo('Operator proposal executed.');
+
+            if (swappedAuth) {
+                chain.contracts.AxelarGateway.authModule = swappedAuth;
+                delete chain.contracts.AxelarGateway.pendingAuthModule;
+                printInfo('Recorded new gateway auth module', swappedAuth);
+            }
+
             return null;
         }
 

--- a/evm/governance.js
+++ b/evm/governance.js
@@ -946,6 +946,12 @@ if (require.main === module) {
     program
         .command('execute-operator-proposal')
         .description('Execute an approved operator proposal (AxelarServiceGovernance only)')
+        .addOption(
+            new Option(
+                '--authSeeder <authSeeder>',
+                'wallet expected to hold a replacement gateway auth module until the handoff (defaults to the signer)',
+            ),
+        )
         .addOption(new Option('--target <target>', 'target address (required if --proposal not provided)'))
         .addOption(new Option('--calldata <calldata>', 'call data (required if --proposal not provided)'))
         .addOption(new Option('--proposal <proposal>', 'governance proposal payload (alternative to target/calldata)'))

--- a/evm/governance.js
+++ b/evm/governance.js
@@ -36,6 +36,7 @@ const { executeByGovernance } = require('../cosmwasm/proposal-utils');
 const IAxelarServiceGovernance = require('@axelar-network/axelar-gmp-sdk-solidity/interfaces/IAxelarServiceGovernance.json');
 const AxelarGateway = require('@axelar-network/axelar-cgp-solidity/artifacts/contracts/AxelarGateway.sol/AxelarGateway.json');
 const IUpgradable = require('@axelar-network/axelar-gmp-sdk-solidity/interfaces/IUpgradable.json');
+const { assertAuthReady } = require('./deploy-consensus-gateway');
 const ProposalType = {
     ScheduleTimelock: 0,
     CancelTimelock: 1,
@@ -217,7 +218,54 @@ function ensureNonZeroActivationTime(commandName, activationTime) {
     }
 }
 
-async function processCommand(_axelar, chain, _chains, action, options) {
+// A consensus gateway upgrade can swap the immutable auth module. If the new one does not hold the operator set that
+// is signing by the time the upgrade lands, every inbound batch reverts and no batch can repair it, because
+// transferOperatorship itself arrives inside a batch. So refuse to execute rather than find out afterwards.
+async function assertGatewayUpgradeAuthReady(axelar, chain, options, target, calldata, wallet) {
+    const gatewayConfig = chain.contracts?.AxelarGateway;
+
+    if (!gatewayConfig?.address || gatewayConfig.connectionType !== 'consensus') {
+        return undefined;
+    }
+
+    if (target.toLowerCase() !== gatewayConfig.address.toLowerCase()) {
+        return undefined;
+    }
+
+    const upgradable = new ethers.utils.Interface(IUpgradable.abi);
+
+    if (calldata.slice(0, 10) !== upgradable.getSighash('upgrade')) {
+        return undefined;
+    }
+
+    const [newImplementation] = upgradable.decodeFunctionData('upgrade', calldata);
+    const provider = wallet.provider;
+
+    const [newAuth, liveAuth] = await Promise.all([
+        new Contract(newImplementation, AxelarGateway.abi, provider).authModule(),
+        new Contract(gatewayConfig.address, AxelarGateway.abi, provider).authModule(),
+    ]);
+
+    printInfo('Live auth module', liveAuth);
+    printInfo('Implementation auth module', newAuth);
+
+    if (newAuth.toLowerCase() === liveAuth.toLowerCase()) {
+        return undefined;
+    }
+
+    printWarn('This upgrade replaces the gateway auth module', `${liveAuth} -> ${newAuth}`);
+
+    await assertAuthReady(axelar, chain, options, {
+        auth: newAuth,
+        proxy: gatewayConfig.address,
+        seeder: options.authSeeder || wallet.address,
+        provider,
+    });
+
+    return newAuth;
+}
+
+async function processCommand(axelar, chain, _chains, action, options) {
     if (!isEvmChain(chain)) {
         throw new Error(`Chain "${chain?.name}" is not an EVM chain (chainType must be "evm")`);
     }
@@ -527,6 +575,8 @@ async function processCommand(_axelar, chain, _chains, action, options) {
                 throw new Error(`TimeLock proposal is not yet eligible for execution. ETA: ${etaToDate(eta)}`);
             }
 
+            const swappedAuth = await assertGatewayUpgradeAuthReady(axelar, chain, options, target, calldata, wallet);
+
             if (prompt('Proceed with executing this proposal?', options.yes)) {
                 throw new Error('Proposal execution cancelled.');
             }
@@ -536,6 +586,13 @@ async function processCommand(_axelar, chain, _chains, action, options) {
             const tx = await governance.executeProposal(target, calldata, nativeValue, { value: nativeValue, ...gasOptions });
             await handleTransactionWithEvent(tx, chain, governance, 'Proposal execution', 'ProposalExecuted');
             printInfo('Proposal executed.');
+
+            if (swappedAuth) {
+                chain.contracts.AxelarGateway.authModule = swappedAuth;
+                delete chain.contracts.AxelarGateway.pendingAuthModule;
+                printInfo('Recorded new gateway auth module', swappedAuth);
+            }
+
             return null;
         }
 
@@ -792,6 +849,12 @@ if (require.main === module) {
     program
         .command('execute')
         .description('Execute a scheduled proposal')
+        .addOption(
+            new Option(
+                '--authSeeder <authSeeder>',
+                'wallet expected to hold a replacement gateway auth module until the handoff (defaults to the signer)',
+            ),
+        )
         .addOption(new Option('--target <target>', 'target address (required if --proposal not provided)'))
         .addOption(new Option('--calldata <calldata>', 'call data (required if --proposal not provided)'))
         .addOption(new Option('--proposal <proposal>', 'governance proposal payload (alternative to target/calldata)'))

--- a/evm/test/consensus-gateway.test.js
+++ b/evm/test/consensus-gateway.test.js
@@ -1,0 +1,101 @@
+'use strict';
+
+const chai = require('chai');
+const { expect } = chai;
+
+const { validateAuthModuleOptions, authReadinessProblems, OLD_KEY_RETENTION } = require('../deploy-consensus-gateway');
+
+const AUTH = '0x1111111111111111111111111111111111111111';
+const PROXY = '0x2222222222222222222222222222222222222222';
+const SEEDER = '0x3333333333333333333333333333333333333333';
+const CODEHASH = '0xaaaa';
+
+const ready = (overrides = {}) => ({
+    auth: AUTH,
+    codehash: CODEHASH,
+    expectedCodehash: CODEHASH,
+    owner: PROXY,
+    proxy: PROXY,
+    seeder: SEEDER,
+    currentEpoch: 20,
+    liveOperatorsEpoch: 20,
+    ...overrides,
+});
+
+describe('validateAuthModuleOptions', () => {
+    it('rejects --authModule without --reuseProxy', () => {
+        expect(() => validateAuthModuleOptions({ authModule: AUTH })).to.throw('--authModule requires --reuseProxy');
+    });
+
+    it('rejects --authModule combined with --reuseAuth', () => {
+        expect(() => validateAuthModuleOptions({ authModule: AUTH, reuseProxy: true, reuseAuth: true })).to.throw(
+            '--authModule cannot be combined with --reuseAuth',
+        );
+    });
+
+    it('rejects --authModule combined with --skipExisting', () => {
+        expect(() => validateAuthModuleOptions({ authModule: AUTH, reuseProxy: true, skipExisting: true })).to.throw(
+            '--authModule cannot be combined with --skipExisting',
+        );
+    });
+
+    it('accepts --authModule with --reuseProxy and --reuseHelpers', () => {
+        expect(() => validateAuthModuleOptions({ authModule: AUTH, reuseProxy: true, reuseHelpers: true })).to.not.throw();
+    });
+
+    it('ignores every other flag combination when --authModule is absent', () => {
+        expect(() => validateAuthModuleOptions({ reuseAuth: true, skipExisting: true })).to.not.throw();
+    });
+});
+
+describe('authReadinessProblems', () => {
+    it('reports nothing for an auth owned by the proxy and holding the live set', () => {
+        expect(authReadinessProblems(ready())).to.deep.equal([]);
+    });
+
+    it('accepts an auth still held by the seeding wallet before the handoff', () => {
+        expect(authReadinessProblems(ready({ owner: SEEDER }))).to.deep.equal([]);
+    });
+
+    it('compares addresses case insensitively', () => {
+        expect(authReadinessProblems(ready({ owner: PROXY.toUpperCase().replace('0X', '0x') }))).to.deep.equal([]);
+    });
+
+    it('rejects an owner that is neither the proxy nor the seeder', () => {
+        const problems = authReadinessProblems(ready({ owner: '0x4444444444444444444444444444444444444444' }));
+        expect(problems).to.have.lengthOf(1);
+        expect(problems[0]).to.contain('is neither the gateway proxy');
+    });
+
+    it('rejects a codehash that does not match the compiled auth', () => {
+        const problems = authReadinessProblems(ready({ codehash: '0xbbbb' }));
+        expect(problems).to.have.lengthOf(1);
+        expect(problems[0]).to.contain('codehash is 0xbbbb');
+    });
+
+    it('rejects an unseeded auth', () => {
+        const problems = authReadinessProblems(ready({ currentEpoch: 0, liveOperatorsEpoch: 0 }));
+        expect(problems).to.have.lengthOf(1);
+        expect(problems[0]).to.contain('unseeded');
+    });
+
+    it('rejects an auth that does not hold the live operator set', () => {
+        const problems = authReadinessProblems(ready({ liveOperatorsEpoch: 0 }));
+        expect(problems).to.have.lengthOf(1);
+        expect(problems[0]).to.contain('live operator set is not registered');
+    });
+
+    it('rejects a live operator set aged out of the retention window', () => {
+        const problems = authReadinessProblems(ready({ currentEpoch: 20, liveOperatorsEpoch: 20 - OLD_KEY_RETENTION }));
+        expect(problems).to.have.lengthOf(1);
+        expect(problems[0]).to.contain('past OLD_KEY_RETENTION');
+    });
+
+    it('accepts a live operator set at the edge of the retention window', () => {
+        expect(authReadinessProblems(ready({ currentEpoch: 20, liveOperatorsEpoch: 20 - OLD_KEY_RETENTION + 1 }))).to.deep.equal([]);
+    });
+
+    it('reports every problem at once', () => {
+        expect(authReadinessProblems(ready({ codehash: '0xbbbb', owner: AUTH, currentEpoch: 0 }))).to.have.lengthOf(3);
+    });
+});


### PR DESCRIPTION
### why

cgp-solidity #310 needs a new `AxelarAuthWeighted` on the deployed consensus fleet. `authModule` is a constructor `immutable`, so that means a new implementation bound to an auth that is not the live one.

Timing is the problem. The implementation must exist ~10 days before the upgrade executes on mainnet, a fresh auth starts at epoch 0, `validateProof` only accepts sets within `OLD_KEY_RETENTION = 16`, and operators rotate daily. Seed early and the auth will not know the set signing at execution, so every batch reverts, and `transferOperatorship` cannot fix it because it arrives inside a batch that must validate first.

So: deploy an unseeded auth at a CREATE2 address, bind the implementation to it, seed just before execution, hand ownership over after. This flag is the binding step. An earlier revision bound the address before deploying there; the constructor rejects that (`AxelarGateway.sol:94`).

### how

`--authModule <addr>` binds the implementation to an existing auth instead of the live one. Requires `--reuseProxy`, rejects `--reuseAuth` and `--skipExisting`, requires a matching codehash at the address, and skips the ownership transfer (handing it over early makes the auth unseedable).

`--upgrade` now reads `governance()` and routes, since it is `AxelarServiceGovernance` on every gateway in scope and a direct call would just revert. It fails with the `governance.js` commands to run instead. `--authModule` there is a cross-check against the implementation binding.

Before any auth-swapping upgrade, this script and `governance.js execute` both assert the replacement has code, a matching codehash, is seeded, holds the live set within retention, and is owned by the proxy or the seeder (`--authSeeder`). Config records it as `pendingAuthModule` until the upgrade lands.

### step order

```
consensus-auth predict / deploy
deploy-consensus-gateway --authModule --reuseProxy --reuseHelpers
governance.js schedule + proposal
consensus-auth seed && verify
governance.js execute
consensus-auth handoff && verify
```
 Pairs with #1414.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes consensus gateway deploy/upgrade and governance execution paths around immutable auth swaps; a mistake could brick inbound GMP batches, though the PR adds explicit pre-flight checks.
> 
> **Overview**
> Adds **`--authModule`** to `deploy-consensus-gateway` so a new implementation can be bound to a **pre-deployed** `AxelarAuthWeighted` (immutable in the constructor) instead of the live auth—needed when auth must be seeded shortly before a timelocked upgrade. The flag requires **`--reuseProxy`**, forbids **`--reuseAuth`** / **`--skipExisting`**, validates bytecode at the address, **skips** immediate ownership transfer to the proxy, and records **`pendingAuthModule`** until the upgrade runs.
> 
> Introduces shared **auth readiness** checks (`assertAuthReady`, `authReadinessProblems`, `OLD_KEY_RETENTION`): correct codehash, seeded state with the **live** operator set within retention, and owner is the gateway proxy or **`--authSeeder`**. These run before **`--upgrade`** (with **`assertCanUpgradeDirectly`** pointing at governance when needed) and before **`governance.js`** `execute` / `execute-operator-proposal` when calldata is a consensus gateway **`upgrade`** that swaps auth. Successful upgrade execution updates **`authModule`** and clears **`pendingAuthModule`**.
> 
> **`consensus-auth handoff`** now **fails** if post-transfer verification does not show proxy ownership. Unit tests cover CLI flag validation and readiness problem detection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0f2d4c6000c699cd85e1cdf2ba2259172a29d27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->