### PR TITLE
docs(axelard): add v1.5.3 upgrade release note

### DIFF
--- a/releases/axelard/2026-08-v1.5.3.md
+++ b/releases/axelard/2026-08-v1.5.3.md
@@ -12,9 +12,9 @@
 | **Testnet**          | Deployed              | 2026-08-11 |
 | **Mainnet**          | Deployed              | 2026-08-25 |
 
-Release: [v1.5.0](https://github.com/axelarnetwork/axelar-core/releases/tag/v1.5.0) (the `v1.5` line notes)
+Release: [v1.5.0](https://github.com/axelarnetwork/axelar-core/releases/tag/v1.5.0) (the `v1.5` line notes), [v1.5.3](https://github.com/axelarnetwork/axelar-core/releases/tag/v1.5.3) (the deployed version)
 
-Changelog: [v1.5.0 changelog](https://github.com/axelarnetwork/axelar-core/blob/v1.5.0/CHANGELOG.md)
+Changelog: [v1.5.0 changelog](https://github.com/axelarnetwork/axelar-core/blob/v1.5.0/CHANGELOG.md), [v1.5.3 changelog](https://github.com/axelarnetwork/axelar-core/blob/v1.5.3/CHANGELOG.md)
 
 ## Background
 
@@ -22,7 +22,7 @@ Changelog: [v1.5.0 changelog](https://github.com/axelarnetwork/axelar-core/blob/
 
 **On the `v1.5.x` line, deploy `v1.5.3` or higher.** `v1.5.0` is a pre-release, and `v1.5.1` and `v1.5.2` are superseded by `v1.5.3`.
 
-Binaries are distributed from S3 and Docker Hub (see [Prerequisites](#prerequisites)), not from a GitHub release page. The `v1.5.3` changelog is published on the axelar-core repo after the mainnet upgrade; the changes since `v1.4.10` are summarized below.
+Binaries are available from the [v1.5.3 release page](https://github.com/axelarnetwork/axelar-core/releases/tag/v1.5.3), from S3, and from Docker Hub (see [Prerequisites](#prerequisites)). The changes since `v1.4.10` are summarized below.
 
 ### Changes since v1.4.10
 

--- a/releases/axelard/2026-08-v1.5.3.md
+++ b/releases/axelard/2026-08-v1.5.3.md
@@ -5,12 +5,14 @@
 | **Created By** | @jakovmitrovski, @h4writer, @dolfje |
 | **Deployment** | @jakovmitrovski, @h4writer, @dolfje |
 
-| **Network**          | **Deployment Status** | **Date**   |
-| -------------------- | --------------------- | ---------- |
-| **Stagenet**         | Deployed              | 2026-08-04 |
-| **Devnet Amplifier** | Deployed              | 2026-08-04 |
-| **Testnet**          | Deployed              | 2026-08-11 |
-| **Mainnet**          | Deployed              | 2026-08-25 |
+| **Network**          | **Deployment Status** | **Version** | **Date**   |
+| -------------------- | --------------------- | ----------- | ---------- |
+| **Devnet Amplifier** | Deployed              | `v1.5.2`    | 2026-08-04 |
+| **Stagenet**         | Deployed              | `v1.5.2`    | 2026-08-04 |
+| **Testnet**          | Deployed              | `v1.5.3`    | 2026-08-11 |
+| **Mainnet**          | Deployed              | `v1.5.3`    | 2026-08-25 |
+
+Devnet Amplifier and Stagenet were upgraded with `v1.5.2` before `v1.5.3` was cut; Testnet and Mainnet ran `v1.5.3`. On the `v1.5.x` line, deploy `v1.5.3` or higher.
 
 Release: [v1.5.0](https://github.com/axelarnetwork/axelar-core/releases/tag/v1.5.0) (the `v1.5` line notes), [v1.5.3](https://github.com/axelarnetwork/axelar-core/releases/tag/v1.5.3) (the deployed version)
 
@@ -66,8 +68,9 @@ Binaries are available from the [v1.5.3 release page](https://github.com/axelarn
 - Flattens a `RefundMsgRequest`'s inner message in the ante handler so it passes through the message ante decorators ([#2365](https://github.com/axelarnetwork/axelar-core/pull/2365)); rejects `RefundMsg` requests whose inner message has a different `permission_role` than the wrapper ([#2341](https://github.com/axelarnetwork/axelar-core/pull/2341)); derives the refund sender from each msg, not the first ([#2346](https://github.com/axelarnetwork/axelar-core/pull/2346)).
 - Clears accrued rewards when a chain maintainer voluntarily deregisters ([#2351](https://github.com/axelarnetwork/axelar-core/pull/2351)).
 - Rejects `MsgRetryFailedEvent` for deprecated pre-v1.4 event types with a clear error instead of a recovered panic ([#2361](https://github.com/axelarnetwork/axelar-core/pull/2361)).
+- Removes the dead link-deposit CLI commands (`axelard tx evm link` / `confirm-erc20-deposit` / `create-burn-tokens`, and `axelard tx axelarnet link` / `confirm-deposit`), left registered after their `Msg` RPCs were removed in the `v1.4` line ([#2367](https://github.com/axelarnetwork/axelar-core/pull/2367)).
 - **Disables `axelard export`** ([#2369](https://github.com/axelarnetwork/axelar-core/pull/2369)). State export to genesis is not supported, since axelar-core upgrades via in-place store migrations rather than genesis export/import. The command now returns a clear error instead of silently producing non-round-trippable genesis.
-- Dependency bumps for security advisories: grpc v1.82.0, x/net v0.56.0, go-ethereum v1.16.9, xz v0.5.15, go-getter v1.7.9 ([#2355](https://github.com/axelarnetwork/axelar-core/pull/2355)); ledger-cosmos-go v0.15.0 and zondax/ledger-go v1.0.0 ([#2348](https://github.com/axelarnetwork/axelar-core/pull/2348)); rosetta fork moved to the `axelar-core-v1.5.x-compatible` branch ([#2363](https://github.com/axelarnetwork/axelar-core/pull/2363)).
+- Dependency bumps for security advisories: grpc v1.82.0, x/net v0.56.0, go-ethereum v1.16.9, xz v0.5.15, go-getter v1.7.9 ([#2355](https://github.com/axelarnetwork/axelar-core/pull/2355)); ledger-cosmos-go v1.0.0 and zondax/ledger-go v1.0.1 ([#2348](https://github.com/axelarnetwork/axelar-core/pull/2348), finalized by the v0.53 migration [#2349](https://github.com/axelarnetwork/axelar-core/pull/2349)); rosetta fork moved to the `axelar-core-v1.5.x-compatible` branch ([#2363](https://github.com/axelarnetwork/axelar-core/pull/2363)).
 
 `ampd` is **not** bumped for this upgrade. Verifier handlers continue against the same `ampd` version.
 

--- a/releases/axelard/2026-08-v1.5.3.md
+++ b/releases/axelard/2026-08-v1.5.3.md
@@ -1,0 +1,188 @@
+# axelard v1.5.3
+
+|                | **Owner**                             |
+| -------------- | ------------------------------------- |
+| **Created By** | @jakovmitrovski, @h4writer, @dolfje |
+| **Deployment** | @jakovmitrovski, @h4writer, @dolfje |
+
+| **Network**          | **Deployment Status** | **Date**   |
+| -------------------- | --------------------- | ---------- |
+| **Stagenet**         | Deployed              | 2026-08-04 |
+| **Devnet Amplifier** | Deployed              | 2026-08-04 |
+| **Testnet**          | Deployed              | 2026-08-11 |
+| **Mainnet**          | Deployed              | 2026-08-25 |
+
+Release: [v1.5.0](https://github.com/axelarnetwork/axelar-core/releases/tag/v1.5.0) (the `v1.5` line notes)
+
+Changelog: [v1.5.0 changelog](https://github.com/axelarnetwork/axelar-core/blob/v1.5.0/CHANGELOG.md)
+
+## Background
+
+`v1.5.3` is the binary for the consensus-breaking `v1.5` upgrade that follows the `v1.4.x` line. The governance plan name is `v1.5`.
+
+**On the `v1.5.x` line, deploy `v1.5.3` or higher.** `v1.5.0` is a pre-release, and `v1.5.1` and `v1.5.2` are superseded by `v1.5.3`.
+
+Binaries are distributed from S3 and Docker Hub (see [Prerequisites](#prerequisites)), not from a GitHub release page. The `v1.5.3` changelog is published on the axelar-core repo after the mainnet upgrade; the changes since `v1.4.10` are summarized below.
+
+### Changes since v1.4.10
+
+#### Cosmos stack migration ([#2349](https://github.com/axelarnetwork/axelar-core/pull/2349))
+
+- **Migrates to cosmos-sdk v0.53, ibc-go v10, and wasmd v0.60.** Removes the `x/crisis` and `x/capability` modules and their stores, and registers the 07-tendermint light client as a modular route.
+- **Runs the ibc core (6 -> 8) and ibc transfer (5 -> 6, `DenomTrace` -> `Denom`) state migrations at the upgrade height.** The ibc transfer REST/CLI query surface is renamed upstream: **`denom_traces` becomes `denoms`**. Update any tooling that queries the old path.
+- `x/tss` remains mounted for historical transaction decoding.
+- **Bumps wasmd to v0.60.8 and wasmvm to v2.3.4**, patching CWA-2026-005 (high-severity block-production delay via wasm execution). This is why **`libwasmvm` moves from v2.2.6 to v2.3.4**.
+- Bumps the cosmos-sdk fork to v0.53.8 and CometBFT to v0.38.25 ([#2377](https://github.com/axelarnetwork/axelar-core/pull/2377)).
+
+#### New modules
+
+- **Adds `x/authz`** ([#2358](https://github.com/axelarnetwork/axelar-core/pull/2358)), enabling scoped, revocable, expiring authorization grants, for example a validator delegating governance voting to an operational key. `MsgExec` is restricted to flat messages: it cannot wrap another `MsgExec` or a batch request, and a batch request cannot wrap a `MsgExec`.
+- **Adds `x/feepolicy`** ([#2370](https://github.com/axelarnetwork/axelar-core/pull/2370)). A transaction may pay fees in a single denomination only, taken from a governance-controlled allowlist (default `["uaxl"]`). The v1.5 upgrade handler seeds the allowed denoms from the staking bond denom rather than leaving the module default, so chains that bond a denom other than `uaxl` are handled correctly ([#2384](https://github.com/axelarnetwork/axelar-core/pull/2384)).
+
+#### Nexus and EVM
+
+- **Orders the nexus EVM processing-message queue by insertion sequence (FIFO)** ([#2373](https://github.com/axelarnetwork/axelar-core/pull/2373)), so messages are delivered in arrival order rather than by message ID.
+- Stops queueing messages whose destination route needs the original payload, which the nexus `EndBlocker` can never supply ([#2378](https://github.com/axelarnetwork/axelar-core/pull/2378)).
+- Adds nexus migration (8 -> 9) that eagerly reallocates existing `MaintainerState` bitmaps down to the reduced max size ([#2353](https://github.com/axelarnetwork/axelar-core/pull/2353)).
+- Reuses an already registered EVM chain param subspace when creating a chain, instead of panicking ([#2381](https://github.com/axelarnetwork/axelar-core/pull/2381)).
+
+#### Voting correctness
+
+- **Resolves the source chain in the EVM vote handler's `HandleResult` from the poll metadata instead of the voter-supplied result**, and rejects a result whose chain does not match the poll's ([#2388](https://github.com/axelarnetwork/axelar-core/pull/2388)).
+- **Resolves the completed-poll chain from the poll metadata instead of the vote result**, so a result naming an unregistered chain can no longer stall the `x/vote` `EndBlocker` ([#2376](https://github.com/axelarnetwork/axelar-core/pull/2376)).
+- **Skips the missing-vote penalty when an EVM poll expires with zero votes**, so it no longer marks every maintainer missing and clears their rewards ([#2375](https://github.com/axelarnetwork/axelar-core/pull/2375)).
+
+#### Wasm and payload guards
+
+- Raises the wasm static validation limits (`MaxFunctionLocals` 2048, `MaxTotalFunctionLocals` 20,000) above the wasmvm v2.3.4 defaults, which otherwise reject optimizer-built Amplifier contracts at store-code time ([#2359](https://github.com/axelarnetwork/axelar-core/pull/2359)).
+- Tightens the ABI inflation guard for `CosmWasmV1` payloads: lowers the inflation budget to 50 KB, restricts wasm argument types to an allowlist, and charges for element types of empty dynamic arrays ([#2362](https://github.com/axelarnetwork/axelar-core/pull/2362)). This is the `v1.4.10` guard, now unconditional.
+- Charges execution gas before translating the message payload, so the decode and ABI inflation guards are metered before they run ([#2356](https://github.com/axelarnetwork/axelar-core/pull/2356)).
+
+#### Other
+
+- Speeds up `SubmitPubKey` by verifying the proof of public key ownership after the cheaper keygen-session checks, charging a fixed 200,000 gas for the verification, and memoizing `GetPermissionRole` per message type ([#2389](https://github.com/axelarnetwork/axelar-core/pull/2389)).
+- Guards the cumulative burned-fee tracker against overflow, rolling back the tracker update for that denomination instead of failing the block ([#2371](https://github.com/axelarnetwork/axelar-core/pull/2371)).
+- `vald` confirms transaction inclusion via CometBFT event subscriptions instead of indexer polling, so it can broadcast against nodes with the transaction indexer disabled ([#2344](https://github.com/axelarnetwork/axelar-core/pull/2344)).
+- Flattens a `RefundMsgRequest`'s inner message in the ante handler so it passes through the message ante decorators ([#2365](https://github.com/axelarnetwork/axelar-core/pull/2365)); rejects `RefundMsg` requests whose inner message has a different `permission_role` than the wrapper ([#2341](https://github.com/axelarnetwork/axelar-core/pull/2341)); derives the refund sender from each msg, not the first ([#2346](https://github.com/axelarnetwork/axelar-core/pull/2346)).
+- Clears accrued rewards when a chain maintainer voluntarily deregisters ([#2351](https://github.com/axelarnetwork/axelar-core/pull/2351)).
+- Rejects `MsgRetryFailedEvent` for deprecated pre-v1.4 event types with a clear error instead of a recovered panic ([#2361](https://github.com/axelarnetwork/axelar-core/pull/2361)).
+- **Disables `axelard export`** ([#2369](https://github.com/axelarnetwork/axelar-core/pull/2369)). State export to genesis is not supported, since axelar-core upgrades via in-place store migrations rather than genesis export/import. The command now returns a clear error instead of silently producing non-round-trippable genesis.
+- Dependency bumps for security advisories: grpc v1.82.0, x/net v0.56.0, go-ethereum v1.16.9, xz v0.5.15, go-getter v1.7.9 ([#2355](https://github.com/axelarnetwork/axelar-core/pull/2355)); ledger-cosmos-go v0.15.0 and zondax/ledger-go v1.0.0 ([#2348](https://github.com/axelarnetwork/axelar-core/pull/2348)); rosetta fork moved to the `axelar-core-v1.5.x-compatible` branch ([#2363](https://github.com/axelarnetwork/axelar-core/pull/2363)).
+
+`ampd` is **not** bumped for this upgrade. Verifier handlers continue against the same `ampd` version.
+
+## Migrate CosmWasm Contracts
+
+No Amplifier contract migrations are required for this upgrade.
+
+## Deployment Steps for Axelar Maintainers
+
+1. Submit upgrade proposal and vote on it. Plan name is `v1.5`:
+
+    ```bash
+    axelard tx gov submit-proposal \
+        software-upgrade "v1.5" \
+        --upgrade-height $upgradeHeight \
+        --deposit ${govProposalDepositAmount}uaxl \
+        --description "This proposal is intended to upgrade axelar-core to v1.5.3" \
+        --title "Axelar v1.5.3 Upgrade Proposal" \
+        --from validator --gas auto --gas-adjustment 1.2
+
+    axelard tx gov vote ${proposalId} yes \
+        --from validator --gas auto --gas-adjustment 1.5
+    ```
+
+2. Inform all validators about the upgrade and upgrade height. This upgrade also requires validators to **remove the Moonbeam entry from their vald `config.toml`**.
+3. Wait for proposal to pass.
+4. When upgrade height is reached, follow the steps for Axelar Validators below to upgrade our nodes.
+
+### Post-Upgrade Checklist for Maintainers
+
+- [ ] All validator nodes are producing blocks on `v1.5.3`
+- [ ] No live signing/voting sessions are stuck after the height transition
+- [ ] `x/feepolicy` allowed denoms match the network's bond denom
+- [ ] IBC channels are live and relayers have been restarted against the `denoms` query path
+- [ ] Testing
+    - [ ] General testing: GMP calls, IBC transfers, key rotation
+
+## Deployment Steps for Axelar Validators
+
+### Prerequisites
+
+- **Docker:**
+
+    ```bash
+    docker pull axelarnet/axelar-core:v1.5.3
+    ```
+
+    Manifest digest `sha256:b2779cf4a9ea2d9032f6265861ce490f7df47673f27552ee8ea20b0106e59a51`. Published for `linux/amd64` only.
+
+- **Prebuilt binaries:** available from S3. Verify the `sha256` of each zip before use, see [verifying binaries](https://docs.axelar.dev/node/config-node#verifying-binaries).
+
+    | Target | Download | SHA256 |
+    | ------ | -------- | ------ |
+    | linux/amd64 | [axelard-linux-amd64-v1.5.3.zip](https://axelar-releases.s3.us-east-2.amazonaws.com/axelard/v1.5.3/axelard-linux-amd64-v1.5.3.zip) | `4edb57597a09959cd7a4063253f1f738d0e4ab312bc7405a2b8c8b7b902e0ff7` |
+    | linux/amd64 (static) | [axelard-linux-amd64-v1.5.3-static.zip](https://axelar-releases.s3.us-east-2.amazonaws.com/axelard/v1.5.3/axelard-linux-amd64-v1.5.3-static.zip) | `a75b13df9689ed1d267937437f84c921a8908e82068591e91ce26044418125a3` |
+    | darwin/amd64 | [axelard-darwin-amd64-v1.5.3.zip](https://axelar-releases.s3.us-east-2.amazonaws.com/axelard/v1.5.3/axelard-darwin-amd64-v1.5.3.zip) | `410c566ff8d80d8c8006958c252fb90f184c0381cbb1c257e63ae756702d6169` |
+    | darwin/arm64 | [axelard-darwin-arm64-v1.5.3.zip](https://axelar-releases.s3.us-east-2.amazonaws.com/axelard/v1.5.3/axelard-darwin-arm64-v1.5.3.zip) | `cf3c85c0ab3d62c0529e79d9726aac7faf298b02eaa6d9d2d02f3d9b2a34e644` |
+
+    The statically linked Linux binary bundles `libwasmvm` and runs on any distribution without it installed.
+
+- **Building from source:** use `Go 1.25`. The recommended approach is static linking with `make build-static`, which eliminates additional libwasmvm handling.
+
+- **libwasmvm must be reinstalled.** For anything except the Docker image or the `-static` zip, `libwasmvm` is **bumped from v2.2.6 to v2.3.4** in this release. Reinstall from the [wasmvm v2.3.4 release](https://github.com/CosmWasm/wasmvm/releases/tag/v2.3.4) before starting the new binary and make sure `LD_LIBRARY_PATH` points at the directory holding it.
+
+    | Library | SHA256 |
+    | ------- | ------ |
+    | `libwasmvm.x86_64.so` | `b1b298e3d1722c96c401bcdfc8508f9da8ae139f5b194a8af5aaa3818a0c57b1` |
+    | `libwasmvm.aarch64.so` | `3de57a9e90f8ce70875f11a79ccc361ce70a600cc41a98ed2e3784cd8d56cf84` |
+
+### Upgrade Details by Network
+
+| Network     | Proposal | Upgrade Height | Upgrade Time (UTC) |
+| ----------- | -------- | -------------- | ------------------ |
+| **Testnet** | [636](https://testnet.axelarscan.io/proposals/636) | 34883050 | 2026-08-11 ~08:00 |
+| **Mainnet** | [495](https://axelarscan.io/proposals/495) | 33625777 | 2026-08-25 ~10:30 |
+
+### Upgrade Process
+
+1. Wait for upgrade height to be reached. **Do not replace the binary before the halt.** The node must keep running `v1.4.10` all the way to the upgrade height, halt there on its own, and only then be restarted on `v1.5.3`.
+2. Stop the validator `axelard` node and `vald`. `ampd` is not bumped and does not need to be restarted for the version change.
+3. Replace the binaries:
+   - `axelard` -> `v1.5.3`
+   - `vald` -> `v1.5.3` (bundled in the same `axelard` build)
+   - `tofnd` -> `v1.0.1` (no change vs. v1.4.x)
+   - `libwasmvm` -> `v2.3.4` (dynamic binary and source builds only)
+4. **Remove the Moonbeam entry from your vald `config.toml`.** Delete the whole `[[axelar_bridge_evm]]` block whose `name = "Moonbeam"`.
+5. No other `app.toml` / `config.toml` changes are required relative to a node already running `v1.4.x` (`iavl-cache-size = 0`, `iavl-disable-fastnode = true`, `timeout_commit = 1s`).
+6. Restart the validator node and `vald` with the new binaries. When restarting `axelard` do not do a rollback.
+7. Please also upgrade any other Axelar nodes you operate (RPC nodes etc.), and restart your IBC relayer (e.g. hermes).
+
+### Post-Deployment Checklist
+
+- [ ] Verify that nodes are producing new blocks after the upgrade.
+- [ ] Verify vald is participating in message validation, signing, heartbeats etc.
+- [ ] Verify vald no longer connects to a Moonbeam EVM bridge on startup.
+- [ ] Test [GMP calls](../evm/EVM-GMP-Release-Template.md)
+
+## Troubleshooting
+
+### `app hash` mismatch
+
+The most likely cause is a stale `libwasmvm`. Confirm the loaded library is `v2.3.4`. Otherwise, make sure all replicas across your fleet were swapped to `v1.5.3` before the upgrade height; mixed binaries across replicas after the upgrade height will fork.
+
+### `libwasmvm` errors with the dynamic binary
+
+`libwasmvm` is **bumped from v2.2.6 (v1.4.x) to v2.3.4** in this upgrade. Replace the library on every dynamic-binary node before starting the new binary, otherwise it refuses to launch with a wasmvm version-mismatch error. Ensure `LD_LIBRARY_PATH` points at its location. For the Docker image and the `-static` binary no change is necessary.
+
+### `vald` restarts right after the upgrade
+
+`vald` requires the local `axelard` RPC to be reachable at startup and exits if it is not, so on nodes where `axelard` takes a while to open its store, `vald` may restart a few times with `unable to start client: dial tcp 127.0.0.1:26657: connect: connection refused` before settling. This is expected; it resolves once `axelard` is serving RPC.
+
+### IBC queries return no results
+
+The ibc transfer query surface is renamed upstream in ibc-go v10: `denom_traces` becomes `denoms`. Update relayers, explorers, and scripts that query the old path.
+
+### Rollback
+
+This is a state-machine-breaking upgrade. **There is no in-place rollback** to `v1.4.x` once a node has executed the `v1.5` upgrade handler. The cosmos-sdk, ibc, and nexus store migrations are persisted to state. Operators must restore from a pre-upgrade snapshot if rollback is required.


### PR DESCRIPTION
Adds `releases/axelard/2026-08-v1.5.3.md`, the release/upgrade note for the consensus-breaking `v1.5` upgrade (plan name `v1.5`, binary `v1.5.3`).

Deployment dates:

| Network | Date |
| --- | --- |
| Stagenet | 2026-08-04 |
| Devnet Amplifier | 2026-08-04 |
| Testnet | 2026-08-11 |
| Mainnet | 2026-08-25 |

Upgrade details, verified against the live chains:

| Network | Proposal | Height |
| --- | --- | --- |
| Testnet | 636 | 34883050 |
| Mainnet | 495 | 33625777 |

Notes:

- Binaries are referenced from S3 and Docker Hub with their SHA256s, since `v1.5.3` has no public GitHub release page. The `Release:` / `Changelog:` links point at `v1.5.0` for the `v1.5` line notes; on the `v1.5.x` line operators should deploy `v1.5.3` or higher.
- `libwasmvm` bumps from v2.2.6 to v2.3.4, so dynamic-binary and source builds must reinstall it.
- The upgrade process includes removing the Moonbeam `[[axelar_bridge_evm]]` entry from vald `config.toml`.
- `ampd` is not bumped.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or deployment automation impact.
> 
> **Overview**
> Adds **`releases/axelard/2026-08-v1.5.3.md`**, the operator release note for the consensus-breaking **`v1.5`** upgrade (governance plan `v1.5`, binary **`v1.5.3`**).
> 
> The doc records deployment status across networks (including that Devnet/Stagenet ran **`v1.5.2`** before **`v1.5.3`** was cut), Testnet/Mainnet proposal IDs and upgrade heights, and links to binaries on GitHub, S3, and Docker with **SHA256** checksums.
> 
> It summarizes **what changed since `v1.4.10`** (Cosmos/IBC/wasm stack migration, new `x/authz` and `x/feepolicy`, nexus/EVM and voting fixes, wasm guards, operational changes like disabled `axelard export`) and spells out **validator actions**: stay on **`v1.4.10`** until halt, upgrade **`axelard`/`vald`** to **`v1.5.3`**, reinstall **`libwasmvm` v2.3.4** for dynamic builds, **remove Moonbeam** from vald `config.toml`, restart relayers for the IBC **`denoms`** query path, and notes that **`ampd` is not bumped**. Post-upgrade checklists and troubleshooting (app hash, rollback) are included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57dab6b80bccd72f48cc57c94fdba8b7daaa23f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->