### PR TITLE
docs(evm): document gateway pause commands and the versioned salt

### DIFF
--- a/evm/README.md
+++ b/evm/README.md
@@ -59,6 +59,8 @@ Deploy the original Axelar gateway contract for legacy consensus-based connectio
 6. Upgrade to the new implementation contract
    `ts-node evm/deploy-consensus-gateway.js --upgrade`
 
+*Note: pass `--salt` for a versioned deployment, e.g. `-s "AxelarGateway v6.5.0"`. The default salt is the unversioned `AxelarGateway`, so omitting it derives a different implementation address than a release intends.*
+
 ## AxelarGasService
 
 1. Run the following to deploy the gas service,
@@ -256,6 +258,27 @@ Full docs can be found [here](./docs/contract-ownership.md).
 `ts-node evm/gateway.js --action transferOperatorship --destination <gatewayAddress> --payload <calldata> --yes`
 
 Other gateway actions remain in `evm/gateway.js`; use `--action` accordingly.
+
+### Gateway pause commands (evm/gateway.js)
+
+Read the current state:
+
+`ts-node evm/gateway.js --action paused -n <chain>`
+`ts-node evm/gateway.js --action pauser -n <chain>`
+
+Pause or unpause. On a consensus gateway the caller must be the `pauser` or the `governance` address; on an amplifier gateway it must be the `operator` or the `owner`:
+
+`ts-node evm/gateway.js --action setPauseStatus --pause <true|false> -n <chain> --yes`
+
+Hand the pauser role to another address (consensus only). The caller must be the current `pauser` or `governance`:
+
+`ts-node evm/gateway.js --action transferPauser --destination <addr> -n <chain> --yes`
+
+A freshly upgraded gateway has `pauser() == address(0)`, so the first assignment has to come from governance. Since `governance` is a contract on every environment, route it through `governance.js` rather than this script:
+
+`ts-node evm/governance.js schedule raw <activationTime> --target <gatewayAddress> --calldata <transferPauser calldata> -n <chain>`
+
+Pausing a gateway blocks `callContract` and `callContractWithToken`, and blocks consumers from calling `validateContractCall` / `validateContractCallAndMint`, with a bypass so governance can still consume approvals. It does not block `execute`, so signed batches still land. This halts all GMP and ITS traffic on that chain, not just token flows.
 
 ### Operators script (evm/operators.js)
 

--- a/evm/README.md
+++ b/evm/README.md
@@ -59,7 +59,7 @@ Deploy the original Axelar gateway contract for legacy consensus-based connectio
 6. Upgrade to the new implementation contract
    `ts-node evm/deploy-consensus-gateway.js --upgrade`
 
-*Note: pass `--salt` for a versioned deployment, e.g. `-s "AxelarGateway v6.5.0"`. The default salt is the unversioned `AxelarGateway`, so omitting it derives a different implementation address than a release intends.*
+*Note: a versioned deployment needs both a deterministic deploy method and a salt, e.g. `-m create3 -s "AxelarGateway v6.5.0"`. The salt only applies to `create2` and `create3`; the default `create` is nonce based and ignores it, so passing `-s` without `-m` is rejected. The default salt is the unversioned `AxelarGateway`, so omitting it derives a different implementation address than a release intends.*
 
 ## AxelarGasService
 

--- a/evm/docs/emergency-response.md
+++ b/evm/docs/emergency-response.md
@@ -32,7 +32,25 @@ Actions that require governance proposal submission, voting period, and timelock
 - Add `--operatorProposal` flag to skip timelock.
 - Documentation: [Transfer Gateway Operatorship via Governance](./governance-workflows.md#transfer-gateway-operatorship-via-governance-amplifier)
 
+**Transfer Pauser** (consensus)
+
+- A freshly upgraded gateway has `pauser() == address(0)`, so the first assignment must come from governance: `evm/governance.js schedule raw <activationTime> --target <gatewayAddress> --calldata <transferPauser calldata>`.
+- Replace `schedule` with `schedule-operator` to skip timelock.
+- Documentation: [Gateway pause commands](../README.md#gateway-pause-commands-evmgatewayjs)
+
 **Note:** To skip timelock, replace `schedule` with `schedule-operator` for `governance.js` actions or add `--operatorProposal` flag for contract-specific scripts. Operator proposals use `AxelarServiceGovernance` and bypass timelock via operator approval. See [AxelarServiceGovernance Commands](./governance.md#axelarservicegovernance-commands) for details.
+
+### Pauser Actions
+
+Actions that can be executed directly from the pauser wallet on a consensus gateway, or the operator wallet on an amplifier gateway. Immediate execution, no timelock.
+
+- **Pause**: `evm/gateway.js --action setPauseStatus --pause true` - [Gateway pause commands](../README.md#gateway-pause-commands-evmgatewayjs)
+- **Unpause**: `evm/gateway.js --action setPauseStatus --pause false` - [Gateway pause commands](../README.md#gateway-pause-commands-evmgatewayjs)
+- **Check state**: `evm/gateway.js --action paused` and `evm/gateway.js --action pauser`
+
+Pausing blocks `callContract` and `callContractWithToken`, and blocks consumers from calling `validateContractCall` / `validateContractCallAndMint`, with a governance bypass. `execute` still works, so signed batches continue to land. This halts all GMP and ITS traffic on the chain.
+
+Governance can also pause without the pauser role, since `setPauseStatus` is `onlyPauserOrGovernance`. On a chain where no pauser is set, that is the only route, and it needs `schedule-operator` to avoid waiting out the timelock.
 
 ### Operator Actions
 


### PR DESCRIPTION
### why

Two gaps left by the v6.5.0 pausable gateway work.

1. Consensus gateways became pausable in cgp-solidity 6.5.0 and `evm/gateway.js` gained the actions in #1408, but nothing documents them. The emergency-response playbook has no pause entry for `AxelarGateway` at all, while ITS documents its pause under both operator and owner actions.
2. #1408 changed `--salt` from a prefix-with-append into a full override and made the default unversioned. Following the README's gateway upgrade steps verbatim now derives a different implementation address than a release intends, and nothing says so.

### how

`evm/README.md`

- New "Gateway pause commands" section covering `paused`, `pauser`, `setPauseStatus` and `transferPauser`, with the authorization rules for both gateway types: `pauser` or `governance` on consensus, `operator` or `owner` on amplifier.
- Spells out that a freshly upgraded gateway has `pauser() == address(0)`, so the first assignment must come from governance, and that since `governance` is a contract on every environment it has to be routed via `governance.js schedule raw` rather than this script.
- States the blast radius plainly: pausing blocks `callContract` / `callContractWithToken` and gates `validateContractCall*` with a governance bypass, but leaves `execute` working, so it halts all GMP and ITS traffic on the chain rather than just token flows.
- A note on the Gateway Upgrade steps that `--salt` should be passed for a versioned deployment.

`evm/docs/emergency-response.md`

- New "Pauser Actions" section, matching the existing Operator and Mint Limiter sections.
- A "Transfer Pauser" entry under Governance Actions for the initial assignment.
- Notes that governance can pause without a pauser being set, and that this needs `schedule-operator` to avoid the timelock, which is the relevant path on any chain where the pauser is left unassigned.
