### PR TITLE
docs: add EVM and Stellar ITS transfer commands

### DIFF
--- a/evm/README.md
+++ b/evm/README.md
@@ -536,6 +536,21 @@ ts-node evm/verify-contract.js --help
 
 ## Interchain Token Service
 
+### Interchain Transfer
+
+Transfers a token that is already deployed or linked on the destination chain under the same token ID. The script estimates cross-chain gas and encodes the destination address automatically. The amount is human-readable and is converted using the token's decimals.
+
+```bash
+ts-node evm/its.js interchain-transfer \
+  --destinationChain <destination-chain> \
+  --tokenId <token-id> \
+  --destinationAddress <destination-address> \
+  --amount <amount> \
+  --gasValue auto \
+  --chainNames <source-chain> \
+  --env <env>
+```
+
 ### Link Token
 
 #### Legacy custom ITS tokens

--- a/stellar/README.md
+++ b/stellar/README.md
@@ -300,8 +300,17 @@ ts-node stellar/its.js link-token [salt] [destination-chain] [destination-token-
 
 #### Interchain Transfer
 
+Transfers a token that is already deployed or linked on the destination chain under the same token ID. The script estimates cross-chain gas and encodes the destination address automatically. The amount is in the Stellar token's base units.
+
 ```bash
-ts-node stellar/its.js interchain-transfer [token-id] [destination-chain] [destination-address] [amount] --data [data] --gas-amount [amount]
+ts-node stellar/its.js interchain-transfer \
+  <token-id> \
+  <destination-chain> \
+  <destination-address> \
+  <amount> \
+  --gas-amount auto \
+  --chain-name <source-chain> \
+  --env <env>
 ```
 
 #### Execute


### PR DESCRIPTION
### why
- <!-- Explain the reason for this change -->

### how
<!-- An agent will fill this out -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to README files; no runtime or deployment logic changed.
> 
> **Overview**
> Documents how to run **ITS interchain transfers** via `its.js` on EVM and Stellar—no script or behavior changes.
> 
> **EVM** (`evm/README.md`): Adds an **Interchain Transfer** subsection under Interchain Token Service (before Link Token) describing same-token-ID cross-chain moves, automatic gas estimation and destination encoding, and human-readable amounts (decimals). Example uses named flags: `--destinationChain`, `--tokenId`, `--destinationAddress`, `--amount`, `--gasValue auto`, `--chainNames`, `--env`.
> 
> **Stellar** (`stellar/README.md`): Expands the existing Interchain Transfer entry with the same behavioral notes (base-unit amounts on Stellar) and replaces the one-line example with a multi-line invocation using positional args plus `--gas-amount auto`, `--chain-name`, and `--env`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56cc9ec399138e2ee8b27fb956ab8a4401630713. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->