### PR TITLE
fix(evm): reject --salt when the deploy method ignores it

### DIFF
--- a/evm/deploy-consensus-gateway.js
+++ b/evm/deploy-consensus-gateway.js
@@ -132,6 +132,10 @@ async function deploy(axelar, chain, chains, options) {
     const authFactory = new ContractFactory(AxelarAuthWeighted.abi, AxelarAuthWeighted.bytecode, wallet);
     const tokenDeployerFactory = new ContractFactory(TokenDeployer.abi, TokenDeployer.bytecode, wallet);
     const gatewayProxyFactory = new ContractFactory(AxelarGatewayProxy.abi, AxelarGatewayProxy.bytecode, wallet);
+    if (options.salt && options.deployMethod === 'create') {
+        throw new Error('--salt has no effect with --deployMethod create; use create2 or create3');
+    }
+
     const salt = options.salt || 'AxelarGateway';
     const { deployerContract } = getDeployOptions(options.deployMethod, salt, chain);
 


### PR DESCRIPTION
### why

`--salt` only affects `create2` and `create3`. The default `--deployMethod create` is nonce based, and `getDeployOptions` returns `{}` for it, so the salt is silently discarded.

That makes `-s "AxelarGateway v6.5.0"` on its own look like a versioned deployment while actually producing a nonce-derived address.

`contractConfig.salt` is only recorded when the method is not `create` (line 373 before this change), so the salt was already understood to be inapplicable there. This makes it an explicit error rather than a silent no-op.

### how

```js
if (options.salt && options.deployMethod === 'create') {
    throw new Error('--salt has no effect with --deployMethod create; use create2 or create3');
}
```

Placed next to the salt derivation rather than with the other argument checks, so it sits where the reader is already thinking about salts.

The documentation half is handled in #1411.