### PR TITLE
feat(evm): add consensus auth module deploy and verify script

### DIFF
--- a/evm/consensus-auth.js
+++ b/evm/consensus-auth.js
@@ -5,7 +5,7 @@ const { ethers } = require('hardhat');
 const {
     ContractFactory,
     Contract,
-    utils: { keccak256 },
+    utils: { defaultAbiCoder, keccak256 },
 } = ethers;
 
 const {
@@ -25,11 +25,15 @@ const { addEvmOptions } = require('./cli-utils');
 const { getWallet } = require('./sign-utils');
 const { getAuthParams } = require('./deploy-consensus-gateway');
 
+const AxelarGateway = require('@axelar-network/axelar-cgp-solidity/artifacts/contracts/AxelarGateway.sol/AxelarGateway.json');
 const AxelarAuthWeighted = require('@axelar-network/axelar-cgp-solidity/artifacts/contracts/auth/AxelarAuthWeighted.sol/AxelarAuthWeighted.json');
 const IDeployer = require('@axelar-network/axelar-gmp-sdk-solidity/interfaces/IDeployer.json');
 
 // deploying with no seed keeps the init code, and therefore the CREATE2 address, independent of the operator sets
 const EMPTY_SEED = [[]];
+
+// AxelarAuthWeighted rejects a proof whose operator set is this many epochs behind the current one
+const OLD_KEY_RETENTION = 16;
 
 function authFactory(wallet) {
     return new ContractFactory(AxelarAuthWeighted.abi, AxelarAuthWeighted.bytecode, wallet);
@@ -47,6 +51,36 @@ async function predictAddress(wallet, chain, salt) {
     });
 
     return { address, deployerContract };
+}
+
+async function resolveAuthAddress(wallet, chain, options) {
+    if (Boolean(options.salt) === Boolean(options.authModule)) {
+        throw new Error('Provide exactly one of --salt or --authModule');
+    }
+
+    if (options.authModule) {
+        return options.authModule;
+    }
+
+    return (await predictAddress(wallet, chain, options.salt)).address;
+}
+
+// candidates are oldest first, so epochs land in the same order the live auth saw them
+async function selectSetsToSeed(auth, candidates) {
+    const seeds = [];
+
+    for (const set of candidates) {
+        // skip anything already registered: transferOperatorship reverts DuplicateOperators
+        if (!seeds.includes(set) && (await auth.epochForHash(operatorsHash(set))).eq(0)) {
+            seeds.push(set);
+        }
+    }
+
+    return seeds;
+}
+
+function encodeOperatorSet(operators, weights, threshold) {
+    return defaultAbiCoder.encode(['address[]', 'uint256[]', 'uint256'], [operators, weights, threshold]);
 }
 
 function gatewayAddress(chain) {
@@ -70,6 +104,7 @@ function operatorsHash(params) {
 }
 
 async function reportState(auth, expectedOwner) {
+    const allowedOwners = [].concat(expectedOwner || []);
     const owner = await auth.owner();
     const currentEpoch = await auth.currentEpoch();
 
@@ -80,8 +115,8 @@ async function reportState(auth, expectedOwner) {
         printInfo('Auth newest epoch hash', await auth.hashForEpoch(currentEpoch));
     }
 
-    if (expectedOwner && owner.toLowerCase() !== expectedOwner.toLowerCase()) {
-        printError(`Owner is ${owner}, expected ${expectedOwner}`);
+    if (allowedOwners.length > 0 && !allowedOwners.some((allowed) => allowed.toLowerCase() === owner.toLowerCase())) {
+        printError(`Owner is ${owner}, expected ${allowedOwners.join(' or ')}`);
         return false;
     }
 
@@ -136,13 +171,59 @@ async function deploy(axelar, chain, chains, options) {
     printInfo('Auth deployed unseeded; run `seed` shortly before executing the gateway upgrade', address);
 }
 
+// AxelarAuthWeighted keeps a proof valid for OLD_KEY_RETENTION epochs, so a batch signed just before a rotation still
+// validates against the live auth. Copy the tail of its history so the replacement accepts those batches too.
+async function recentOperatorSets(provider, chain, options) {
+    const count = Number(options.copyEpochs);
+
+    if (!Number.isInteger(count) || count < 0 || count >= OLD_KEY_RETENTION) {
+        throw new Error(`--copyEpochs must be an integer between 0 and ${OLD_KEY_RETENTION - 1}`);
+    }
+
+    if (count === 0) {
+        return [];
+    }
+
+    const liveAuth = await new Contract(gatewayAddress(chain), AxelarGateway.abi, provider).authModule();
+    const auth = new Contract(liveAuth, AxelarAuthWeighted.abi, provider);
+    const filter = auth.filters.OperatorshipTransferred();
+
+    const chunk = Number(options.logChunkSize);
+    const lookback = Number(options.lookbackBlocks);
+    const latest = await provider.getBlockNumber();
+    const floor = Math.max(0, latest - lookback + 1);
+
+    const events = [];
+    let to = latest;
+
+    while (events.length < count && to >= floor) {
+        const from = Math.max(floor, to - chunk + 1);
+        events.unshift(...(await auth.queryFilter(filter, from, to)));
+        to = from - 1;
+    }
+
+    printInfo('Live auth module', liveAuth);
+
+    if (events.length < count) {
+        printWarn(
+            `Found ${events.length} of ${count} requested operator set(s) in the last ${lookback} blocks of ${liveAuth}`,
+            'raise --lookbackBlocks to copy more history',
+        );
+    }
+
+    const sets = events.slice(-count).map(({ args }) => encodeOperatorSet(args.newOperators, args.newWeights, args.newThreshold));
+    printInfo('Historical operator sets to copy', sets.length);
+
+    return sets;
+}
+
 async function seed(axelar, chain, chains, options) {
     const provider = ethers.getDefaultProvider(chain.rpc);
     const wallet = await getWallet(options.privateKey, provider, options);
     const gasOptions = await getGasOptions(chain, options, 'AxelarAuthWeighted');
 
     const proxy = gatewayAddress(chain);
-    const address = options.authModule || (await predictAddress(wallet, chain, options.salt)).address;
+    const address = await resolveAuthAddress(wallet, chain, options);
 
     printInfo('Gateway proxy', proxy);
     printInfo('Auth module', address);
@@ -157,15 +238,9 @@ async function seed(axelar, chain, chains, options) {
         throw new Error(`Auth at ${address} is not owned by ${wallet.address}; it cannot be seeded`);
     }
 
+    const history = await recentOperatorSets(provider, chain, options);
     const { params } = await getAuthParams(axelar, chain.axelarId, options);
-    const seeds = [];
-
-    for (const set of params) {
-        // skip anything already registered: transferOperatorship reverts DuplicateOperators
-        if (!seeds.includes(set) && (await auth.epochForHash(operatorsHash(set))).eq(0)) {
-            seeds.push(set);
-        }
-    }
+    const seeds = await selectSetsToSeed(auth, [...history, ...params]);
 
     if (!seeds.length) {
         printInfo('Auth already holds every current operator set; nothing to seed', address);
@@ -208,7 +283,7 @@ async function handoff(axelar, chain, chains, options) {
     const gasOptions = await getGasOptions(chain, options, 'AxelarAuthWeighted');
 
     const proxy = gatewayAddress(chain);
-    const address = options.authModule || (await predictAddress(wallet, chain, options.salt)).address;
+    const address = await resolveAuthAddress(wallet, chain, options);
 
     printInfo('Gateway proxy', proxy);
     printInfo('Auth module', address);
@@ -254,7 +329,7 @@ async function verify(axelar, chain, chains, options) {
     const wallet = await getWallet(options.privateKey, provider, options);
 
     const proxy = gatewayAddress(chain);
-    const address = options.authModule || (await predictAddress(wallet, chain, options.salt)).address;
+    const address = await resolveAuthAddress(wallet, chain, options);
 
     printInfo('Auth module', address);
 
@@ -263,7 +338,11 @@ async function verify(axelar, chain, chains, options) {
     }
 
     const auth = authFactory(wallet).attach(address);
-    let ok = await reportState(auth, proxy);
+    let ok = await reportState(auth, [proxy, wallet.address]);
+
+    if (ok && (await auth.owner()).toLowerCase() === wallet.address.toLowerCase()) {
+        printWarn('Auth is still owned by the seeding wallet', 'run `handoff` before rotations resume flowing through the gateway');
+    }
 
     const { params } = await getAuthParams(axelar, chain.axelarId, options);
     const liveHash = operatorsHash(params[params.length - 1]);
@@ -294,41 +373,60 @@ if (require.main === module) {
 
     program.name('consensus-auth').description('Deploy and verify a replacement AxelarAuthWeighted for a consensus gateway');
 
-    const addOptions = (cmd, { salt = true } = {}) => {
+    // predict and deploy derive the address from the salt, so they cannot accept an address instead
+    const addDerivingOptions = (cmd) => {
         addEvmOptions(cmd);
-
-        if (salt) {
-            cmd.addOption(new Option('-s, --salt <salt>', 'CREATE2 salt for the auth module').makeOptionMandatory(true));
-        }
-
-        cmd.addOption(new Option('--prevKeyIDs <prevKeyIDs>', 'comma separated older key IDs to seed alongside the current one'));
+        cmd.addOption(new Option('-s, --salt <salt>', 'CREATE2 salt for the auth module').makeOptionMandatory(true));
 
         return cmd;
     };
 
-    addOptions(program.command('predict').description('Print the predicted auth module address')).action((options) =>
+    // the rest act on an auth that already exists, addressed either by its salt or by its address
+    const addExistingOptions = (cmd, verb) => {
+        addEvmOptions(cmd);
+        cmd.addOption(new Option('-s, --salt <salt>', 'CREATE2 salt the auth module was deployed with'));
+        cmd.addOption(new Option('--authModule <authModule>', `${verb} this address instead of deriving it from --salt`));
+
+        return cmd;
+    };
+
+    addDerivingOptions(program.command('predict').description('Print the predicted auth module address')).action((options) =>
         mainProcessor(options, predict),
     );
 
-    addOptions(program.command('deploy').description('Deploy an unseeded auth module owned by the deployer wallet')).action((options) =>
-        mainProcessor(options, deploy),
+    addDerivingOptions(program.command('deploy').description('Deploy an unseeded auth module owned by the deployer wallet')).action(
+        (options) => mainProcessor(options, deploy),
     );
 
-    addOptions(program.command('seed').description('Seed the auth module with the current operator sets; repeatable, keeps ownership'))
-        .addOption(new Option('--authModule <authModule>', 'seed this address instead of the predicted one'))
+    addExistingOptions(
+        program.command('seed').description('Seed the auth module with the current operator sets; repeatable, keeps ownership'),
+        'seed',
+    )
+        .addOption(new Option('--prevKeyIDs <prevKeyIDs>', 'comma separated older key IDs to seed alongside the current one'))
+        .addOption(new Option('--copyEpochs <copyEpochs>', 'how many recent operator sets to copy from the live auth module').default('3'))
+        .addOption(new Option('--lookbackBlocks <lookbackBlocks>', 'how far back to scan for those sets').default('250000'))
+        .addOption(new Option('--logChunkSize <logChunkSize>', 'block range per getLogs request').default('10000'))
         .action((options) => mainProcessor(options, seed));
 
-    addOptions(program.command('handoff').description('Hand auth ownership to the gateway proxy; refuses a stale seed'))
-        .addOption(new Option('--authModule <authModule>', 'hand off this address instead of the predicted one'))
-        .action((options) => mainProcessor(options, handoff));
+    addExistingOptions(
+        program.command('handoff').description('Hand auth ownership to the gateway proxy; refuses a stale seed'),
+        'hand off',
+    ).action((options) => mainProcessor(options, handoff));
 
-    addOptions(program.command('verify').description('Check the auth module is seeded with the live operator set and owned by the gateway'))
-        .addOption(new Option('--authModule <authModule>', 'verify this address instead of the predicted one'))
-        .action((options) => mainProcessor(options, verify));
+    addExistingOptions(
+        program.command('verify').description('Check the auth module is seeded with the live operator set and owned by the gateway'),
+        'verify',
+    ).action((options) => mainProcessor(options, verify));
 
     program.parse();
 }
 
 module.exports = {
     predictAuthAddress: predictAddress,
+    resolveAuthAddress,
+    selectSetsToSeed,
+    recentOperatorSets,
+    encodeOperatorSet,
+    operatorsHash,
+    OLD_KEY_RETENTION,
 };

--- a/evm/consensus-auth.js
+++ b/evm/consensus-auth.js
@@ -1,0 +1,334 @@
+'use strict';
+
+const { Command, Option } = require('commander');
+const { ethers } = require('hardhat');
+const {
+    ContractFactory,
+    Contract,
+    utils: { keccak256 },
+} = ethers;
+
+const {
+    printInfo,
+    printWarn,
+    printError,
+    prompt,
+    mainProcessor,
+    isContract,
+    getGasOptions,
+    getDeployOptions,
+    getDeployedAddress,
+    getSaltFromKey,
+    wasEventEmitted,
+} = require('./utils');
+const { addEvmOptions } = require('./cli-utils');
+const { getWallet } = require('./sign-utils');
+const { getAuthParams } = require('./deploy-consensus-gateway');
+
+const AxelarAuthWeighted = require('@axelar-network/axelar-cgp-solidity/artifacts/contracts/auth/AxelarAuthWeighted.sol/AxelarAuthWeighted.json');
+const IDeployer = require('@axelar-network/axelar-gmp-sdk-solidity/interfaces/IDeployer.json');
+
+// deploying with no seed keeps the init code, and therefore the CREATE2 address, independent of the operator sets
+const EMPTY_SEED = [[]];
+
+function authFactory(wallet) {
+    return new ContractFactory(AxelarAuthWeighted.abi, AxelarAuthWeighted.bytecode, wallet);
+}
+
+async function predictAddress(wallet, chain, salt) {
+    const { deployerContract } = getDeployOptions('create2', salt, chain);
+
+    const address = await getDeployedAddress(wallet.address, 'create2', {
+        salt,
+        deployerContract,
+        contractJson: AxelarAuthWeighted,
+        constructorArgs: EMPTY_SEED,
+        provider: wallet.provider,
+    });
+
+    return { address, deployerContract };
+}
+
+function gatewayAddress(chain) {
+    const address = chain.contracts.AxelarGateway?.address;
+
+    if (!address) {
+        throw new Error(`AxelarGateway is not deployed on ${chain.name}`);
+    }
+
+    if (chain.contracts.AxelarGateway.connectionType === 'amplifier') {
+        throw new Error(`${chain.name} runs an amplifier gateway, which has no AxelarAuthWeighted`);
+    }
+
+    return address;
+}
+
+// core encodes operator sets canonically, so hashing the encoded params matches the contract's
+// keccak256(abi.encode(operators, weights, threshold))
+function operatorsHash(params) {
+    return keccak256(params);
+}
+
+async function reportState(auth, expectedOwner) {
+    const owner = await auth.owner();
+    const currentEpoch = await auth.currentEpoch();
+
+    printInfo('Auth owner', owner);
+    printInfo('Auth currentEpoch', currentEpoch.toString());
+
+    if (currentEpoch.gt(0)) {
+        printInfo('Auth newest epoch hash', await auth.hashForEpoch(currentEpoch));
+    }
+
+    if (expectedOwner && owner.toLowerCase() !== expectedOwner.toLowerCase()) {
+        printError(`Owner is ${owner}, expected ${expectedOwner}`);
+        return false;
+    }
+
+    return true;
+}
+
+async function predict(axelar, chain, chains, options) {
+    const wallet = await getWallet(options.privateKey, ethers.getDefaultProvider(chain.rpc), options);
+    const { address, deployerContract } = await predictAddress(wallet, chain, options.salt);
+
+    printInfo('Deployer contract', deployerContract);
+    printInfo('Salt', options.salt);
+    printInfo('Predicted auth module', address);
+    printInfo('Already deployed', (await isContract(address, wallet.provider)) ? 'yes' : 'no');
+}
+
+async function deploy(axelar, chain, chains, options) {
+    const provider = ethers.getDefaultProvider(chain.rpc);
+    const wallet = await getWallet(options.privateKey, provider, options);
+    const gasOptions = await getGasOptions(chain, options, 'AxelarAuthWeighted');
+
+    const { address, deployerContract } = await predictAddress(wallet, chain, options.salt);
+
+    printInfo('Auth module', address);
+
+    if (await isContract(address, provider)) {
+        throw new Error(`Auth module already deployed at ${address}. Use a fresh salt.`);
+    }
+
+    if (prompt(`Deploy an unseeded auth at ${address} on ${chain.name}, owned by ${wallet.address}?`, options.yes)) {
+        return;
+    }
+
+    const deployer = new Contract(deployerContract, IDeployer.abi, wallet);
+    const initCode = authFactory(wallet).getDeployTransaction(...EMPTY_SEED).data;
+    const init = new ethers.utils.Interface(AxelarAuthWeighted.abi).encodeFunctionData('transferOwnership', [wallet.address]);
+
+    const deployTx = await deployer.deployAndInit(initCode, getSaltFromKey(options.salt), init, gasOptions);
+    printInfo('Deploy tx', deployTx.hash);
+    await deployTx.wait(chain.confirmations);
+
+    if (!(await isContract(address, provider))) {
+        throw new Error(`Auth module was not deployed at the predicted address ${address}`);
+    }
+
+    const auth = authFactory(wallet).attach(address);
+
+    if (!(await reportState(auth, wallet.address))) {
+        throw new Error('Auth ownership was not handed to the deployer wallet; it cannot be seeded');
+    }
+
+    printInfo('Auth deployed unseeded; run `seed` shortly before executing the gateway upgrade', address);
+}
+
+async function seed(axelar, chain, chains, options) {
+    const provider = ethers.getDefaultProvider(chain.rpc);
+    const wallet = await getWallet(options.privateKey, provider, options);
+    const gasOptions = await getGasOptions(chain, options, 'AxelarAuthWeighted');
+
+    const proxy = gatewayAddress(chain);
+    const address = options.authModule || (await predictAddress(wallet, chain, options.salt)).address;
+
+    printInfo('Gateway proxy', proxy);
+    printInfo('Auth module', address);
+
+    if (!(await isContract(address, provider))) {
+        throw new Error(`No auth module at ${address}; run \`deploy\` first`);
+    }
+
+    const auth = authFactory(wallet).attach(address);
+
+    if (!(await reportState(auth, wallet.address))) {
+        throw new Error(`Auth at ${address} is not owned by ${wallet.address}; it cannot be seeded`);
+    }
+
+    const { params } = await getAuthParams(axelar, chain.axelarId, options);
+    const seeds = [];
+
+    for (const set of params) {
+        // skip anything already registered: transferOperatorship reverts DuplicateOperators
+        if (!seeds.includes(set) && (await auth.epochForHash(operatorsHash(set))).eq(0)) {
+            seeds.push(set);
+        }
+    }
+
+    if (!seeds.length) {
+        printInfo('Auth already holds every current operator set; nothing to seed', address);
+        return;
+    }
+
+    printInfo('Operator sets to seed', seeds.length);
+
+    if (prompt(`Seed ${seeds.length} set(s) into ${address}? Ownership stays with ${wallet.address}.`, options.yes)) {
+        return;
+    }
+
+    for (const [index, set] of seeds.entries()) {
+        const tx = await auth.transferOperatorship(set, gasOptions);
+        printInfo(`Seed ${index + 1}/${seeds.length} tx`, tx.hash);
+
+        const receipt = await tx.wait(chain.confirmations);
+
+        if (!wasEventEmitted(receipt, auth, 'OperatorshipTransferred')) {
+            throw new Error(`Seeding operator set ${index + 1} did not emit OperatorshipTransferred`);
+        }
+    }
+
+    const seededEpoch = await auth.currentEpoch();
+    const newestHash = await auth.hashForEpoch(seededEpoch);
+    const expectedHash = operatorsHash(seeds[seeds.length - 1]);
+
+    if (newestHash !== expectedHash) {
+        throw new Error(`Newest epoch hash is ${newestHash}, expected ${expectedHash}`);
+    }
+
+    await reportState(auth, wallet.address);
+
+    printInfo('Seeded; ownership NOT transferred yet. Run `handoff` immediately before executing the upgrade', address);
+}
+
+async function handoff(axelar, chain, chains, options) {
+    const provider = ethers.getDefaultProvider(chain.rpc);
+    const wallet = await getWallet(options.privateKey, provider, options);
+    const gasOptions = await getGasOptions(chain, options, 'AxelarAuthWeighted');
+
+    const proxy = gatewayAddress(chain);
+    const address = options.authModule || (await predictAddress(wallet, chain, options.salt)).address;
+
+    printInfo('Gateway proxy', proxy);
+    printInfo('Auth module', address);
+
+    if (!(await isContract(address, provider))) {
+        throw new Error(`No auth module at ${address}; run \`deploy\` first`);
+    }
+
+    const auth = authFactory(wallet).attach(address);
+
+    if (!(await reportState(auth, wallet.address))) {
+        throw new Error(`Auth at ${address} is not owned by ${wallet.address}`);
+    }
+
+    // handing off a stale seed is unrecoverable: only the owner can add sets, and that becomes the proxy
+    const { params } = await getAuthParams(axelar, chain.axelarId, options);
+    const liveHash = operatorsHash(params[params.length - 1]);
+    const currentEpoch = await auth.currentEpoch();
+
+    if (currentEpoch.eq(0)) {
+        throw new Error('Auth is unseeded; run `seed` first');
+    }
+
+    if ((await auth.hashForEpoch(currentEpoch)) !== liveHash) {
+        throw new Error(`Newest epoch does not match the live operator set ${liveHash}; run \`seed\` again before handing off`);
+    }
+
+    if (prompt(`Hand ownership of ${address} to ${proxy}? This is one way.`, options.yes)) {
+        return;
+    }
+
+    const tx = await auth.transferOwnership(proxy, gasOptions);
+    printInfo('Transfer ownership tx', tx.hash);
+    await tx.wait(chain.confirmations);
+
+    await reportState(auth, proxy);
+
+    printInfo('Auth module ready', address);
+}
+
+async function verify(axelar, chain, chains, options) {
+    const provider = ethers.getDefaultProvider(chain.rpc);
+    const wallet = await getWallet(options.privateKey, provider, options);
+
+    const proxy = gatewayAddress(chain);
+    const address = options.authModule || (await predictAddress(wallet, chain, options.salt)).address;
+
+    printInfo('Auth module', address);
+
+    if (!(await isContract(address, provider))) {
+        throw new Error(`No contract at ${address}`);
+    }
+
+    const auth = authFactory(wallet).attach(address);
+    let ok = await reportState(auth, proxy);
+
+    const { params } = await getAuthParams(axelar, chain.axelarId, options);
+    const liveHash = operatorsHash(params[params.length - 1]);
+    const currentEpoch = await auth.currentEpoch();
+    const newestHash = await auth.hashForEpoch(currentEpoch);
+
+    printInfo('Live operator set hash', liveHash);
+
+    if (newestHash !== liveHash) {
+        printError(`Newest epoch hash ${newestHash} does not match the live operator set ${liveHash}`);
+        ok = false;
+    }
+
+    if (!(await auth.epochForHash(liveHash)).gt(0)) {
+        printError('Live operator set is not registered in this auth module');
+        ok = false;
+    }
+
+    if (!ok) {
+        throw new Error('Auth module is NOT ready; do not execute the gateway upgrade');
+    }
+
+    printInfo('Auth module verified', address);
+}
+
+if (require.main === module) {
+    const program = new Command();
+
+    program.name('consensus-auth').description('Deploy and verify a replacement AxelarAuthWeighted for a consensus gateway');
+
+    const addOptions = (cmd, { salt = true } = {}) => {
+        addEvmOptions(cmd);
+
+        if (salt) {
+            cmd.addOption(new Option('-s, --salt <salt>', 'CREATE2 salt for the auth module').makeOptionMandatory(true));
+        }
+
+        cmd.addOption(new Option('--prevKeyIDs <prevKeyIDs>', 'comma separated older key IDs to seed alongside the current one'));
+
+        return cmd;
+    };
+
+    addOptions(program.command('predict').description('Print the predicted auth module address')).action((options) =>
+        mainProcessor(options, predict),
+    );
+
+    addOptions(program.command('deploy').description('Deploy an unseeded auth module owned by the deployer wallet')).action((options) =>
+        mainProcessor(options, deploy),
+    );
+
+    addOptions(program.command('seed').description('Seed the auth module with the current operator sets; repeatable, keeps ownership'))
+        .addOption(new Option('--authModule <authModule>', 'seed this address instead of the predicted one'))
+        .action((options) => mainProcessor(options, seed));
+
+    addOptions(program.command('handoff').description('Hand auth ownership to the gateway proxy; refuses a stale seed'))
+        .addOption(new Option('--authModule <authModule>', 'hand off this address instead of the predicted one'))
+        .action((options) => mainProcessor(options, handoff));
+
+    addOptions(program.command('verify').description('Check the auth module is seeded with the live operator set and owned by the gateway'))
+        .addOption(new Option('--authModule <authModule>', 'verify this address instead of the predicted one'))
+        .action((options) => mainProcessor(options, verify));
+
+    program.parse();
+}
+
+module.exports = {
+    predictAuthAddress: predictAddress,
+};

--- a/evm/consensus-auth.js
+++ b/evm/consensus-auth.js
@@ -171,7 +171,26 @@ async function deploy(axelar, chain, chains, options) {
     printInfo('Auth deployed unseeded; run `seed` shortly before executing the gateway upgrade', address);
 }
 
-// AxelarAuthWeighted keeps a proof valid for OLD_KEY_RETENTION epochs, so a batch signed just before a rotation still
+// block times differ by two orders of magnitude across the fleet, so a fixed block count is not a usable window.
+// Sample the recent average and convert the requested number of days into blocks.
+async function blocksPerDay(provider, latest) {
+    const span = Math.min(latest, 10000);
+
+    if (span === 0) {
+        throw new Error('Chain has no history to sample a block time from');
+    }
+
+    const [head, earlier] = await Promise.all([provider.getBlock(latest), provider.getBlock(latest - span)]);
+    const seconds = (head.timestamp - earlier.timestamp) / span;
+
+    if (!(seconds > 0)) {
+        throw new Error(`Sampled a non positive block time of ${seconds}s; pass --lookbackBlocks instead`);
+    }
+
+    return Math.ceil(86400 / seconds);
+}
+
+// AxelarAuthWeighted keeps a proof valid for OLD_KEY_RETENTION epochs, so a batch signed before a rotation still
 // validates against the live auth. Copy the tail of its history so the replacement accepts those batches too.
 async function recentOperatorSets(provider, chain, options) {
     const count = Number(options.copyEpochs);
@@ -189,25 +208,29 @@ async function recentOperatorSets(provider, chain, options) {
     const filter = auth.filters.OperatorshipTransferred();
 
     const chunk = Number(options.logChunkSize);
-    const lookback = Number(options.lookbackBlocks);
     const latest = await provider.getBlockNumber();
+    const lookback = options.lookbackBlocks
+        ? Number(options.lookbackBlocks)
+        : Number(options.lookbackDays) * (await blocksPerDay(provider, latest));
     const floor = Math.max(0, latest - lookback + 1);
+
+    printInfo('Live auth module', liveAuth);
+    printInfo('Scanning back', `${lookback} blocks in ${chunk} block requests`);
 
     const events = [];
     let to = latest;
 
+    // walk backwards and stop as soon as enough rotations are in hand, so the window only costs what it needs to
     while (events.length < count && to >= floor) {
         const from = Math.max(floor, to - chunk + 1);
         events.unshift(...(await auth.queryFilter(filter, from, to)));
         to = from - 1;
     }
 
-    printInfo('Live auth module', liveAuth);
-
     if (events.length < count) {
         printWarn(
             `Found ${events.length} of ${count} requested operator set(s) in the last ${lookback} blocks of ${liveAuth}`,
-            'raise --lookbackBlocks to copy more history',
+            'raise --lookbackDays to copy more history',
         );
     }
 
@@ -403,8 +426,13 @@ if (require.main === module) {
         'seed',
     )
         .addOption(new Option('--prevKeyIDs <prevKeyIDs>', 'comma separated older key IDs to seed alongside the current one'))
-        .addOption(new Option('--copyEpochs <copyEpochs>', 'how many recent operator sets to copy from the live auth module').default('3'))
-        .addOption(new Option('--lookbackBlocks <lookbackBlocks>', 'how far back to scan for those sets').default('250000'))
+        .addOption(
+            new Option('--copyEpochs <copyEpochs>', 'how many recent operator sets to copy from the live auth module').default(
+                String(OLD_KEY_RETENTION - 1),
+            ),
+        )
+        .addOption(new Option('--lookbackDays <lookbackDays>', 'how far back to scan for those sets').default('30'))
+        .addOption(new Option('--lookbackBlocks <lookbackBlocks>', 'scan this many blocks instead of deriving it from --lookbackDays'))
         .addOption(new Option('--logChunkSize <logChunkSize>', 'block range per getLogs request').default('10000'))
         .action((options) => mainProcessor(options, seed));
 
@@ -424,6 +452,7 @@ if (require.main === module) {
 module.exports = {
     predictAuthAddress: predictAddress,
     resolveAuthAddress,
+    blocksPerDay,
     selectSetsToSeed,
     recentOperatorSets,
     encodeOperatorSet,

--- a/evm/consensus-auth.js
+++ b/evm/consensus-auth.js
@@ -250,6 +250,11 @@ async function recentOperatorSets(provider, chain, options) {
 }
 
 async function seed(axelar, chain, chains, options) {
+    // both flags add older sets, from different sources; mixing them makes the resulting epoch order unpredictable
+    if (options.prevKeyIDs && Number(options.copyEpochs) !== 0) {
+        throw new Error('Pass either --prevKeyIDs or --copyEpochs; combine --prevKeyIDs with --copyEpochs 0');
+    }
+
     const provider = ethers.getDefaultProvider(chain.rpc);
     const wallet = await getWallet(options.privateKey, provider, options);
     const gasOptions = await getGasOptions(chain, options, 'AxelarAuthWeighted');
@@ -272,11 +277,22 @@ async function seed(axelar, chain, chains, options) {
 
     const history = await recentOperatorSets(provider, chain, options);
     const { params } = await getAuthParams(axelar, chain.axelarId, options);
+    const liveSet = params[params.length - 1];
     const seeds = await selectSetsToSeed(auth, [...history, ...params]);
 
     if (!seeds.length) {
         printInfo('Auth already holds every current operator set; nothing to seed', address);
         return;
+    }
+
+    // seeds land in order, so the live set has to be last or the newest epoch ends up holding a retired set.
+    // that happens when a rerun widens --copyEpochs: the recent sets are already registered and only the older
+    // ones are left to add. epochs cannot be rewritten, so the auth is spent; deploy a fresh one with a new salt.
+    if (seeds[seeds.length - 1] !== liveSet) {
+        throw new Error(
+            `Seeding would leave a retired operator set in the newest epoch of ${address}. ` +
+                'This auth module cannot be repaired; deploy a replacement with a different --salt and seed it once.',
+        );
     }
 
     printInfo('Operator sets to seed', seeds.length);
@@ -434,7 +450,12 @@ if (require.main === module) {
         program.command('seed').description('Seed the auth module with the current operator sets; repeatable, keeps ownership'),
         'seed',
     )
-        .addOption(new Option('--prevKeyIDs <prevKeyIDs>', 'comma separated older key IDs to seed alongside the current one'))
+        .addOption(
+            new Option(
+                '--prevKeyIDs <prevKeyIDs>',
+                'comma separated older key IDs to seed alongside the current one; requires --copyEpochs 0',
+            ),
+        )
         .addOption(
             new Option('--copyEpochs <copyEpochs>', 'how many recent operator sets to copy from the live auth module').default(
                 String(OLD_KEY_RETENTION - 1),

--- a/evm/consensus-auth.js
+++ b/evm/consensus-auth.js
@@ -227,6 +227,15 @@ async function recentOperatorSets(provider, chain, options) {
         to = from - 1;
     }
 
+    // a live auth has hundreds of epochs, so finding nothing means the RPC did not serve the logs, not that
+    // there is no history. Several providers gate getLogs beyond a few recent blocks behind an archive tier.
+    if (events.length === 0) {
+        throw new Error(
+            `No OperatorshipTransferred logs from ${liveAuth} in the last ${lookback} blocks. ` +
+                'Use an RPC that serves historical getLogs, or pass --copyEpochs 0 to skip copying history.',
+        );
+    }
+
     if (events.length < count) {
         printWarn(
             `Found ${events.length} of ${count} requested operator set(s) in the last ${lookback} blocks of ${liveAuth}`,

--- a/evm/deploy-consensus-gateway.js
+++ b/evm/deploy-consensus-gateway.js
@@ -46,7 +46,7 @@ async function checkKeyRotation(axelar, chain) {
         return;
     }
 
-    throw new Error(`Key rotation is in progress for ${chain.name}: ${resp}`);
+    throw new Error(`Key rotation is in progress for ${chain}: ${JSON.stringify(resp)}`);
 }
 
 async function getAuthParams(axelar, chain, options) {
@@ -534,4 +534,5 @@ if (require.main === module) {
 
 module.exports = {
     deployLegacyGateway: deploy,
+    getAuthParams,
 };

--- a/evm/test/consensus-auth.test.js
+++ b/evm/test/consensus-auth.test.js
@@ -1,0 +1,115 @@
+'use strict';
+
+const { expect } = require('chai');
+const { ethers } = require('hardhat');
+const {
+    utils: { defaultAbiCoder, keccak256 },
+    BigNumber,
+} = ethers;
+
+const {
+    resolveAuthAddress,
+    selectSetsToSeed,
+    recentOperatorSets,
+    encodeOperatorSet,
+    operatorsHash,
+    OLD_KEY_RETENTION,
+} = require('../consensus-auth');
+
+// chai-as-promised is not a dependency here, so assert rejections directly
+const expectRejection = async (promise, message) => {
+    try {
+        await promise;
+    } catch (error) {
+        expect(error.message).to.contain(message);
+        return;
+    }
+
+    throw new Error(`expected a rejection containing "${message}"`);
+};
+
+const AUTH = '0x1111111111111111111111111111111111111111';
+const OPERATORS = ['0x00000000000000000000000000000000000000a1', '0x00000000000000000000000000000000000000b2'];
+const WEIGHTS = [1, 2];
+const THRESHOLD = 2;
+
+// stands in for an auth module that already knows the given encoded sets
+const fakeAuth = (registered = []) => ({
+    epochForHash: async (hash) => BigNumber.from(registered.some((set) => operatorsHash(set) === hash) ? 1 : 0),
+});
+
+describe('resolveAuthAddress', () => {
+    it('rejects --salt and --authModule together', async () => {
+        await expectRejection(
+            resolveAuthAddress(null, null, { salt: 'v6.5.0', authModule: AUTH }),
+            'Provide exactly one of --salt or --authModule',
+        );
+    });
+
+    it('rejects neither being provided', async () => {
+        await expectRejection(resolveAuthAddress(null, null, {}), 'Provide exactly one of --salt or --authModule');
+    });
+
+    it('returns --authModule without deriving an address', async () => {
+        expect(await resolveAuthAddress(null, null, { authModule: AUTH })).to.equal(AUTH);
+    });
+});
+
+describe('encodeOperatorSet', () => {
+    it('round trips through the encoding the auth module decodes', () => {
+        const encoded = encodeOperatorSet(OPERATORS, WEIGHTS, THRESHOLD);
+        const [operators, weights, threshold] = defaultAbiCoder.decode(['address[]', 'uint256[]', 'uint256'], encoded);
+
+        expect(operators.map((operator) => operator.toLowerCase())).to.deep.equal(OPERATORS);
+        expect(weights.map((weight) => weight.toNumber())).to.deep.equal(WEIGHTS);
+        expect(threshold.toNumber()).to.equal(THRESHOLD);
+    });
+
+    it('hashes the way _transferOperatorship does', () => {
+        const encoded = encodeOperatorSet(OPERATORS, WEIGHTS, THRESHOLD);
+
+        expect(operatorsHash(encoded)).to.equal(
+            keccak256(defaultAbiCoder.encode(['address[]', 'uint256[]', 'uint256'], [OPERATORS, WEIGHTS, THRESHOLD])),
+        );
+    });
+});
+
+describe('selectSetsToSeed', () => {
+    const a = encodeOperatorSet(OPERATORS, [1, 1], 2);
+    const b = encodeOperatorSet(OPERATORS, [1, 2], 2);
+    const c = encodeOperatorSet(OPERATORS, [1, 3], 2);
+
+    it('keeps every unknown set in the order given', async () => {
+        expect(await selectSetsToSeed(fakeAuth(), [a, b, c])).to.deep.equal([a, b, c]);
+    });
+
+    it('skips sets the auth module already holds', async () => {
+        expect(await selectSetsToSeed(fakeAuth([b]), [a, b, c])).to.deep.equal([a, c]);
+    });
+
+    it('drops duplicates within the candidate list', async () => {
+        expect(await selectSetsToSeed(fakeAuth(), [a, b, a])).to.deep.equal([a, b]);
+    });
+
+    it('returns nothing when every set is already registered', async () => {
+        expect(await selectSetsToSeed(fakeAuth([a, b]), [a, b])).to.deep.equal([]);
+    });
+});
+
+describe('recentOperatorSets', () => {
+    it('copies nothing when asked for zero epochs', async () => {
+        expect(await recentOperatorSets(null, null, { copyEpochs: '0' })).to.deep.equal([]);
+    });
+
+    it('rejects a count at or beyond the retention window', async () => {
+        await expectRejection(recentOperatorSets(null, null, { copyEpochs: String(OLD_KEY_RETENTION) }), '--copyEpochs must be');
+    });
+
+    it('rejects a negative count', async () => {
+        await expectRejection(recentOperatorSets(null, null, { copyEpochs: '-1' }), '--copyEpochs must be');
+    });
+
+    it('rejects a non integer count', async () => {
+        await expectRejection(recentOperatorSets(null, null, { copyEpochs: 'two' }), '--copyEpochs must be');
+    });
+});

--- a/evm/test/consensus-auth.test.js
+++ b/evm/test/consensus-auth.test.js
@@ -9,6 +9,7 @@ const {
 
 const {
     resolveAuthAddress,
+    blocksPerDay,
     selectSetsToSeed,
     recentOperatorSets,
     encodeOperatorSet,
@@ -111,5 +112,30 @@ describe('recentOperatorSets', () => {
 
     it('rejects a non integer count', async () => {
         await expectRejection(recentOperatorSets(null, null, { copyEpochs: 'two' }), '--copyEpochs must be');
+    });
+});
+
+describe('blocksPerDay', () => {
+    // block n is mined at n * seconds, so the sampled average is exactly `seconds`
+    const providerWithBlockTime = (seconds) => ({ getBlock: async (number) => ({ timestamp: number * seconds }) });
+
+    it('derives a day of 12 second blocks', async () => {
+        expect(await blocksPerDay(providerWithBlockTime(12), 20000)).to.equal(7200);
+    });
+
+    it('derives a day of 2 second blocks', async () => {
+        expect(await blocksPerDay(providerWithBlockTime(2), 20000)).to.equal(43200);
+    });
+
+    it('samples a short chain without reading a negative block number', async () => {
+        expect(await blocksPerDay(providerWithBlockTime(12), 500)).to.equal(7200);
+    });
+
+    it('rejects a chain with no history', async () => {
+        await expectRejection(blocksPerDay(providerWithBlockTime(12), 0), 'no history');
+    });
+
+    it('rejects a non advancing timestamp rather than guessing', async () => {
+        await expectRejection(blocksPerDay({ getBlock: async () => ({ timestamp: 1 }) }, 20000), 'non positive block time');
     });
 });


### PR DESCRIPTION
### why

Retrofitting `AxelarAuthWeighted` on the legacy consensus gateways needs an auth contract deployed at an address known in advance, seeded with the operator sets it must accept, and finally owned by the gateway proxy. Nothing existing does this:

- `deploy-consensus-gateway.js` deploys an auth, but with plain `create`, seeded through the constructor, and only when it is **not** reusing the proxy, so it is unreachable during an upgrade.
- The SDK's `deployAndInit` helper hardcodes calling `init(...)`, which `AxelarAuthWeighted` does not have.
- `deploy-contract.js` uses plain `deploy`, which would leave the auth owned by the deployer contract with no way to move it, permanently unable to rotate operators.

### how

`evm/consensus-auth.js` with five subcommands.

`predict` prints the CREATE2 address. Constant empty-seed constructor args keep the init code, and therefore the address, independent of the operator sets. Depends on the deployer EOA, so the same key must predict and deploy.

`deploy` deploys an **unseeded** auth via `ConstAddressDeployer.deployAndInit(initCode, salt, transferOwnership(EOA))`. CREATE2 keeps the deployer contract as the constructor's `msg.sender`, so the init call can hand ownership to the deployer wallet. It must be CREATE3-free: CREATE3 deploys through an ephemeral intermediate, so `Ownable(msg.sender)` would strand ownership in a throwaway contract.

`seed` registers the current operator sets. **Repeatable and keeps ownership**, skipping anything already registered so it cannot trip `DuplicateOperators`.

`handoff` transfers ownership to the gateway proxy. Refuses unless the newest epoch matches the live operator set, because this step is one way: afterwards only the gateway can add sets, so a stale seed would be unrecoverable.

`verify` is the gate before executing an upgrade: owner is the proxy, and the newest epoch hash matches the live set.

Also exports `getAuthParams` from `deploy-consensus-gateway.js` rather than duplicating the key-ID logic, and fixes its key-rotation error, which printed `for undefined: [object Object]` because `getAuthParams` passes a string where the message read `chain.name`.